### PR TITLE
chore: add CODEOWNERS and harden github path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+*       @neo4j/team-connectors
+
+/.github/   @ali-ince @fbiville @venikkin


### PR DESCRIPTION
The whole idea of "hardening" the .github path is to prevent large teams to have review access for that path.

Instead, only a subset of that team must be allowed that.

In our case, listing us 3 should be fine, even if the core team grows beyond that.