### PR TITLE
test: add embedded json integration tests option

### DIFF
--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaIT.kt
@@ -480,7 +480,10 @@ abstract class Neo4jCdcSchemaIT {
 class Neo4jCdcSchemaAvroIT : Neo4jCdcSchemaIT()
 
 @KeyValueConverter(key = KafkaConverter.JSON_SCHEMA, value = KafkaConverter.JSON_SCHEMA)
-class Neo4jCdcSchemaJsonIT : Neo4jCdcSchemaIT()
+class Neo4jCdcSchemaJsonSchemaIT : Neo4jCdcSchemaIT()
+
+@KeyValueConverter(key = KafkaConverter.JSON_EMBEDDED, value = KafkaConverter.JSON_EMBEDDED)
+class Neo4jCdcSchemaJsonEmbeddedIT : Neo4jCdcSchemaIT()
 
 @KeyValueConverter(key = KafkaConverter.PROTOBUF, value = KafkaConverter.PROTOBUF)
 class Neo4jCdcSchemaProtobufIT : Neo4jCdcSchemaIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSourceIdIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSourceIdIT.kt
@@ -516,7 +516,10 @@ abstract class Neo4jCdcSourceIdIT {
 class Neo4jCdcSourceIdAvroIT : Neo4jCdcSourceIdIT()
 
 @KeyValueConverter(key = KafkaConverter.JSON_SCHEMA, value = KafkaConverter.JSON_SCHEMA)
-class Neo4jCdcSourceIdJsonIT : Neo4jCdcSourceIdIT()
+class Neo4jCdcSourceIdJsonSchemaIT : Neo4jCdcSourceIdIT()
+
+@KeyValueConverter(key = KafkaConverter.JSON_EMBEDDED, value = KafkaConverter.JSON_EMBEDDED)
+class Neo4jCdcSourceIdJsonEmbeddedIT : Neo4jCdcSourceIdIT()
 
 @KeyValueConverter(key = KafkaConverter.PROTOBUF, value = KafkaConverter.PROTOBUF)
 class Neo4jCdcSourceIdProtobufIT : Neo4jCdcSourceIdIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
@@ -1632,7 +1632,10 @@ abstract class Neo4jCudIT {
   class Neo4jCudAvroIT : Neo4jCudIT()
 
   @KeyValueConverter(key = KafkaConverter.JSON_SCHEMA, value = KafkaConverter.JSON_SCHEMA)
-  class Neo4jCudJsonIT : Neo4jCudIT()
+  class Neo4jCudJsonSchemaIT : Neo4jCudIT()
+
+  @KeyValueConverter(key = KafkaConverter.JSON_EMBEDDED, value = KafkaConverter.JSON_EMBEDDED)
+  class Neo4jCudJsonEmbeddedIT : Neo4jCudIT()
 
   @KeyValueConverter(key = KafkaConverter.PROTOBUF, value = KafkaConverter.PROTOBUF)
   class Neo4jCudProtobufIT : Neo4jCudIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCypherIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCypherIT.kt
@@ -700,7 +700,10 @@ abstract class Neo4jCypherIT {
   class Neo4jCypherAvroIT : Neo4jCypherIT()
 
   @KeyValueConverter(key = KafkaConverter.JSON_SCHEMA, value = KafkaConverter.JSON_SCHEMA)
-  class Neo4jCypherJsonIT : Neo4jCypherIT()
+  class Neo4jCypherJsonSchemaIT : Neo4jCypherIT()
+
+  @KeyValueConverter(key = KafkaConverter.JSON_EMBEDDED, value = KafkaConverter.JSON_EMBEDDED)
+  class Neo4jCypherJsonEmbeddedIT : Neo4jCypherIT()
 
   @KeyValueConverter(key = KafkaConverter.PROTOBUF, value = KafkaConverter.PROTOBUF)
   class Neo4jCypherProtobufIT : Neo4jCypherIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
@@ -700,7 +700,10 @@ abstract class Neo4jNodePatternIT {
   class Neo4jNodePatternAvroIT : Neo4jNodePatternIT()
 
   @KeyValueConverter(key = KafkaConverter.JSON_SCHEMA, value = KafkaConverter.JSON_SCHEMA)
-  class Neo4jNodePatternJsonIT : Neo4jNodePatternIT()
+  class Neo4jNodePatternJsonSchemaIT : Neo4jNodePatternIT()
+
+  @KeyValueConverter(key = KafkaConverter.JSON_EMBEDDED, value = KafkaConverter.JSON_EMBEDDED)
+  class Neo4jNodePatternJsonEmbeddedIT : Neo4jNodePatternIT()
 
   @KeyValueConverter(key = KafkaConverter.PROTOBUF, value = KafkaConverter.PROTOBUF)
   class Neo4jNodePatternProtobufIT : Neo4jNodePatternIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
@@ -906,7 +906,10 @@ abstract class Neo4jRelationshipPatternIT {
   class Neo4jRelationshipPatternAvroIT : Neo4jRelationshipPatternIT()
 
   @KeyValueConverter(key = KafkaConverter.JSON_SCHEMA, value = KafkaConverter.JSON_SCHEMA)
-  class Neo4jRelationshipPatternJsonIT : Neo4jRelationshipPatternIT()
+  class Neo4jRelationshipPatternJsonSchemaIT : Neo4jRelationshipPatternIT()
+
+  @KeyValueConverter(key = KafkaConverter.JSON_EMBEDDED, value = KafkaConverter.JSON_EMBEDDED)
+  class Neo4jRelationshipPatternJsonEmbeddedIT : Neo4jRelationshipPatternIT()
 
   @KeyValueConverter(key = KafkaConverter.PROTOBUF, value = KafkaConverter.PROTOBUF)
   class Neo4jRelationshipPatternProtobufIT : Neo4jRelationshipPatternIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
@@ -42,6 +42,7 @@ import org.neo4j.cdc.client.model.NodeState
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.assertions.TopicVerifier
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -914,7 +915,10 @@ abstract class Neo4jSinkErrorIT {
 @KeyValueConverter(key = AVRO, value = AVRO) class Neo4jSinkErrorAvroIT : Neo4jSinkErrorIT()
 
 @KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
-class Neo4jSinkErrorJsonIT : Neo4jSinkErrorIT()
+class Neo4jSinkErrorJsonSchemaIT : Neo4jSinkErrorIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jSinkErrorJsonEmbeddedIT : Neo4jSinkErrorIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF)
 class Neo4jSinkErrorProtobufIT : Neo4jSinkErrorIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkIT.kt
@@ -25,6 +25,7 @@ import org.awaitility.Awaitility.await
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInfo
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -77,6 +78,10 @@ abstract class Neo4jSinkIT {
 
 @KeyValueConverter(key = AVRO, value = AVRO) class Neo4jSinkAvroIT : Neo4jSinkIT()
 
-@KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA) class Neo4jSinkJsonIT : Neo4jSinkIT()
+@KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
+class Neo4jSinkJsonSchemaIT : Neo4jSinkIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jSinkJsonEmbeddedIT : Neo4jSinkIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF) class Neo4jSinkProtobufIT : Neo4jSinkIT()

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceIT.kt
@@ -28,6 +28,7 @@ import org.neo4j.connectors.kafka.connect.ConnectHeader
 import org.neo4j.connectors.kafka.data.Headers
 import org.neo4j.connectors.kafka.testing.assertions.TopicVerifier
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -190,7 +191,10 @@ abstract class Neo4jCdcSourceIT {
 @KeyValueConverter(key = AVRO, value = AVRO) class Neo4jCdcSourceAvroIT : Neo4jCdcSourceIT()
 
 @KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
-class Neo4jCdcSourceJsonIT : Neo4jCdcSourceIT()
+class Neo4jCdcSourceJsonSchemaIT : Neo4jCdcSourceIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jCdcSourceJsonEmbeddedIT : Neo4jCdcSourceIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF)
 class Neo4jCdcSourceProtobufIT : Neo4jCdcSourceIT()

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceKeyStrategyIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceKeyStrategyIT.kt
@@ -28,6 +28,7 @@ import org.neo4j.cdc.client.model.EventType
 import org.neo4j.connectors.kafka.testing.assertions.ChangeEventAssert
 import org.neo4j.connectors.kafka.testing.assertions.TopicVerifier
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -315,7 +316,10 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
 class Neo4jCdcSourceKeyStrategyAvroIT : Neo4jCdcSourceKeyStrategyIT()
 
 @KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
-class Neo4jCdcSourceKeyStrategyJsonIT : Neo4jCdcSourceKeyStrategyIT()
+class Neo4jCdcSourceKeyStrategyJsonSchemaIT : Neo4jCdcSourceKeyStrategyIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jCdcSourceKeyStrategyJsonEmbeddedIT : Neo4jCdcSourceKeyStrategyIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF)
 class Neo4jCdcSourceKeyStrategyProtobufIT : Neo4jCdcSourceKeyStrategyIT()

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceNodesIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceNodesIT.kt
@@ -28,6 +28,7 @@ import org.neo4j.cdc.client.model.EventType.NODE
 import org.neo4j.connectors.kafka.testing.assertions.ChangeEventAssert.Companion.assertThat
 import org.neo4j.connectors.kafka.testing.assertions.TopicVerifier
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -619,7 +620,10 @@ abstract class Neo4jCdcSourceNodesIT {
 class Neo4jCdcSourceNodesAvroIT : Neo4jCdcSourceNodesIT()
 
 @KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
-class Neo4jCdcSourceNodesJsonIT : Neo4jCdcSourceNodesIT()
+class Neo4jCdcSourceNodesJsonSchemaIT : Neo4jCdcSourceNodesIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jCdcSourceNodesJsonEmbeddedIT : Neo4jCdcSourceNodesIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF)
 class Neo4jCdcSourceNodesProtobufIT : Neo4jCdcSourceNodesIT()

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceRelationshipsIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceRelationshipsIT.kt
@@ -28,6 +28,7 @@ import org.neo4j.cdc.client.model.EventType.RELATIONSHIP
 import org.neo4j.connectors.kafka.testing.assertions.ChangeEventAssert.Companion.assertThat
 import org.neo4j.connectors.kafka.testing.assertions.TopicVerifier
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -616,7 +617,10 @@ abstract class Neo4jCdcSourceRelationshipsIT {
 class Neo4jCdcSourceRelationshipsAvroIT : Neo4jCdcSourceRelationshipsIT()
 
 @KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
-class Neo4jCdcSourceRelationshipsJsonIT : Neo4jCdcSourceRelationshipsIT()
+class Neo4jCdcSourceRelationshipsJsonSchemaIT : Neo4jCdcSourceRelationshipsIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jCdcSourceRelationshipsJsonEmbeddedIT : Neo4jCdcSourceRelationshipsIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF)
 class Neo4jCdcSourceRelationshipsProtobufIT : Neo4jCdcSourceRelationshipsIT()

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
@@ -25,6 +25,7 @@ import org.neo4j.connectors.kafka.testing.MapSupport.excludingKeys
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.assertions.TopicVerifier
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.AVRO
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_EMBEDDED
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_SCHEMA
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter.PROTOBUF
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -202,7 +203,10 @@ abstract class Neo4jSourceQueryIT {
 @KeyValueConverter(key = AVRO, value = AVRO) class Neo4jSourceAvroIT : Neo4jSourceQueryIT()
 
 @KeyValueConverter(key = JSON_SCHEMA, value = JSON_SCHEMA)
-class Neo4jSourceJsonIT : Neo4jSourceQueryIT()
+class Neo4jSourceJsonSchemaIT : Neo4jSourceQueryIT()
+
+@KeyValueConverter(key = JSON_EMBEDDED, value = JSON_EMBEDDED)
+class Neo4jSourceJsonEmbeddedIT : Neo4jSourceQueryIT()
 
 @KeyValueConverter(key = PROTOBUF, value = PROTOBUF)
 class Neo4jSourceProtobufIT : Neo4jSourceQueryIT()

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
@@ -20,14 +20,17 @@ import io.confluent.connect.avro.AvroConverter
 import io.confluent.connect.json.JsonSchemaConverter
 import io.confluent.connect.protobuf.ProtobufConverter
 import io.confluent.kafka.serializers.KafkaAvroSerializer
+import io.confluent.kafka.serializers.KafkaJsonSerializer
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer
 import org.apache.kafka.common.serialization.Serializer
+import org.apache.kafka.connect.json.JsonConverter
 import org.apache.kafka.connect.storage.Converter
 import org.apache.kafka.connect.storage.StringConverter
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.neo4j.connectors.kafka.testing.AnnotationSupport
 import org.neo4j.connectors.kafka.testing.format.avro.AvroSerializer
+import org.neo4j.connectors.kafka.testing.format.json.JsonEmbeddedSerializer
 import org.neo4j.connectors.kafka.testing.format.json.JsonSchemaSerializer
 import org.neo4j.connectors.kafka.testing.format.protobuf.ProtobufSerializer
 import org.neo4j.connectors.kafka.testing.format.string.StringSerializer
@@ -53,6 +56,11 @@ enum class KafkaConverter(
       converterProvider = { JsonSchemaConverter() },
       serializerClass = KafkaJsonSchemaSerializer::class.java,
       testShimSerializer = JsonSchemaSerializer),
+  JSON_EMBEDDED(
+      className = "org.apache.kafka.connect.json.JsonConverter",
+      converterProvider = { JsonConverter() },
+      serializerClass = KafkaJsonSerializer::class.java,
+      testShimSerializer = JsonEmbeddedSerializer),
   PROTOBUF(
       className = "io.confluent.connect.protobuf.ProtobufConverter",
       converterProvider = { ProtobufConverter() },

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaRecordSerializer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaRecordSerializer.kt
@@ -19,5 +19,5 @@ package org.neo4j.connectors.kafka.testing.format
 import org.apache.kafka.connect.data.Schema
 
 interface KafkaRecordSerializer {
-  fun serialize(value: Any, schema: Schema): Any
+  fun serialize(value: Any, schema: Schema, isKey: Boolean): Any
 }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/avro/AvroSerializer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/avro/AvroSerializer.kt
@@ -26,7 +26,7 @@ object AvroSerializer : KafkaRecordSerializer {
 
   private val avroData = AvroData(CACHE_SIZE)
 
-  override fun serialize(value: Any, schema: Schema): Any {
+  override fun serialize(value: Any, schema: Schema, isKey: Boolean): Any {
     return avroData.fromConnectData(schema, value)
   }
 }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/json/JsonEmbeddedSerializer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/json/JsonEmbeddedSerializer.kt
@@ -14,18 +14,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.connectors.kafka.testing.format.protobuf
+package org.neo4j.connectors.kafka.testing.format.json
 
-import io.confluent.connect.protobuf.ProtobufData
-import io.confluent.connect.protobuf.ProtobufDataConfig
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.json.JsonConverter
 import org.neo4j.connectors.kafka.testing.format.KafkaRecordSerializer
 
-class ProtobufSerializer(config: Map<*, *>) : KafkaRecordSerializer {
+object JsonEmbeddedSerializer : KafkaRecordSerializer {
 
-  private val protobufData = ProtobufData(ProtobufDataConfig(config))
+  private val converter = JsonConverter()
+  private val objectMapper = ObjectMapper()
 
   override fun serialize(value: Any, schema: Schema, isKey: Boolean): Any {
-    return protobufData.fromConnectData(schema, value).value
+    converter.configure(mapOf("schemas.enable" to true), isKey)
+    val data = converter.fromConnectData(null, schema, value)
+    return objectMapper.readTree(data)
   }
 }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/json/JsonSchemaSerializer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/json/JsonSchemaSerializer.kt
@@ -25,7 +25,7 @@ object JsonSchemaSerializer : KafkaRecordSerializer {
 
   private val jsonSchemaData = JsonSchemaData()
 
-  override fun serialize(value: Any, schema: Schema): Any {
+  override fun serialize(value: Any, schema: Schema, isKey: Boolean): Any {
     val jsonSchema = jsonSchemaData.fromConnectSchema(schema)
     val jsonNode = jsonSchemaData.fromConnectData(schema, value)
     return JsonSchemaUtils.envelope(jsonSchema, jsonNode)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/string/StringSerializer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/string/StringSerializer.kt
@@ -21,7 +21,7 @@ import org.neo4j.connectors.kafka.testing.format.KafkaRecordSerializer
 
 object StringSerializer : KafkaRecordSerializer {
 
-  override fun serialize(value: Any, schema: Schema): Any {
+  override fun serialize(value: Any, schema: Schema, isKey: Boolean): Any {
     return when (value) {
       is String -> value
       else -> value.toString()

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaProducer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaProducer.kt
@@ -67,7 +67,9 @@ data class ConvertingKafkaProducer(
               null -> null
               else ->
                   keyConverter.testShimSerializer.serialize(
-                      it.key, it.keySchema ?: throw IllegalArgumentException("null key schema"))
+                      it.key,
+                      it.keySchema ?: throw IllegalArgumentException("null key schema"),
+                      true)
             }
         val serializedValue =
             when (it.value) {
@@ -75,7 +77,8 @@ data class ConvertingKafkaProducer(
               else ->
                   valueConverter.testShimSerializer.serialize(
                       it.value,
-                      it.valueSchema ?: throw IllegalArgumentException("null value schema"))
+                      it.valueSchema ?: throw IllegalArgumentException("null value schema"),
+                      false)
             }
         val converter = SimpleHeaderConverter()
         val recordHeaders =

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistration.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistration.kt
@@ -58,7 +58,13 @@ internal class Neo4jSinkRegistration(
                       put("topics", topics.joinToString(","))
                       put("connector.class", "org.neo4j.connectors.kafka.sink.Neo4jConnector")
                       put("key.converter", keyConverter.className)
+                      if (keyConverter == KafkaConverter.JSON_EMBEDDED) {
+                        put("key.converter.schemas.enable", true)
+                      }
                       put("value.converter", valueConverter.className)
+                      if (valueConverter == KafkaConverter.JSON_EMBEDDED) {
+                        put("value.converter.schemas.enable", true)
+                      }
                       put("errors.retry.timeout", retryTimeout.inWholeMilliseconds)
                       put("errors.retry.delay.max.ms", retryMaxDelay.inWholeMilliseconds)
                       put("errors.tolerance", errorTolerance)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceRegistration.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceRegistration.kt
@@ -56,7 +56,13 @@ internal class Neo4jSourceRegistration(
     val config = buildMap {
       put("connector.class", "org.neo4j.connectors.kafka.source.Neo4jConnector")
       put("key.converter", keyConverter.className)
+      if (keyConverter == KafkaConverter.JSON_EMBEDDED) {
+        put("key.converter.schemas.enable", true)
+      }
       put("value.converter", valueConverter.className)
+      if (valueConverter == KafkaConverter.JSON_EMBEDDED) {
+        put("value.converter.schemas.enable", true)
+      }
       put("neo4j.uri", neo4jUri)
       put("neo4j.authentication.type", "BASIC")
       put("neo4j.authentication.basic.username", neo4jUser)


### PR DESCRIPTION
This PR introduces a mechanism to support running integration tests with embedded JSON Schema, alongside the existing support for Avro, Protobuf, and JSON Schema.