### PR TITLE
test: fix return of resolve value converter

### DIFF
--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
@@ -89,7 +89,7 @@ class KeyValueConverterResolver {
 
   fun resolveValueConverter(context: ExtensionContext?): KafkaConverter {
     initializeKeyValueConverters(context)
-    return keyConverter
+    return valueConverter
   }
 
   private fun initializeKeyValueConverters(context: ExtensionContext?) {


### PR DESCRIPTION
Small change for the return value of resolveValueConverting method which is used to resolve value.converter for Kafka messages and test connectors.
