### PR TITLE
ci: remove triggerRules

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -22,10 +22,6 @@ project {
                 +:main               
             """
               .trimIndent(),
-          triggerRules = """
-                -:comment=^build.*release version.*:**
-                -:comment=^build.*update version.*:**
-            """.trimIndent(),
           forPullRequests = false))
   subProject(
       Build(


### PR DESCRIPTION
For some reason, TC doesn't trigger the `main` branch build. I think it might be related to the trigger rules, that were introduced recently. I didn't manage to reproduce it with a custom UI-configured test build, but I think it's worth trying. 

As a side effect, TC will run the pipeline after each release, but I think it might be a smaller annoyance comparing to a completely void trigger. 