### PR TITLE
chore: remove max retry attempts config property

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfiguration.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfiguration.kt
@@ -76,9 +76,6 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
     get(): kotlin.time.Duration =
         kotlin.time.Duration.parseSimpleString(getString(MAX_TRANSACTION_RETRY_TIMEOUT))
 
-  val maxRetryAttempts
-    get(): Int = getInt(MAX_TRANSACTION_RETRY_ATTEMPTS)
-
   internal val maxConnectionPoolSize
     get(): Int = getInt(POOL_MAX_CONNECTION_POOL_SIZE)
 
@@ -248,7 +245,6 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
     const val AUTHENTICATION_CUSTOM_REALM = "neo4j.authentication.custom.realm"
 
     const val MAX_TRANSACTION_RETRY_TIMEOUT = "neo4j.max-retry-time"
-    const val MAX_TRANSACTION_RETRY_ATTEMPTS = "neo4j.max-retry-attempts"
 
     const val CONNECTION_TIMEOUT = "neo4j.connection-timeout"
     const val POOL_MAX_CONNECTION_POOL_SIZE = "neo4j.pool.max-connection-pool-size"

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationDeclarations.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationDeclarations.kt
@@ -314,11 +314,3 @@ fun ConfigDef.defineRetrySettings(): ConfigDef =
                   group = Groups.CONNECTION_ADVANCED.title
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
                 })
-        .define(
-            ConfigKeyBuilder.of(
-                Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS, ConfigDef.Type.INT) {
-                  importance = Importance.LOW
-                  defaultValue = Neo4jConfiguration.DEFAULT_MAX_RETRY_ATTEMPTS
-                  group = Groups.CONNECTION_ADVANCED.title
-                  validator = Range.atLeast(1)
-                })

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationDeclarations.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationDeclarations.kt
@@ -307,10 +307,10 @@ fun ConfigDef.definePoolSettings(): ConfigDef =
 
 fun ConfigDef.defineRetrySettings(): ConfigDef =
     this.define(
-            ConfigKeyBuilder.of(
-                Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT, ConfigDef.Type.STRING) {
-                  importance = Importance.LOW
-                  defaultValue = Neo4jConfiguration.DEFAULT_MAX_RETRY_DURATION.toSimpleString()
-                  group = Groups.CONNECTION_ADVANCED.title
-                  validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+        ConfigKeyBuilder.of(
+            Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT, ConfigDef.Type.STRING) {
+              importance = Importance.LOW
+              defaultValue = Neo4jConfiguration.DEFAULT_MAX_RETRY_DURATION.toSimpleString()
+              group = Groups.CONNECTION_ADVANCED.title
+              validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
+            })

--- a/common/src/main/resources/neo4j-configuration.properties
+++ b/common/src/main/resources/neo4j-configuration.properties
@@ -33,4 +33,3 @@ neo4j.pool.connection-acquisition-timeout=Type: Duration;\nDescription: Maximum 
 neo4j.pool.idle-time-before-connection-test=Type: Duration;\nDescription: Duration after which idle connections are tested for liveness (valid units are: `ms`, `s`, `m`, `h` and `d`; default unit is `s`).
 neo4j.pool.max-connection-lifetime=Type: Duration;\nDescription: Duration after which a connection is dropped from the connection pool (valid units are: ``ms`, `s`, `m`, `h` and `d`; default unit is `s`).
 neo4j.max-retry-time=Type: Duration;\nDescription: Maximum duration to retry a transaction.
-neo4j.max-retry-attempts=Type: Integer;\nDescription: Maximum number of attempts during the duration specified by `neo4j.max-retry-time`.

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationTest.kt
@@ -87,8 +87,7 @@ class Neo4jConfigurationTest {
           mapOf(
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 0),
+              Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s"),
           type)
     } shouldHaveMessage
         "Invalid value 0 for configuration neo4j.max-retry-attempts: Value must be at least 1"
@@ -100,7 +99,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1"),
           type)
     } shouldHaveMessage
@@ -113,7 +111,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 0),
           type)
@@ -127,7 +124,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5k"),
@@ -142,7 +138,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -158,7 +153,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -175,7 +169,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -193,7 +186,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -212,7 +204,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -232,7 +223,6 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -260,7 +250,6 @@ class Neo4jConfigurationTest {
                 Neo4jConfiguration.URI to "bolt://localhost",
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
                 Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-                Neo4jConfiguration.MAX_TRANSACTION_RETRY_ATTEMPTS to 5,
                 Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
                 Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
                 Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
@@ -275,7 +264,6 @@ class Neo4jConfigurationTest {
     assertEquals(listOf(URI("bolt://localhost")), config.uris)
     assertEquals(AuthTokens.none(), config.authenticationToken)
     assertEquals(5.seconds, config.maxRetryTime)
-    assertEquals(5, config.maxRetryAttempts)
     assertEquals(1.minutes, config.connectionTimeout)
     assertEquals(5, config.maxConnectionPoolSize)
     assertEquals(5.minutes, config.connectionAcquisitionTimeout)

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationTest.kt
@@ -87,17 +87,6 @@ class Neo4jConfigurationTest {
           mapOf(
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s"),
-          type)
-    } shouldHaveMessage
-        "Invalid value 0 for configuration neo4j.max-retry-attempts: Value must be at least 1"
-
-    shouldThrow<ConfigException> {
-      Neo4jConfiguration(
-          Neo4jConfiguration.config(),
-          mapOf(
-              Neo4jConfiguration.URI to "bolt://localhost",
-              Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1"),
           type)


### PR DESCRIPTION
This PR removes unused `neo4j.max-retry-attempts` configuration property from the codebase.