### PR TITLE
fix: use incoming object if schema is not defined

### DIFF
--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkRawJSONIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkRawJSONIT.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.sink
+
+import io.kotest.matchers.shouldBe
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.toJavaDuration
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Test
+import org.neo4j.connectors.kafka.testing.format.KafkaConverter.JSON_RAW
+import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
+import org.neo4j.connectors.kafka.testing.kafka.ConvertingKafkaProducer
+import org.neo4j.connectors.kafka.testing.sink.CypherStrategy
+import org.neo4j.connectors.kafka.testing.sink.Neo4jSink
+import org.neo4j.connectors.kafka.testing.sink.TopicProducer
+import org.neo4j.driver.Session
+
+@KeyValueConverter(key = JSON_RAW, value = JSON_RAW)
+class Neo4jSinkRawJSONIT {
+  companion object {
+    private const val TOPIC = "persons"
+  }
+
+  @Neo4jSink(
+      cypher =
+          [
+              CypherStrategy(
+                  TOPIC,
+                  "WITH __value AS person MERGE (p:Person {name: person.name, surname: person.surname})",
+              ),
+          ],
+  )
+  @Test
+  fun `should support json map`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+  ) {
+    producer.publish(
+        value = mapOf("name" to "Jane", "surname" to "Doe"),
+        valueSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build(),
+    )
+
+    await().atMost(30.seconds.toJavaDuration()).until {
+      session
+          .run(
+              "MATCH (p:Person {name: \$name, surname: \$surname}) RETURN count(p) = 1 AS result",
+              mapOf("name" to "Jane", "surname" to "Doe"),
+          )
+          .single()["result"]
+          .asBoolean()
+    }
+  }
+
+  @Neo4jSink(
+      cypher =
+          [
+              CypherStrategy(
+                  TOPIC,
+                  "WITH __value AS persons UNWIND persons AS person MERGE (p:Person {name: person.name, surname: person.surname})",
+              ),
+          ],
+  )
+  @Test
+  fun `should support json list`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+  ) {
+    producer.publish(
+        value =
+            listOf(
+                mapOf("name" to "Jane", "surname" to "Doe"),
+                mapOf("name" to "John", "surname" to "Doe"),
+            ),
+        valueSchema =
+            SchemaBuilder.array(
+                    SchemaBuilder.map(
+                            Schema.STRING_SCHEMA,
+                            Schema.STRING_SCHEMA,
+                        )
+                        .build(),
+                )
+                .build(),
+    )
+
+    await().atMost(30.seconds.toJavaDuration()).untilAsserted {
+      session
+          .run(
+              "MATCH (p:Person) RETURN count(p) as result",
+          )
+          .single()["result"]
+          .asLong() shouldBe 2L
+    }
+  }
+
+  @Neo4jSink(
+      cypher =
+          [
+              CypherStrategy(
+                  TOPIC,
+                  "WITH __value AS name MERGE (p:Person {name: name})",
+              ),
+          ],
+  )
+  @Test
+  fun `should support raw string value`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+  ) {
+    producer.publish(
+        value = "John",
+        valueSchema = Schema.STRING_SCHEMA,
+    )
+
+    await().atMost(30.seconds.toJavaDuration()).untilAsserted {
+      session
+          .run(
+              "MATCH (p:Person) RETURN count(p) as result",
+          )
+          .single()["result"]
+          .asLong() shouldBe 1L
+    }
+  }
+
+  @Neo4jSink(
+      cypher =
+          [
+              CypherStrategy(
+                  TOPIC,
+                  "WITH __value AS age MERGE (p:Person {age: age})",
+              ),
+          ],
+  )
+  @Test
+  fun `should support raw numeric value`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+  ) {
+    producer.publish(
+        value = 25L,
+        valueSchema = Schema.INT64_SCHEMA,
+    )
+
+    await().atMost(30.seconds.toJavaDuration()).untilAsserted {
+      session
+          .run(
+              "MATCH (p:Person) RETURN count(p) as result",
+          )
+          .single()["result"]
+          .asLong() shouldBe 1L
+    }
+  }
+}

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkRawJsonIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkRawJsonIT.kt
@@ -56,14 +56,14 @@ class Neo4jSinkRawJsonIT {
         valueSchema = SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build(),
     )
 
