### PR TITLE
fix: handle cdc schema events in a strict way and enforce keys

### DIFF
--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaFromStreamsMessageIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaFromStreamsMessageIT.kt
@@ -16,7 +16,6 @@
  */
 package org.neo4j.connectors.kafka.sink
 
-import io.kotest.assertions.nondeterministic.continually
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
@@ -42,6 +41,7 @@ import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
 import org.neo4j.connectors.kafka.testing.kafka.ConvertingKafkaProducer
 import org.neo4j.connectors.kafka.testing.sink.CdcSchemaStrategy
 import org.neo4j.connectors.kafka.testing.sink.Neo4jSink
+import org.neo4j.connectors.kafka.testing.sink.Neo4jSinkRegistration
 import org.neo4j.connectors.kafka.testing.sink.SchemaCompatibilityMode
 import org.neo4j.connectors.kafka.testing.sink.TopicProducer
 import org.neo4j.driver.Session
@@ -69,8 +69,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after =
                         NodeChange(
                             properties = mapOf("id" to 1L, "name" to "john"),
-                            labels = listOf("Person"))),
-            schema = defaultSchema()))
+                            labels = listOf("Person"),
+                        ),
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -93,7 +97,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
     session
         .run(
             "CREATE (n:Person) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 1L, "name" to "john")))
+            mapOf("props" to mapOf("id" to 1L, "name" to "john")),
+        )
         .consume()
 
     producer.publish(
@@ -110,9 +115,14 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                     "id" to 5L,
                                     "name" to "john",
                                     "surname" to "doe",
-                                    "dob" to LocalDate.of(2000, 1, 1).toEpochDay()),
-                            labels = listOf("Person", "Employee"))),
-            schema = defaultSchema()))
+                                    "dob" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                                ),
+                            labels = listOf("Person", "Employee"),
+                        ),
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -126,7 +136,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     "id" to 5L,
                     "name" to "john",
                     "surname" to "doe",
-                    "dob" to LocalDate.of(2000, 1, 1).toEpochDay())
+                    "dob" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                )
           }
     }
   }
@@ -140,7 +151,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
     session
         .run(
             "CREATE (n:Person) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 1L, "name" to "john")))
+            mapOf("props" to mapOf("id" to 1L, "name" to "john")),
+        )
         .consume()
 
     producer.publish(
@@ -150,8 +162,11 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                 NodePayload(
                     id = "person1",
                     before = NodeChange(mapOf("id" to 1L, "name" to "john"), emptyList()),
-                    after = null),
-            schema = defaultSchema()))
+                    after = null,
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result = session.run("MATCH (n:Person {id: ${'$'}id}) RETURN n", mapOf("id" to 1L)).list()
@@ -184,7 +199,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                 "last_name" to "smith",
                                 "email" to "john@smith.org",
                             ),
-                            listOf("Person")),
+                            listOf("Person"),
+                        ),
                 ),
             schema =
                 Schema(
@@ -200,9 +216,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             Constraint(
                                 "Person",
                                 setOf("email"),
-                                StreamsConstraintType.NODE_PROPERTY_EXISTS),
-                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE)),
-                ))
+                                StreamsConstraintType.NODE_PROPERTY_EXISTS,
+                            ),
+                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE),
+                        ),
+                ),
+        )
 
     // when the event is published
     producer.publish(event)
@@ -213,7 +232,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
           session
               .run(
                   "MATCH (n:Person {first_name: ${'$'}first_name}) RETURN n",
-                  mapOf("first_name" to "john"))
+                  mapOf("first_name" to "john"),
+              )
               .list()
 
       result shouldHaveSize 1
@@ -237,7 +257,9 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    )))
+                    ),
+            ),
+        )
         .consume()
 
     // and an update event adding a new property and label
@@ -255,7 +277,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                 "last_name" to "smith",
                                 "email" to "john@smith.org",
                             ),
-                            listOf("Person")),
+                            listOf("Person"),
+                        ),
                     after =
                         NodeChange(
                             properties =
@@ -263,8 +286,11 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                     "first_name" to "john",
                                     "last_name" to "smith",
                                     "email" to "john@smith.org",
-                                    "location" to "London"),
-                            labels = listOf("Person", "Employee"))),
+                                    "location" to "London",
+                                ),
+                            labels = listOf("Person", "Employee"),
+                        ),
+                ),
             schema =
                 Schema(
                     constraints =
@@ -273,9 +299,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             Constraint(
                                 "Person",
                                 setOf("email"),
-                                StreamsConstraintType.NODE_PROPERTY_EXISTS),
-                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE)),
-                ))
+                                StreamsConstraintType.NODE_PROPERTY_EXISTS,
+                            ),
+                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE),
+                        ),
+                ),
+        )
 
     // when the message is published
     producer.publish(updateEvent)
@@ -286,7 +315,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
           session
               .run(
                   "MATCH (n:Person {first_name: ${'$'}first_name}) RETURN n",
-                  mapOf("first_name" to "john"))
+                  mapOf("first_name" to "john"),
+              )
               .single()
 
       result.get("n").asNode() should
@@ -297,7 +327,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     "first_name" to "john",
                     "last_name" to "smith",
                     "email" to "john@smith.org",
-                    "location" to "London")
+                    "location" to "London",
+                )
           }
     }
   }
@@ -319,7 +350,9 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    )))
+                    ),
+            ),
+        )
         .consume()
 
     // and a deletion event and with a unique constraint referencing a property that doesn't exist
@@ -338,7 +371,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                 "last_name" to "smith",
                                 "email" to "john@smith.org",
                             ),
-                            listOf("Person")),
+                            listOf("Person"),
+                        ),
                 ),
             schema =
                 Schema(
@@ -354,9 +388,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             Constraint(
                                 "Person",
                                 setOf("email"),
-                                StreamsConstraintType.NODE_PROPERTY_EXISTS),
-                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE)),
-                ))
+                                StreamsConstraintType.NODE_PROPERTY_EXISTS,
+                            ),
+                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE),
+                        ),
+                ),
+        )
 
     // when the event is published
     producer.publish(event)
@@ -367,7 +404,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
           session
               .run(
                   "MATCH (n:Person {first_name: ${'$'}first_name}) RETURN n",
-                  mapOf("first_name" to "john"))
+                  mapOf("first_name" to "john"),
+              )
               .list()
 
       result shouldHaveSize 0
