### PR TITLE
fix: flaky test (crashes when list is empty)

### DIFF
--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
@@ -607,7 +607,7 @@ class Neo4jQueryTaskTest {
       until(30.seconds) {
         task.poll()?.let { list.addAll(it) }
         val actualList = list.map { (it.value() as Struct).toMap() }
-        actualList.first() == expected
+        actualList.firstOrNull() == expected
       }
     }
   }


### PR DESCRIPTION
Accounts for the cases when no records are polled.