### PR TITLE
test: add return nested object test for source query strategy

### DIFF
--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
@@ -90,6 +90,37 @@ abstract class Neo4jSourceQueryIT {
       topic = TOPIC,
       strategy = SourceStrategy.QUERY,
       streamingProperty = "timestamp",
+      startFrom = "EARLIEST",
+      query =
+          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck " +
+              "RETURN ts.name as name, ts.surname as surname, ts.timestamp as timestamp, " +
+              "{key1: {subKey1: 'value', subKey2: 'value'}, key2: {subKey1: 'value', subKey2: true}} AS nested")
+  @Test
+  fun `should return nested object`(
+      @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer,
+      session: Session
+  ) = runTest {
+    session.run("CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: 0})").consume()
+
+    TopicVerifier.createForMap(consumer)
+        .assertMessageValue { value ->
+          value shouldBe
+              mapOf(
+                  "name" to "jane",
+                  "surname" to "doe",
+                  "timestamp" to 0,
+                  "nested" to
+                      mapOf(
+                          "key1" to mapOf("subKey1" to "value", "subKey2" to "value"),
+                          "key2" to mapOf("subKey1" to "value", "subKey2" to true)))
+        }
+        .verifyWithin(Duration.ofSeconds(30))
+  }
+
+  @Neo4jSource(
+      topic = TOPIC,
+      strategy = SourceStrategy.QUERY,
+      streamingProperty = "timestamp",
       startFrom = "NOW",
       query =
           "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp")


### PR DESCRIPTION
This pr adds a test to see the issue https://github.com/neo4j-contrib/neo4j-streams/issues/555 is not valid for 5.1 connector.