@@ -378,7 +416,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should fail to delete a node when no valid unique constraints are provided`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
+      sink: Neo4jSinkRegistration
   ) = runTest {
 
     // given a database containing 1 node
@@ -391,7 +430,9 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    )))
+                    ),
+            ),
+        )
         .consume()
 
     // and a deletion event and with a multiple unique constraints which do not have a valid
@@ -410,7 +451,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                 "first_name" to "john",
                                 "last_name" to "smith",
                             ),
-                            listOf("Person")),
+                            listOf("Person"),
+                        ),
                 ),
             schema =
                 Schema(
@@ -425,24 +467,108 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             Constraint(
                                 "Person",
                                 setOf("email"),
-                                StreamsConstraintType.NODE_PROPERTY_EXISTS),
-                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE)),
-                ))
+                                StreamsConstraintType.NODE_PROPERTY_EXISTS,
+                            ),
+                            Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE),
+                        ),
+                ),
+        )
 
     // when the event is published
     producer.publish(event)
 
-    // then the node should not be deleted and should still exist
-    continually(10.seconds) {
-      val result =
-          session
-              .run(
-                  "MATCH (n:Person {first_name: ${'$'}first_name}) RETURN n",
-                  mapOf("first_name" to "john"))
-              .list()
-
-      result shouldHaveSize 1
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
     }
+
+    // and the node should not be deleted and should still exist
+    val result =
+        session
+            .run(
+                "MATCH (n:Person {first_name: ${'$'}first_name}) RETURN n",
+                mapOf("first_name" to "john"),
+            )
+            .list()
+
+    result shouldHaveSize 1
+  }
+
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
+  fun `should fail to delete a node when no constraints are provided`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+
+    // given a database containing 1 node
+    session
+        .run(
+            "CREATE (n:Person) SET n = ${'$'}props",
+            mapOf(
+                "props" to
+                    mapOf(
+                        "first_name" to "john",
+                        "last_name" to "smith",
+                        "email" to "john@smith.org",
+                    ),
+            ),
+        )
+        .consume()
+
+    // and a deletion event and with a multiple unique constraints which do not have a valid
+    // property
+    val event =
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.deleted),
+            payload =
+                NodePayload(
+                    id = "1",
+                    type = EntityType.node,
+                    after = null,
+                    before =
+                        NodeChange(
+                            mapOf(
+                                "first_name" to "john",
+                                "last_name" to "smith",
+                            ),
+                            listOf("Person"),
+                        ),
+                ),
+            schema =
+                Schema(
+                    properties =
+                        mapOf(
+                            "first_name" to "String",
+                            "last_name" to "String",
+                        ),
+                    constraints = emptyList(),
+                ),
+        )
+
+    // when the event is published
+    producer.publish(event)
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and the node should not be deleted and should still exist
+    val result =
+        session
+            .run(
+                "MATCH (n:Person {first_name: ${'$'}first_name}) RETURN n",
+                mapOf("first_name" to "john"),
+            )
+            .list()
+
+    result shouldHaveSize 1
   }
 
   @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
@@ -459,7 +585,9 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
             """,
             mapOf(
                 "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
-                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe")))
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -474,8 +602,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     before = null,
                     after =
                         RelationshipChange(
-                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()))),
-            schema = Schema()))
+                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result = session.run("MATCH (start)-[r:KNOWS]->(end) RETURN start, r, end").single()
@@ -499,6 +631,108 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
 
   @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
   @Test
+  fun `should fail to create a relationship when start node keys is empty`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+    session
+        .run(
+            """
+            CREATE (n1:Person) SET n1 = ${'$'}person1
+            CREATE (n2:Person) SET n2 = ${'$'}person2
+            """,
+            mapOf(
+                "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+            ),
+        )
+        .consume()
+
+    producer.publish(
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.created),
+            payload =
+                RelationshipPayload(
+                    id = "knows1",
+                    label = "KNOWS",
+                    start = RelationshipNodeChange("person1", listOf("Person"), emptyMap()),
+                    end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
+                    before = null,
+                    after =
+                        RelationshipChange(
+                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and relationship should not be created
+    val result = session.run("MATCH (start)-[r:KNOWS]->(end) RETURN count(r)").single()
+    result.get(0).asInt() shouldBe 0
+  }
+
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
+  fun `should fail to create a relationship when end node keys is empty`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+    session
+        .run(
+            """
+            CREATE (n1:Person) SET n1 = ${'$'}person1
+            CREATE (n2:Person) SET n2 = ${'$'}person2
+            """,
+            mapOf(
+                "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+            ),
+        )
+        .consume()
+
+    producer.publish(
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.created),
+            payload =
+                RelationshipPayload(
+                    id = "knows1",
+                    label = "KNOWS",
+                    start = RelationshipNodeChange("person1", listOf("Person"), mapOf("id" to 1L)),
+                    end = RelationshipNodeChange("person2", listOf("Person"), emptyMap()),
+                    before = null,
+                    after =
+                        RelationshipChange(
+                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and relationship should not be created
+    val result = session.run("MATCH (start)-[r:KNOWS]->(end) RETURN count(r)").single()
+    result.get(0).asInt() shouldBe 0
+  }
+
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
   fun `should update relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session
@@ -514,7 +748,9 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                 "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
                 "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
                 "knows" to
-                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend")))
+                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -530,11 +766,17 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         RelationshipChange(
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
-                                "type" to "friend")),
+                                "type" to "friend",
+                            ),
+                        ),
                     after =
                         RelationshipChange(
-                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()))),
-            schema = Schema()))
+                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result = session.run("MATCH (start)-[r:KNOWS]->(end) RETURN start, r, end").single()
@@ -542,6 +784,164 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
       result.get("r").asRelationship() should
           {
             it.asMap() shouldBe mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay())
