### PR TITLE
ci: run pr builds for everybody

### DIFF
--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -58,7 +58,7 @@ fun BuildFeatures.enablePullRequests() = pullRequests {
   vcsRootExtId = Neo4jKafkaConnectorVcs.id.toString()
   provider = github {
     authType = token { token = "%github-pull-request-token%" }
-    filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
+    filterAuthorRole = PullRequests.GitHubRoleFilter.EVERYBODY
   }
 }
 


### PR DESCRIPTION
This PR updates CI pipeline so that PR builds can be triggered for anybody raising PRs, but will be still protected with an explicit approval (from connectors project in TC).