### PR TITLE
fix: prevent exception caused by adding duplicate fields in schema generation

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/ChangeEventExtensions.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/ChangeEventExtensions.kt
@@ -202,6 +202,8 @@ class ChangeEventConverter() {
   }
 
   private fun schemaForKeys(keys: List<Map<String, Any>>?): Schema {
+    val addedFields = mutableSetOf<String>()
+
     return SchemaBuilder.array(
             // We need to define a uniform structure of key array elements. Because all elements
             // must have identical structure, we list all available keys as optional fields.
@@ -209,10 +211,11 @@ class ChangeEventConverter() {
                 .apply {
                   keys?.forEach { key ->
                     key.forEach {
-                      field(
-                          it.key,
-                          DynamicTypes.toConnectSchema(
-                              it.value, optional = true, forceMapsAsStruct = true))
+                      if (addedFields.add(it.key)) {
+                        field(
+                            it.key,
+                            toConnectSchema(it.value, optional = true, forceMapsAsStruct = true))
+                      }
                     }
                   }
                 }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceNodesIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceNodesIT.kt
@@ -584,9 +584,6 @@ abstract class Neo4jCdcSourceNodesIT {
       @TopicConsumer(topic = "cdc", offset = "earliest") consumer: ConvertingKafkaConsumer,
       session: Session
   ) {
-    session.run("CREATE CONSTRAINT FOR (n:TestSource) REQUIRE (n.prop1, n.prop2) IS KEY").consume()
-    session.run("CREATE CONSTRAINT FOR (n:TestSource) REQUIRE (n.prop3) IS KEY").consume()
-
     session
         .run(
             "CREATE (n:TestSource) SET n = ${'$'}props",
@@ -602,7 +599,6 @@ abstract class Neo4jCdcSourceNodesIT {
 
     TopicVerifier.create<ChangeEvent, ChangeEvent>(consumer)
         .assertMessageValue { value ->
-          println(value)
           assertThat(value)
               .hasEventType(NODE)
               .hasOperation(CREATE)


### PR DESCRIPTION
This PR fixes an issue where duplicate fields in the ChangeEvent schema generation process were causing `org.apache.kafka.connect.errors.SchemaBuilderException: Cannot create field because of field name duplication id` exception. When building the schema for key array elements, if different maps contained the same field name, the field was being added multiple times, resulting in the exception.