### PR TITLE
build: remove deprecated sortpom attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -588,7 +588,7 @@
                 <configuration>
                     <encoding>${project.build.sourceEncoding}</encoding>
                     <keepBlankLines>false</keepBlankLines>
-                    <indentSchemaLocation>true</indentSchemaLocation>
+                    <indentAttribute>schemaLocation</indentAttribute>
                     <nrOfIndentSpace>4</nrOfIndentSpace>
                     <sortProperties>true</sortProperties>
                     <sortDependencies>scope,groupId,artifactId</sortDependencies>


### PR DESCRIPTION
This PR removes the deprecated `indentSchemaLocation` attribute with the new `indentAttribute` counterpart.