### PR TITLE
build: upgrade byte-buddy to fix issue with JDK 21

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -92,6 +92,13 @@
         </resources>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
                     <includes>
                         <include>**/*Test.*</include>
                     </includes>

--- a/sink/pom.xml
+++ b/sink/pom.xml
@@ -67,6 +67,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -94,6 +94,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -93,6 +93,13 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-javaagent:${net.bytebuddy:byte-buddy-agent:jar}</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
Mockito was failing to mock some classes, outputting things like:

```
Mockito cannot mock this class:
class org.apache.kafka.clients.consumer.KafkaConsumer.
[...]
Underlying exception : org.mockito.exceptions.base.MockitoException:
Could not modify all classes [...]
```

Further to this upgrade, the ByteBuddy agent is dynamically loaded which raises a warning.

This commit also fixes the warning, as dynamic loading of agents will be prohibited in the future.

This is only a temporary fix wrt ByteBuddy agent, as the long-term solution for this problem is still shaping up at the time of writing: https://github.com/mockito/mockito/issues/3037