-    await().atMost(30.seconds.toJavaDuration()).until {
+    await().atMost(30.seconds.toJavaDuration()).untilAsserted {
       session
           .run(
-              "MATCH (p:Person {name: \$name, surname: \$surname}) RETURN count(p) = 1 AS result",
+              "MATCH (p:Person {name: ${'$'}name, surname: ${'$'}surname}) RETURN count(p) as result",
               mapOf("name" to "Jane", "surname" to "Doe"),
           )
           .single()["result"]
-          .asBoolean()
+          .asLong() shouldBe 1L
     }
   }
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/SinkStrategy.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/SinkStrategy.kt
@@ -89,7 +89,7 @@ data class SinkMessage(val record: SinkRecord) {
             }
       }
       converted
-    }
+    } ?: value
   }
 
   override fun toString(): String {

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
@@ -31,12 +31,15 @@ import org.junit.jupiter.api.extension.ExtensionContext
 import org.neo4j.connectors.kafka.testing.AnnotationSupport
 import org.neo4j.connectors.kafka.testing.format.avro.AvroSerializer
 import org.neo4j.connectors.kafka.testing.format.json.JsonEmbeddedSerializer
+import org.neo4j.connectors.kafka.testing.format.json.JsonRawSerializer
 import org.neo4j.connectors.kafka.testing.format.json.JsonSchemaSerializer
 import org.neo4j.connectors.kafka.testing.format.protobuf.ProtobufSerializer
 import org.neo4j.connectors.kafka.testing.format.string.StringSerializer
 
 private val PROTOBUF_OPTIONS =
     mapOf("enhanced.protobuf.schema.support" to "true", "optional.for.nullables" to "true")
+
+private val JSON_RAW_OPTIONS = mapOf("schemas.enable" to "false")
 
 enum class KafkaConverter(
     val className: String,
@@ -50,28 +53,40 @@ enum class KafkaConverter(
       className = "io.confluent.connect.avro.AvroConverter",
       converterProvider = { AvroConverter() },
       serializerClass = KafkaAvroSerializer::class.java,
-      testShimSerializer = AvroSerializer),
+      testShimSerializer = AvroSerializer,
+  ),
   JSON_SCHEMA(
       className = "io.confluent.connect.json.JsonSchemaConverter",
       converterProvider = { JsonSchemaConverter() },
       serializerClass = KafkaJsonSchemaSerializer::class.java,
-      testShimSerializer = JsonSchemaSerializer),
+      testShimSerializer = JsonSchemaSerializer,
+  ),
   JSON_EMBEDDED(
       className = "org.apache.kafka.connect.json.JsonConverter",
       converterProvider = { JsonConverter() },
       serializerClass = KafkaJsonSerializer::class.java,
-      testShimSerializer = JsonEmbeddedSerializer),
+      testShimSerializer = JsonEmbeddedSerializer,
+  ),
+  JSON_RAW(
+      className = "org.apache.kafka.connect.json.JsonConverter",
+      converterProvider = { JsonConverter() },
+      serializerClass = KafkaJsonSerializer::class.java,
+      testShimSerializer = JsonRawSerializer,
+      additionalProperties = JSON_RAW_OPTIONS,
+  ),
   PROTOBUF(
       className = "io.confluent.connect.protobuf.ProtobufConverter",
       converterProvider = { ProtobufConverter() },
       serializerClass = KafkaProtobufSerializer::class.java,
       testShimSerializer = ProtobufSerializer(PROTOBUF_OPTIONS),
-      additionalProperties = PROTOBUF_OPTIONS),
+      additionalProperties = PROTOBUF_OPTIONS,
+  ),
   STRING(
       className = "org.apache.kafka.connect.storage.StringConverter",
       converterProvider = { StringConverter() },
       serializerClass = org.apache.kafka.common.serialization.StringSerializer::class.java,
-      testShimSerializer = StringSerializer)
+      testShimSerializer = StringSerializer,
+  )
 }
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/json/JsonRawSerializer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/json/JsonRawSerializer.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.testing.format.json
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.json.JsonConverter
+import org.neo4j.connectors.kafka.testing.format.KafkaRecordSerializer
+
+object JsonRawSerializer : KafkaRecordSerializer {
+
+  private val converter = JsonConverter()
+  private val objectMapper = ObjectMapper()
+
+  override fun serialize(value: Any, schema: Schema, isKey: Boolean): Any {
+    converter.configure(mapOf("schemas.enable" to false), isKey)
+    val data = converter.fromConnectData(null, schema, value)
+    return objectMapper.readTree(data)
+  }
+}


### PR DESCRIPTION
This PR fixes an issue where `org.apache.kafka.connect.json.JsonConverter` is not supported when `schemas.enable` is set to `false` which should support incoming JSON strings.