+          }
+      result.get("start").asNode() should
+          {
+            it.labels() shouldBe listOf("Person")
+            it.asMap() shouldBe mapOf("id" to 1L, "name" to "john", "surname" to "doe")
+          }
+      result.get("end").asNode() should
+          {
+            it.labels() shouldBe listOf("Person")
+            it.asMap() shouldBe mapOf("id" to 2L, "name" to "mary", "surname" to "doe")
+          }
+    }
+  }
+
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
+  fun `should fail to update a relationship when start node keys is empty`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+    session
+        .run(
+            """
+            CREATE (n1:Person) SET n1 = ${'$'}person1
+            CREATE (n2:Person) SET n2 = ${'$'}person2
+            CREATE (n1)-[r:KNOWS]->(n2) SET r = ${'$'}knows
+            """,
+            mapOf(
+                "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+                "knows" to
+                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend"),
+            ),
+        )
+        .consume()
+
+    producer.publish(
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.updated),
+            payload =
+                RelationshipPayload(
+                    id = "knows1",
+                    label = "KNOWS",
+                    start = RelationshipNodeChange("person1", listOf("Person"), emptyMap()),
+                    end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
+                    before =
+                        RelationshipChange(
+                            mapOf(
+                                "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                                "type" to "friend",
+                            ),
+                        ),
+                    after =
+                        RelationshipChange(
+                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and relationship should not be updated
+    val result = session.run("MATCH (start)-[r:KNOWS]->(end) RETURN start, r, end").single()
+
+    result.get("r").asRelationship() should
+        {
+          it.asMap() shouldBe
+              mapOf(
+                  "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                  "type" to "friend",
+              )
+        }
+    result.get("start").asNode() should
+        {
+          it.labels() shouldBe listOf("Person")
+          it.asMap() shouldBe mapOf("id" to 1L, "name" to "john", "surname" to "doe")
+        }
+    result.get("end").asNode() should
+        {
+          it.labels() shouldBe listOf("Person")
+          it.asMap() shouldBe mapOf("id" to 2L, "name" to "mary", "surname" to "doe")
+        }
+  }
+
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
+  fun `should fail to update a relationship when end node keys is empty`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+    session
+        .run(
+            """
+            CREATE (n1:Person) SET n1 = ${'$'}person1
+            CREATE (n2:Person) SET n2 = ${'$'}person2
+            CREATE (n1)-[r:KNOWS]->(n2) SET r = ${'$'}knows
+            """,
+            mapOf(
+                "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+                "knows" to
+                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend"),
+            ),
+        )
+        .consume()
+
+    producer.publish(
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.updated),
+            payload =
+                RelationshipPayload(
+                    id = "knows1",
+                    label = "KNOWS",
+                    start = RelationshipNodeChange("person1", listOf("Person"), mapOf("id" to 1L)),
+                    end = RelationshipNodeChange("person2", listOf("Person"), emptyMap()),
+                    before =
+                        RelationshipChange(
+                            mapOf(
+                                "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                                "type" to "friend",
+                            ),
+                        ),
+                    after =
+                        RelationshipChange(
+                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and relationship should not be updated
+    eventually(30.seconds) {
+      val result = session.run("MATCH (start)-[r:KNOWS]->(end) RETURN start, r, end").single()
+
+      result.get("r").asRelationship() should
+          {
+            it.asMap() shouldBe
+                mapOf(
+                    "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                    "type" to "friend",
+                )
           }
       result.get("start").asNode() should
           {
@@ -573,7 +973,9 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                 "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
                 "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
                 "knows" to
-                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend")))
+                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -589,9 +991,14 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         RelationshipChange(
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
-                                "type" to "friend")),
-                    after = null),
-            schema = Schema()))
+                                "type" to "friend",
+                            ),
+                        ),
+                    after = null,
+                ),
+            schema = Schema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result = session.run("MATCH ()-[r:KNOWS]->() RETURN count(r)").single()
@@ -600,10 +1007,125 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
     }
   }
 
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
+  fun `should fail to delete a relationship when start node keys is empty`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+    session
+        .run(
+            """
+            CREATE (n1:Person) SET n1 = ${'$'}person1
+            CREATE (n2:Person) SET n2 = ${'$'}person2
+            CREATE (n1)-[r:KNOWS]->(n2) SET r = ${'$'}knows
+            """,
+            mapOf(
+                "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+                "knows" to
+                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend"),
+            ),
+        )
+        .consume()
+
+    producer.publish(
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.deleted),
+            payload =
+                RelationshipPayload(
+                    id = "knows1",
+                    label = "KNOWS",
+                    start = RelationshipNodeChange("person1", listOf("Person"), emptyMap()),
+                    end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
+                    before =
+                        RelationshipChange(
+                            mapOf(
+                                "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                                "type" to "friend",
+                            ),
+                        ),
+                    after = null,
+                ),
+            schema = Schema(),
+        ),
+    )
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and relationship should not be deleted
+    val result = session.run("MATCH ()-[r:KNOWS]->() RETURN count(r)").single()
+    result.get(0).asInt() shouldBe 1
+  }
+
+  @Neo4jSink(cdcSchema = [CdcSchemaStrategy(TOPIC)])
+  @Test
+  fun `should fail to delete a relationship when end node keys is empty`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+      sink: Neo4jSinkRegistration,
+  ) = runTest {
+    session
+        .run(
+            """
+            CREATE (n1:Person) SET n1 = ${'$'}person1
+            CREATE (n2:Person) SET n2 = ${'$'}person2
+            CREATE (n1)-[r:KNOWS]->(n2) SET r = ${'$'}knows
+            """,
+            mapOf(
+                "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
+                "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
+                "knows" to
+                    mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend"),
+            ),
+        )
+        .consume()
+
+    producer.publish(
+        StreamsTransactionEvent(
+            meta = newMetadata(operation = OperationType.deleted),
+            payload =
+                RelationshipPayload(
+                    id = "knows1",
+                    label = "KNOWS",
+                    start = RelationshipNodeChange("person1", listOf("Person"), mapOf("id" to 1L)),
+                    end = RelationshipNodeChange("person2", listOf("Person"), emptyMap()),
+                    before =
+                        RelationshipChange(
+                            mapOf(
+                                "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
+                                "type" to "friend",
+                            ),
+                        ),
+                    after = null,
+                ),
+            schema = Schema(),
+        ),
+    )
+
+    // sink connector should transition into FAILED state
+    eventually(30.seconds) {
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
+    }
+
+    // and relationship should not be deleted
+    val result = session.run("MATCH ()-[r:KNOWS]->() RETURN count(r)").single()
+    result.get(0).asInt() shouldBe 1
+  }
+
   @Neo4jSink(
       schemaControlKeyCompatibility = SchemaCompatibilityMode.NONE,
       schemaControlValueCompatibility = SchemaCompatibilityMode.NONE,
-      cdcSchema = [CdcSchemaStrategy(TOPIC)])
+      cdcSchema = [CdcSchemaStrategy(TOPIC)],
+  )
   @Test
   fun `should sync continuous changes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
@@ -613,7 +1135,11 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 1, txEventId = 0, txEventsCount = 1, operation = OperationType.created),
+                    txId = 1,
+                    txEventId = 0,
+                    txEventsCount = 1,
+                    operation = OperationType.created,
+                ),
             payload =
                 NodePayload(
                     id = "person1",
@@ -621,14 +1147,22 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after =
                         NodeChange(
                             properties = mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
-                            labels = listOf("Person"))),
-            schema = defaultSchema()))
+                            labels = listOf("Person"),
+                        ),
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     producer.publish(
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 2, txEventId = 0, txEventsCount = 1, operation = OperationType.created),
+                    txId = 2,
+                    txEventId = 0,
+                    txEventsCount = 1,
+                    operation = OperationType.created,
+                ),
             payload =
                 NodePayload(
                     id = "person2",
@@ -636,14 +1170,22 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after =
                         NodeChange(
                             properties = mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
-                            labels = listOf("Person"))),
-            schema = defaultSchema()))
+                            labels = listOf("Person"),
+                        ),
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     producer.publish(
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 3, txEventId = 0, txEventsCount = 1, operation = OperationType.created),
+                    txId = 3,
+                    txEventId = 0,
+                    txEventsCount = 1,
+                    operation = OperationType.created,
+                ),
             payload =
                 RelationshipPayload(
                     id = "knows1",
@@ -651,8 +1193,11 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     start = RelationshipNodeChange("person1", listOf("Person"), mapOf("id" to 1L)),
                     end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
                     before = null,
-                    after = RelationshipChange(emptyMap())),
-            schema = Schema()))
+                    after = RelationshipChange(emptyMap()),
+                ),
+            schema = Schema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -664,7 +1209,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
             MATCH (start)-[r:KNOWS]->(end)
             RETURN start, r, end
           """,
-                  mapOf("startId" to 1L, "endId" to 2L))
+                  mapOf("startId" to 1L, "endId" to 2L),
+              )
               .single()
 
       result.get("r").asRelationship() should { it.asMap() shouldBe emptyMap() }
@@ -684,7 +1230,11 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 4, txEventId = 0, txEventsCount = 1, operation = OperationType.updated),
+                    txId = 4,
+                    txEventId = 0,
+                    txEventsCount = 1,
+                    operation = OperationType.updated,
+                ),
             payload =
                 RelationshipPayload(
                     id = "knows1",
@@ -694,8 +1244,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     before = RelationshipChange(emptyMap()),
                     after =
                         RelationshipChange(
-                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()))),
-            schema = Schema()))
+                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
+                        ),
+                ),
+            schema = Schema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -707,7 +1261,8 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
             MATCH (start)-[r:KNOWS]->(end)
             RETURN r
           """,
-                  mapOf("startId" to 1L, "endId" to 2L))
+                  mapOf("startId" to 1L, "endId" to 2L),
+              )
               .single()
 
       result.get("r").asRelationship() should
@@ -720,7 +1275,11 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 5, txEventId = 0, txEventsCount = 3, operation = OperationType.deleted),
+                    txId = 5,
+                    txEventId = 0,
+                    txEventsCount = 3,
+                    operation = OperationType.deleted,
+                ),
             payload =
                 RelationshipPayload(
                     id = "knows1",
@@ -729,38 +1288,57 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
                     before =
                         RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay())),
-                    after = null),
-            schema = Schema()))
+                    after = null,
+                ),
+            schema = Schema(),
+        ),
+    )
 
     producer.publish(
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 5, txEventId = 1, txEventsCount = 3, operation = OperationType.deleted),
+                    txId = 5,
+                    txEventId = 1,
+                    txEventsCount = 3,
+                    operation = OperationType.deleted,
+                ),
             payload =
                 NodePayload(
                     id = "person1",
                     before =
                         NodeChange(
                             properties = mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
-                            labels = listOf("Person")),
-                    after = null),
-            schema = defaultSchema()))
+                            labels = listOf("Person"),
+                        ),
+                    after = null,
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     producer.publish(
         StreamsTransactionEvent(
             meta =
                 newMetadata(
-                    txId = 5, txEventId = 2, txEventsCount = 3, operation = OperationType.deleted),
+                    txId = 5,
+                    txEventId = 2,
+                    txEventsCount = 3,
+                    operation = OperationType.deleted,
+                ),
             payload =
                 NodePayload(
                     id = "person2",
                     before =
                         NodeChange(
                             properties = mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
-                            labels = listOf("Person")),
-                    after = null),
-            schema = defaultSchema()))
+                            labels = listOf("Person"),
+                        ),
+                    after = null,
+                ),
+            schema = defaultSchema(),
+        ),
+    )
 
     eventually(30.seconds) {
       val result = session.run("MATCH (n) RETURN count(n)").single()
@@ -786,5 +1364,6 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
           txId = txId,
           txEventId = txEventId,
           txEventsCount = txEventsCount,
-          operation = operation)
+          operation = operation,
+      )
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandler.kt
@@ -37,7 +37,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     val node = buildNode(event.keys, "n")
     val stmt =
-        Cypher.merge(node)
+        Cypher.create(node)
             .set(node, Cypher.parameter("nProps", event.after.properties))
             .let {
               val labels = event.after.labels.minus(event.keys.keys)
@@ -62,7 +62,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     val node = buildNode(event.keys, "n")
     val stmt =
-        Cypher.merge(node)
+        Cypher.match(node)
             .mutate(node, Cypher.parameter("nProps", event.mutatedProperties()))
             .let {
               val addedLabels = event.addedLabels()
@@ -97,11 +97,11 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
       throw InvalidDataException("create operation requires 'after' field in the event object")
     }
 
-    val (start, end, rel) = buildRelationship(event, "r")
+    val (start, end, rel) = buildRelationship(event, "r", true)
     val stmt =
-        Cypher.merge(start)
-            .merge(end)
-            .merge(rel)
+        Cypher.match(start)
+            .match(end)
+            .create(rel)
             .set(rel, Cypher.parameter("rProps", event.after.properties))
             .build()
 
@@ -116,11 +116,9 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
       throw InvalidDataException("update operation requires 'after' field in the event object")
     }
 
-    val (start, end, rel) = buildRelationship(event, "r")
+    val (start, end, rel, matchNodes) = buildRelationship(event, "r", false)
     val stmt =
-        Cypher.merge(start)
-            .merge(end)
-            .merge(rel)
+        (if (matchNodes) Cypher.match(start).match(end).match(rel) else Cypher.match(rel))
             .mutate(rel, Cypher.parameter("rProps", event.mutatedProperties()))
             .build()
 
@@ -128,17 +126,28 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
   }
 
   override fun transformDelete(event: RelationshipEvent): Query {
-    val (start, end, rel) = buildRelationship(event, "r")
-    val stmt = Cypher.match(start).match(end).match(rel).delete(rel).build()
+    val (start, end, rel, matchNodes) = buildRelationship(event, "r", false)
+    val stmt =
+        (if (matchNodes) Cypher.match(start).match(end).match(rel) else Cypher.match(rel))
+            .delete(rel)
+            .build()
 
     return Query(renderer.render(stmt), stmt.parameters)
   }
 
-  private fun buildNode(keys: Map<String, List<Map<String, Any>>>, named: String): Node {
-    val validKeys = keys.filterValues { it.isNotEmpty() }
+  private fun buildNode(
+      keys: Map<String, List<Map<String, Any>>>,
+      named: String,
+  ): Node {
+    val validKeys =
+        keys
+            .mapValues { kvp -> kvp.value.filter { it.isNotEmpty() } }
+            .filterValues { it.isNotEmpty() }
 
-    require(validKeys.isNotEmpty()) {
-      "schema strategy requires at least one node key with valid properties aliased '$named'."
+    if (validKeys.isEmpty()) {
+      throw InvalidDataException(
+          "schema strategy requires at least one node key with valid properties on node aliased '$named'.",
+      )
     }
 
     val node =
@@ -153,20 +162,47 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
                           e.key,
                           Cypher.parameter(
                               "${named}${e.key.replaceFirstChar { c -> c.uppercaseChar() }}",
-                              e.value))
+                              e.value,
+                          ),
+                      )
                     },
             )
             .named(named)
+
     return node
   }
+
+  data class RelationshipOutput(
+      val start: Node,
+      val end: Node,
+      val relationship: Relationship,
+      val matchNodes: Boolean
+  )
 
   @Suppress("SameParameterValue")
   private fun buildRelationship(
       event: RelationshipEvent,
-      named: String
-  ): Triple<Node, Node, Relationship> {
-    val start = buildNode(event.start.keys, "start")
-    val end = buildNode(event.end.keys, "end")
+      named: String,
+      forCreate: Boolean
+  ): RelationshipOutput {
+    val relationshipHasKeys = event.keys.filter { it.isNotEmpty() }.any()
+
+    // if this is a create event, we enforce start and end key properties
+    // else we check whether relationship has its own keys or not
+    val start =
+        if (!forCreate && relationshipHasKeys) Cypher.anyNode("start")
+        else
+            buildNode(
+                event.start.keys,
+                "start",
+            )
+    val end =
+        if (!forCreate && relationshipHasKeys) Cypher.anyNode("end")
+        else
+            buildNode(
+                event.end.keys,
+                "end",
+            )
     val rel =
         start
             .relationshipTo(end, event.type)
@@ -179,10 +215,13 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
                           e.key,
                           Cypher.parameter(
                               "${named}${e.key.replaceFirstChar { c -> c.uppercaseChar() }}",
-                              e.value))
+                              e.value,
+                          ),
+                      )
                     },
             )
             .named(named)
-    return Triple(start, end, rel)
+
+    return RelationshipOutput(start, end, rel, forCreate || !relationshipHasKeys)
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandler.kt
@@ -37,7 +37,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     val node = buildNode(event.keys, "n")
     val stmt =
-        Cypher.create(node)
+        Cypher.merge(node)
             .set(node, Cypher.parameter("nProps", event.after.properties))
             .let {
               val labels = event.after.labels.minus(event.keys.keys)
@@ -62,7 +62,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     val node = buildNode(event.keys, "n")
     val stmt =
-        Cypher.match(node)
+        Cypher.merge(node)
             .mutate(node, Cypher.parameter("nProps", event.mutatedProperties()))
             .let {
               val addedLabels = event.addedLabels()
@@ -99,9 +99,9 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     val (start, end, rel) = buildRelationship(event, "r", true)
     val stmt =
-        Cypher.match(start)
-            .match(end)
-            .create(rel)
+        Cypher.merge(start)
+            .merge(end)
+            .merge(rel)
             .set(rel, Cypher.parameter("rProps", event.after.properties))
             .build()
 
@@ -118,7 +118,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     val (start, end, rel, matchNodes) = buildRelationship(event, "r", false)
     val stmt =
-        (if (matchNodes) Cypher.match(start).match(end).match(rel) else Cypher.match(rel))
+        (if (matchNodes) Cypher.merge(start).merge(end).merge(rel) else Cypher.match(rel))
             .mutate(rel, Cypher.parameter("rProps", event.mutatedProperties()))
             .build()
 

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandlerTest.kt
@@ -30,11 +30,14 @@ import org.neo4j.cdc.client.model.NodeEvent
 import org.neo4j.cdc.client.model.NodeState
 import org.neo4j.cdc.client.model.RelationshipEvent
 import org.neo4j.cdc.client.model.RelationshipState
+import org.neo4j.connectors.kafka.data.StreamsTransactionEventExtensions.toChangeEvent
+import org.neo4j.connectors.kafka.events.StreamsTransactionEvent
 import org.neo4j.connectors.kafka.exceptions.InvalidDataException
 import org.neo4j.connectors.kafka.sink.ChangeQuery
 import org.neo4j.connectors.kafka.sink.SinkMessage
 import org.neo4j.connectors.kafka.sink.strategy.TestUtils.newChangeEventMessage
 import org.neo4j.connectors.kafka.sink.strategy.TestUtils.randomChangeEvent
+import org.neo4j.connectors.kafka.utils.JSONUtils
 import org.neo4j.cypherdsl.core.renderer.Configuration
 import org.neo4j.cypherdsl.core.renderer.Renderer
 import org.neo4j.driver.Query
@@ -51,9 +54,11 @@ class CdcSchemaHandlerTest {
                     emptyList(),
                     emptyMap(),
                     null,
-                    NodeState(emptyList(), mapOf("name" to "john", "surname" to "doe"))),
+                    NodeState(emptyList(), mapOf("name" to "john", "surname" to "doe")),
+                ),
                 1,
-                0),
+                0,
+            ),
             newChangeEventMessage(
                 RelationshipEvent(
                     "rel-element-id",
@@ -63,9 +68,11 @@ class CdcSchemaHandlerTest {
                     emptyList(),
                     EntityOperation.CREATE,
                     null,
-                    RelationshipState(emptyMap())),
+                    RelationshipState(emptyMap()),
+                ),
                 1,
-                0),
+                0,
+            ),
             newChangeEventMessage(
                 RelationshipEvent(
                     "rel-element-id",
@@ -73,14 +80,17 @@ class CdcSchemaHandlerTest {
                     Node(
                         "start-element-id",
                         listOf("Person"),
-                        mapOf("Person" to listOf(mapOf("id" to 5L)))),
+                        mapOf("Person" to listOf(mapOf("id" to 5L))),
+                    ),
                     Node("end-element-id", listOf("Person"), emptyMap()),
                     emptyList(),
                     EntityOperation.CREATE,
                     null,
-                    RelationshipState(emptyMap())),
+                    RelationshipState(emptyMap()),
+                ),
                 1,
-                0),
+                0,
+            ),
             newChangeEventMessage(
                 RelationshipEvent(
                     "rel-element-id",
@@ -89,25 +99,32 @@ class CdcSchemaHandlerTest {
                     Node(
                         "end-element-id",
                         listOf("Person"),
-                        mapOf("Person" to listOf(mapOf("id" to 5L)))),
+                        mapOf("Person" to listOf(mapOf("id" to 5L))),
+                    ),
                     emptyList(),
                     EntityOperation.CREATE,
                     null,
-                    RelationshipState(emptyMap())),
+                    RelationshipState(emptyMap()),
+                ),
                 1,
-                0))
+                0,
+            ),
+        )
         .forEach {
-          shouldThrow<IllegalArgumentException> {
+          shouldThrow<InvalidDataException> {
                 val handler =
                     CdcSchemaHandler(
-                        "my-topic", Renderer.getRenderer(Configuration.defaultConfig()))
+                        "my-topic",
+                        Renderer.getRenderer(Configuration.defaultConfig()),
+                    )
 
                 handler.handle(listOf(it))
               }
               .also {
                 it shouldHaveMessage
                     Regex(
-                        "^schema strategy requires at least one node key with valid properties aliased.*$")
+                        "^schema strategy requires at least one node key with valid properties on node aliased '(n|start|end)'.$",
+                    )
               }
         }
   }
@@ -125,9 +142,15 @@ class CdcSchemaHandlerTest {
                 NodeState(
                     listOf("Person"),
                     mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                        "name" to "john",
+                        "surname" to "doe",
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -137,7 +160,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps",
+                        "CREATE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -145,7 +168,14 @@ class CdcSchemaHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "surname" to "doe",
-                                    "dob" to LocalDate.of(1990, 1, 1))))))))
+                                    "dob" to LocalDate.of(1990, 1, 1),
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -158,9 +188,15 @@ class CdcSchemaHandlerTest {
                 NodeState(
                     listOf("Person", "Employee"),
                     mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                        "name" to "john",
+                        "surname" to "doe",
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -170,7 +206,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage1),
                     Query(
-                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps SET n:`Employee`",
+                        "CREATE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps SET n:`Employee`",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -178,7 +214,14 @@ class CdcSchemaHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "surname" to "doe",
-                                    "dob" to LocalDate.of(1990, 1, 1))))))))
+                                    "dob" to LocalDate.of(1990, 1, 1),
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -194,9 +237,15 @@ class CdcSchemaHandlerTest {
                 NodeState(
                     listOf("Person", "Employee"),
                     mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                        "name" to "john",
+                        "surname" to "doe",
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -206,12 +255,17 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps",
+                        "MATCH (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
-                            "nProps" to
-                                mapOf("name" to "john", "dob" to LocalDate.of(1990, 1, 1))))))))
+                            "nProps" to mapOf("name" to "john", "dob" to LocalDate.of(1990, 1, 1)),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -222,13 +276,20 @@ class CdcSchemaHandlerTest {
                 mapOf("Person" to listOf(mapOf("name" to "john", "surname" to "doe"))),
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf("name" to "joe", "surname" to "doe", "married" to true)),
+                    mapOf("name" to "joe", "surname" to "doe", "married" to true),
+                ),
                 NodeState(
                     listOf("Person", "Manager"),
                     mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                        "name" to "john",
+                        "surname" to "doe",
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -238,7 +299,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage1),
                     Query(
-                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
+                        "MATCH (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -246,7 +307,14 @@ class CdcSchemaHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "dob" to LocalDate.of(1990, 1, 1),
-                                    "married" to null)))))))
+                                    "married" to null,
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
 
     val sinkMessage2 =
         newChangeEventMessage(
@@ -256,16 +324,24 @@ class CdcSchemaHandlerTest {
                 listOf("Person", "Employee"),
                 mapOf(
                     "Person" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Employee" to listOf(mapOf("id" to 5000L))),
+                    "Employee" to listOf(mapOf("id" to 5000L)),
+                ),
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf("name" to "joe", "surname" to "doe", "married" to true)),
+                    mapOf("name" to "joe", "surname" to "doe", "married" to true),
+                ),
                 NodeState(
                     listOf("Person", "Manager"),
                     mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                        "name" to "john",
+                        "surname" to "doe",
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage2),
         listOf(
@@ -275,7 +351,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage2),
                     Query(
-                        "MERGE (n:`Person`:`Employee` {name: ${'$'}nName, surname: ${'$'}nSurname, id: ${'$'}nId}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
+                        "MATCH (n:`Person`:`Employee` {name: ${'$'}nName, surname: ${'$'}nSurname, id: ${'$'}nId}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
                         mapOf(
                             "nId" to 5000L,
                             "nName" to "john",
@@ -284,7 +360,14 @@ class CdcSchemaHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "dob" to LocalDate.of(1990, 1, 1),
-                                    "married" to null)))))))
+                                    "married" to null,
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -298,10 +381,13 @@ class CdcSchemaHandlerTest {
                 mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe"))),
                 NodeState(
                     emptyList(),
-                    mapOf("name" to "joe", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1))),
-                null),
+                    mapOf("name" to "joe", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1)),
+                ),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -312,7 +398,12 @@ class CdcSchemaHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MATCH (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) DETACH DELETE n",
-                        mapOf("nName" to "joe", "nSurname" to "doe"))))))
+                        mapOf("nName" to "joe", "nSurname" to "doe"),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -325,17 +416,21 @@ class CdcSchemaHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1)))),
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -345,14 +440,20 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MERGE (start:`Person` {id: ${'$'}startId}) " +
-                            "MERGE (end:`Person` {id: ${'$'}endId}) " +
-                            "MERGE (start)-[r:`KNOWS` {}]->(end) " +
+                        "MATCH (start:`Person` {id: ${'$'}startId}) " +
+                            "MATCH (end:`Person` {id: ${'$'}endId}) " +
+                            "CREATE (start)-[r:`KNOWS` {}]->(end) " +
                             "SET r = ${'$'}rProps",
                         mapOf(
                             "startId" to 1L,
                             "endId" to 2L,
-                            "rProps" to mapOf("since" to LocalDate.of(2000, 1, 1))))))))
+                            "rProps" to mapOf("since" to LocalDate.of(2000, 1, 1)),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -367,19 +468,25 @@ class CdcSchemaHandlerTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to listOf(mapOf("id" to 1L)),
-                        "Employee" to listOf(mapOf("contractId" to 5000L)))),
+                        "Employee" to listOf(mapOf("contractId" to 5000L)),
+                    ),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to listOf(mapOf("id" to 2L)),
-                        "Employee" to listOf(mapOf("contractId" to 5001L)))),
+                        "Employee" to listOf(mapOf("contractId" to 5001L)),
+                    ),
+                ),
                 emptyList(),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
-                RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1)))),
+                RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -389,16 +496,22 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MERGE (start:`Person`:`Employee` {id: ${'$'}startId, contractId: ${'$'}startContractId}) " +
-                            "MERGE (end:`Person`:`Employee` {id: ${'$'}endId, contractId: ${'$'}endContractId}) " +
-                            "MERGE (start)-[r:`KNOWS` {}]->(end) " +
+                        "MATCH (start:`Person`:`Employee` {id: ${'$'}startId, contractId: ${'$'}startContractId}) " +
+                            "MATCH (end:`Person`:`Employee` {id: ${'$'}endId, contractId: ${'$'}endContractId}) " +
+                            "MATCH (start)-[r:`KNOWS` {}]->(end) " +
                             "SET r += ${'$'}rProps",
                         mapOf(
                             "startId" to 1L,
                             "startContractId" to 5000L,
                             "endId" to 2L,
                             "endContractId" to 5001L,
-                            "rProps" to mapOf("since" to LocalDate.of(1999, 1, 1))))))))
+                            "rProps" to mapOf("since" to LocalDate.of(1999, 1, 1)),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -410,17 +523,22 @@ class CdcSchemaHandlerTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to listOf(mapOf("id" to 1L)),
-                        "Employee" to listOf(mapOf("contractId" to 5000L)))),
+                        "Employee" to listOf(mapOf("contractId" to 5000L)),
+                    ),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 listOf(mapOf("id" to 1001L)),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("name" to "john", "surname" to "doe")),
-                RelationshipState(mapOf("name" to "joe", "surname" to "doe"))),
+                RelationshipState(mapOf("name" to "joe", "surname" to "doe")),
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -430,16 +548,17 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage1),
                     Query(
-                        "MERGE (start:`Person`:`Employee` {id: ${'$'}startId, contractId: ${'$'}startContractId}) " +
-                            "MERGE (end:`Person` {id: ${'$'}endId}) " +
-                            "MERGE (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
+                        "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
                             "SET r += ${'$'}rProps",
                         mapOf(
-                            "startId" to 1L,
-                            "startContractId" to 5000L,
-                            "endId" to 2L,
                             "rId" to 1001L,
-                            "rProps" to mapOf("name" to "joe")))))))
+                            "rProps" to mapOf("name" to "joe"),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -452,17 +571,21 @@ class CdcSchemaHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.DELETE,
                 RelationshipState(mapOf("name" to "john", "surname" to "doe")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -476,7 +599,12 @@ class CdcSchemaHandlerTest {
                             "MATCH (end:`Person` {id: ${'$'}endId}) " +
                             "MATCH (start)-[r:`KNOWS` {}]->(end) " +
                             "DELETE r",
-                        mapOf("startId" to 1L, "endId" to 2L))))))
+                        mapOf("startId" to 1L, "endId" to 2L),
+                    ),
+                ),
+            ),
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -488,17 +616,22 @@ class CdcSchemaHandlerTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to listOf(mapOf("id" to 1L)),
-                        "Employee" to listOf(mapOf("contractId" to 5000L)))),
+                        "Employee" to listOf(mapOf("contractId" to 5000L)),
+                    ),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 listOf(mapOf("id" to 1001L)),
                 EntityOperation.DELETE,
                 RelationshipState(mapOf("name" to "john", "surname" to "doe")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -508,15 +641,15 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage1),
                     Query(
-                        "MATCH (start:`Person`:`Employee` {id: ${'$'}startId, contractId: ${'$'}startContractId}) " +
-                            "MATCH (end:`Person` {id: ${'$'}endId}) " +
-                            "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
-                            "DELETE r",
+                        "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " + "DELETE r",
                         mapOf(
-                            "startId" to 1L,
-                            "startContractId" to 5000L,
-                            "endId" to 2L,
-                            "rId" to 1001L))))))
+                            "rId" to 1001L,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -531,7 +664,9 @@ class CdcSchemaHandlerTest {
                 newChangeEventMessage(randomChangeEvent(), 0, 2),
                 newChangeEventMessage(randomChangeEvent(), 1, 0),
                 newChangeEventMessage(randomChangeEvent(), 1, 1),
-                newChangeEventMessage(randomChangeEvent(), 2, 0)))
+                newChangeEventMessage(randomChangeEvent(), 2, 0),
+            ),
+        )
 
     result
         .shouldHaveSize(3)
@@ -551,7 +686,8 @@ class CdcSchemaHandlerTest {
                       { q3 ->
                         q3.txId shouldBe 0
                         q3.seq shouldBe 2
-                      })
+                      },
+                  )
             },
             { second ->
               second
@@ -564,16 +700,20 @@ class CdcSchemaHandlerTest {
                       { q2 ->
                         q2.txId shouldBe 1
                         q2.seq shouldBe 1
-                      })
+                      },
+                  )
             },
             { third ->
               third
                   .shouldHaveSize(1)
-                  .shouldMatchInOrder({ q1 ->
-                    q1.txId shouldBe 2
-                    q1.seq shouldBe 0
-                  })
-            })
+                  .shouldMatchInOrder(
+                      { q1 ->
+                        q1.txId shouldBe 2
+                        q1.seq shouldBe 0
+                      },
+                  )
+            },
+        )
   }
 
   @Test
@@ -588,9 +728,11 @@ class CdcSchemaHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(nodeChangeEventMessage))
@@ -609,17 +751,21 @@ class CdcSchemaHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.CREATE,
                 null,
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(relationshipChangeEventMessage))
@@ -639,9 +785,13 @@ class CdcSchemaHandlerTest {
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
                 NodeState(
-                    listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe"))),
+                    listOf("Person", "Employee"),
+                    mapOf("name" to "joe", "surname" to "doe"),
+                ),
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(nodeChangeEventMessage))
@@ -660,17 +810,21 @@ class CdcSchemaHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.UPDATE,
                 null,
-                RelationshipState(mapOf("name" to "john", "surname" to "doe"))),
+                RelationshipState(mapOf("name" to "john", "surname" to "doe")),
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(relationshipChangeEventMessage))
@@ -689,9 +843,11 @@ class CdcSchemaHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 NodeState(listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(nodeChangeEventMessage))
@@ -710,17 +866,21 @@ class CdcSchemaHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("name" to "john", "surname" to "doe")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(relationshipChangeEventMessage))
@@ -737,9 +897,11 @@ class CdcSchemaHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("name" to "john"), mapOf("invalid" to null))),
                 NodeState(emptyList(), mapOf("name" to "john")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -750,7 +912,12 @@ class CdcSchemaHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MATCH (n:`Person` {name: ${'$'}nName}) DETACH DELETE n",
-                        mapOf("nName" to "john"))))))
+                        mapOf("nName" to "john"),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
@@ -768,9 +935,12 @@ class CdcSchemaHandlerTest {
                         listOf("Person"),
                         mapOf(
                             "name" to "john",
-                        ))),
+                        ),
+                    ),
+                ),
             txId = 1,
-            seq = 0)
+            seq = 0,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -780,17 +950,23 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MERGE (n:`Person` {name: ${'$'}nName}) SET n = ${'$'}nProps",
+                        "CREATE (n:`Person` {name: ${'$'}nName}) SET n = ${'$'}nProps",
                         mapOf(
                             "nName" to "john",
                             "nProps" to
                                 mapOf(
                                     "name" to "john",
-                                )))))))
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
   }
 
   @Test
-  fun `should fail to generate query when no keys properties are provided`() {
+  fun `should fail when node keys is empty`() {
     // given a sink message which contains a key with no properties
     val sinkMessage =
         newChangeEventMessage(
@@ -800,13 +976,773 @@ class CdcSchemaHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to emptyList()),
                 NodeState(emptyList(), mapOf("name" to "john")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
-    // when the key is handled
-    // then an exception is thrown
-    shouldThrow<IllegalArgumentException> {
+    assertInvalidDataException(sinkMessage, "n")
+  }
+
+  @Test
+  fun `should fail when relationship start keys is empty for create even if relationship has keys`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                listOf(mapOf("id" to 1L)),
+                EntityOperation.CREATE,
+                null,
+                RelationshipState(mapOf("id" to 1L, "since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is empty for create even if relationship has keys`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList()),
+                ),
+                listOf(mapOf("id" to 1L)),
+                EntityOperation.CREATE,
+                null,
+                RelationshipState(mapOf("id" to 1L, "since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should fail when relationship start keys is empty for create`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                emptyList(),
+                EntityOperation.CREATE,
+                null,
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship start keys is effectively empty for create`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList<Map<String, Any>>()),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                emptyList(),
+                EntityOperation.CREATE,
+                null,
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is empty for create`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                emptyList(),
+                EntityOperation.CREATE,
+                null,
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is effectively empty for create`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList<Map<String, Any>>()),
+                ),
+                emptyList(),
+                EntityOperation.CREATE,
+                null,
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should generate correct statement when relationship start keys is empty but relationship has its own keys for update`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                listOf(mapOf("id" to 1L)),
+                EntityOperation.UPDATE,
+                RelationshipState(mapOf("id" to 1L)),
+                RelationshipState(mapOf("id" to 1L, "since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    verify(
+        listOf(sinkMessage),
+        listOf(
+            listOf(
+                ChangeQuery(
+                    1,
+                    0,
+                    listOf(sinkMessage),
+                    Query(
+                        "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
+                            "SET r += ${'$'}rProps",
+                        mapOf(
+                            "rId" to 1L,
+                            "rProps" to
+                                mapOf(
+                                    "since" to LocalDate.of(2000, 1, 1),
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+  }
+
+  @Test
+  fun `should generate correct statement when relationship end keys is empty but relationship has its own keys for update`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                listOf(mapOf("id" to 1L)),
+                EntityOperation.UPDATE,
+                RelationshipState(mapOf("id" to 1L)),
+                RelationshipState(mapOf("id" to 1L, "since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    verify(
+        listOf(sinkMessage),
+        listOf(
+            listOf(
+                ChangeQuery(
+                    1,
+                    0,
+                    listOf(sinkMessage),
+                    Query(
+                        "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
+                            "SET r += ${'$'}rProps",
+                        mapOf(
+                            "rId" to 1L,
+                            "rProps" to
+                                mapOf(
+                                    "since" to LocalDate.of(2000, 1, 1),
+                                ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+  }
+
+  @Test
+  fun `should fail when relationship start keys is empty for update`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                emptyList(),
+                EntityOperation.UPDATE,
+                RelationshipState(emptyMap<String, Any>()),
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship start keys is effectively empty for update`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList<Map<String, Any>>()),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                emptyList(),
+                EntityOperation.UPDATE,
+                RelationshipState(emptyMap<String, Any>()),
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is empty for update`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                emptyList(),
+                EntityOperation.UPDATE,
+                RelationshipState(emptyMap<String, Any>()),
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is effectively empty for update`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList<Map<String, Any>>()),
+                ),
+                emptyList(),
+                EntityOperation.UPDATE,
+                RelationshipState(emptyMap<String, Any>()),
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should generate correct statement when relationship start keys is empty but relationship has its own keys for deletion`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                listOf(mapOf("id" to 1L)),
+                EntityOperation.DELETE,
+                RelationshipState(mapOf("id" to 1L)),
+                null,
+            ),
+            1,
+            0,
+        )
+
+    verify(
+        listOf(sinkMessage),
+        listOf(
+            listOf(
+                ChangeQuery(
+                    1,
+                    0,
+                    listOf(sinkMessage),
+                    Query(
+                        "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " + "DELETE r",
+                        mapOf(
+                            "rId" to 1L,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+  }
+
+  @Test
+  fun `should generate correct statement when relationship end keys is empty but relationship has its own keys for deletion`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                listOf(mapOf("id" to 1L)),
+                EntityOperation.DELETE,
+                RelationshipState(mapOf("id" to 1L)),
+                null,
+            ),
+            1,
+            0,
+        )
+
+    verify(
+        listOf(sinkMessage),
+        listOf(
+            listOf(
+                ChangeQuery(
+                    1,
+                    0,
+                    listOf(sinkMessage),
+                    Query(
+                        "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " + "DELETE r",
+                        mapOf(
+                            "rId" to 1L,
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+  }
+
+  @Test
+  fun `should fail when relationship start keys is empty for deletion`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                emptyList(),
+                EntityOperation.DELETE,
+                RelationshipState(emptyMap<String, Any>()),
+                null,
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship start keys is effectively empty for deletion`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList<Map<String, Any>>()),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                emptyList(),
+                EntityOperation.DELETE,
+                RelationshipState(emptyMap<String, Any>()),
+                null,
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is empty for deletion`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    emptyMap<String, List<Map<String, Any>>>(),
+                ),
+                emptyList(),
+                EntityOperation.DELETE,
+                RelationshipState(emptyMap<String, Any>()),
+                null,
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should fail when relationship end keys is effectively empty for deletion`() {
+    val sinkMessage =
+        newChangeEventMessage(
+            RelationshipEvent(
+                "rel-element-id",
+                "KNOWS",
+                Node(
+                    "start-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
+                Node(
+                    "end-element-id",
+                    listOf("Person"),
+                    mapOf("Person" to emptyList<Map<String, Any>>()),
+                ),
+                emptyList(),
+                EntityOperation.DELETE,
+                RelationshipState(emptyMap<String, Any>()),
+                null,
+            ),
+            1,
+            0,
+        )
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  @Test
+  fun `should fail when streams node keys is empty`() {
+    val streamsMessage =
+        """
+      {
+        "meta": {
+          "timestamp": 1728643218066,
+          "username": "neo4j",
+          "txId": 18,
+          "txEventId": 0,
+          "txEventsCount": 1,
+          "operation": "deleted",
+          "source": {
+            "hostname": "neo4j03"
+          }
+        },
+        "payload": {
+          "id": "0",
+          "before": {
+            "properties": {
+              "first_name": "Ali",
+              "last_name": "Ince",
+              "id": 1
+            },
+            "labels": [
+              "Person"
+            ]
+          },
+          "after": null,
+          "type": "node"
+        },
+        "schema": {
+          "properties": {
+            "first_name": "String",
+            "last_name": "String",
+            "id": "Long"
+          },
+          "constraints": []
+        }
+      }
+    """
+            .trimIndent()
+    val event: StreamsTransactionEvent = JSONUtils.asStreamsTransactionEvent(streamsMessage)
+    val sinkMessage = newChangeEventMessage(event.toChangeEvent().event, 1, 0)
+
+    assertInvalidDataException(sinkMessage, "n")
+  }
+
+  @Test
+  fun `should fail when streams relationship start node keys is empty`() {
+    val streamsMessage =
+        """
+      {
+        "meta": {
+          "timestamp": 1728641686524,
+          "username": "neo4j",
+          "txId": 17,
+          "txEventId": 0,
+          "txEventsCount": 1,
+          "operation": "deleted",
+          "source": {
+            "hostname": "neo4j03"
+          }
+        },
+        "payload": {
+          "id": "0",
+          "start": {
+            "id": "0",
+            "labels": [
+              "Person"
+            ],
+            "ids": {}
+          },
+          "end": {
+            "id": "2",
+            "labels": [
+              "Company"
+            ],
+            "ids": {
+              "name": "Neo4j"
+            }
+          },
+          "before": {
+            "properties": {}
+          },
+          "after": null,
+          "label": "WORKS_FOR",
+          "type": "relationship"
+        },
+        "schema": {
+          "properties": {},
+          "constraints": []
+        }
+      }
+    """
+            .trimIndent()
+    val event: StreamsTransactionEvent = JSONUtils.asStreamsTransactionEvent(streamsMessage)
+    val sinkMessage = newChangeEventMessage(event.toChangeEvent().event, 1, 0)
+
+    assertInvalidDataException(sinkMessage, "start")
+  }
+
+  @Test
+  fun `should fail when streams relationship end node keys is empty`() {
+    val streamsMessage =
+        """
+      {
+        "meta": {
+          "timestamp": 1728641686524,
+          "username": "neo4j",
+          "txId": 17,
+          "txEventId": 0,
+          "txEventsCount": 1,
+          "operation": "deleted",
+          "source": {
+            "hostname": "neo4j03"
+          }
+        },
+        "payload": {
+          "id": "0",
+          "start": {
+            "id": "0",
+            "labels": [
+              "Person"
+            ],
+            "ids": {
+              "name": "john"
+            }
+          },
+          "end": {
+            "id": "2",
+            "labels": [
+              "Company"
+            ],
+            "ids": {}
+          },
+          "before": {
+            "properties": {}
+          },
+          "after": null,
+          "label": "WORKS_FOR",
+          "type": "relationship"
+        },
+        "schema": {
+          "properties": {},
+          "constraints": []
+        }
+      }
+    """
+            .trimIndent()
+    val event: StreamsTransactionEvent = JSONUtils.asStreamsTransactionEvent(streamsMessage)
+    val sinkMessage = newChangeEventMessage(event.toChangeEvent().event, 1, 0)
+
+    assertInvalidDataException(sinkMessage, "end")
+  }
+
+  private fun assertInvalidDataException(sinkMessage: SinkMessage, alias: String) {
+    shouldThrow<InvalidDataException> {
           val handler =
               CdcSchemaHandler("my-topic", Renderer.getRenderer(Configuration.defaultConfig()))
 
@@ -815,7 +1751,8 @@ class CdcSchemaHandlerTest {
         .also {
           it shouldHaveMessage
               Regex(
-                  "^schema strategy requires at least one node key with valid properties aliased.*$")
+                  "^schema strategy requires at least one node key with valid properties on node aliased '$alias'.$",
+              )
         }
   }
 

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandlerTest.kt
@@ -160,7 +160,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "CREATE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps",
+                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -206,7 +206,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage1),
                     Query(
-                        "CREATE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps SET n:`Employee`",
+                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n = ${'$'}nProps SET n:`Employee`",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -255,7 +255,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MATCH (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps",
+                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -299,7 +299,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage1),
                     Query(
-                        "MATCH (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
+                        "MERGE (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
                         mapOf(
                             "nName" to "john",
                             "nSurname" to "doe",
@@ -351,7 +351,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage2),
                     Query(
-                        "MATCH (n:`Person`:`Employee` {name: ${'$'}nName, surname: ${'$'}nSurname, id: ${'$'}nId}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
+                        "MERGE (n:`Person`:`Employee` {name: ${'$'}nName, surname: ${'$'}nSurname, id: ${'$'}nId}) SET n += ${'$'}nProps SET n:`Manager` REMOVE n:`Employee`",
                         mapOf(
                             "nId" to 5000L,
                             "nName" to "john",
@@ -440,9 +440,9 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MATCH (start:`Person` {id: ${'$'}startId}) " +
-                            "MATCH (end:`Person` {id: ${'$'}endId}) " +
-                            "CREATE (start)-[r:`KNOWS` {}]->(end) " +
+                        "MERGE (start:`Person` {id: ${'$'}startId}) " +
+                            "MERGE (end:`Person` {id: ${'$'}endId}) " +
+                            "MERGE (start)-[r:`KNOWS` {}]->(end) " +
                             "SET r = ${'$'}rProps",
                         mapOf(
                             "startId" to 1L,
@@ -496,9 +496,9 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "MATCH (start:`Person`:`Employee` {id: ${'$'}startId, contractId: ${'$'}startContractId}) " +
-                            "MATCH (end:`Person`:`Employee` {id: ${'$'}endId, contractId: ${'$'}endContractId}) " +
-                            "MATCH (start)-[r:`KNOWS` {}]->(end) " +
+                        "MERGE (start:`Person`:`Employee` {id: ${'$'}startId, contractId: ${'$'}startContractId}) " +
+                            "MERGE (end:`Person`:`Employee` {id: ${'$'}endId, contractId: ${'$'}endContractId}) " +
+                            "MERGE (start)-[r:`KNOWS` {}]->(end) " +
                             "SET r += ${'$'}rProps",
                         mapOf(
                             "startId" to 1L,
@@ -950,7 +950,7 @@ class CdcSchemaHandlerTest {
                     0,
                     listOf(sinkMessage),
                     Query(
-                        "CREATE (n:`Person` {name: ${'$'}nName}) SET n = ${'$'}nProps",
+                        "MERGE (n:`Person` {name: ${'$'}nName}) SET n = ${'$'}nProps",
                         mapOf(
                             "nName" to "john",
                             "nProps" to


### PR DESCRIPTION
This PR;

- Handles empty lists inside key maps while checking for existence of node keys,
- Reworks statement generation based on relationship key existence.