### PR TITLE
ci: remove build cache feature

### DIFF
--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -14,7 +14,7 @@ import jetbrains.buildServer.configs.kotlin.buildFeatures.pullRequests
 const val GITHUB_OWNER = "neo4j"
 const val GITHUB_REPOSITORY = "neo4j-kafka-connector"
 const val MAVEN_DEFAULT_ARGS =
-    "--no-transfer-progress --batch-mode -Dmaven.repo.local=%teamcity.build.checkoutDir%/.m2"
+    "--no-transfer-progress --batch-mode"
 
 enum class LinuxSize(val value: String) {
   SMALL("small"),

--- a/.teamcity/builds/IntegrationTests.kt
+++ b/.teamcity/builds/IntegrationTests.kt
@@ -2,7 +2,6 @@ package builds
 
 import jetbrains.buildServer.configs.kotlin.BuildStep
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.buildFeatures.buildCache
 import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.buildSteps.MavenBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
@@ -105,17 +104,7 @@ class IntegrationTests(id: String, name: String, init: BuildType.() -> Unit) :
         }
       }
 
-      features {
-        dockerSupport {}
-
-        buildCache {
-          this.name = "neo4j-kafka-connector"
-          publish = true
-          use = true
-          publishOnlyChanged = true
-          rules = ".m2/repository"
-        }
-      }
+      features { dockerSupport {} }
 
       requirements { runOnLinux(LinuxSize.LARGE) }
     })

--- a/.teamcity/builds/Maven.kt
+++ b/.teamcity/builds/Maven.kt
@@ -1,7 +1,6 @@
 package builds
 
 import jetbrains.buildServer.configs.kotlin.BuildType
-import jetbrains.buildServer.configs.kotlin.buildFeatures.buildCache
 import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerSupport
 import jetbrains.buildServer.configs.kotlin.buildSteps.MavenBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.maven
@@ -50,17 +49,7 @@ class Maven(id: String, name: String, goals: String, args: String? = null) :
         }
       }
 
-      features {
-        dockerSupport {}
-
-        buildCache {
-          this.name = "neo4j-kafka-connector"
-          publish = true
-          use = true
-          publishOnlyChanged = true
-          rules = ".m2/repository"
-        }
-      }
+      features { dockerSupport {} }
 
       requirements { runOnLinux(LinuxSize.SMALL) }
     })


### PR DESCRIPTION
This PR removes the experimental build cache feature which is not available on on-prem version of TC.