### PR TITLE
test: allow messages to be in any order

### DIFF
--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
@@ -1002,6 +1002,7 @@ abstract class Neo4jSinkErrorIT {
 
           it.value shouldBe nodePatternMessageToFail.value
         }
+        .inAnyOrder()
         .verifyWithin(Duration.ofSeconds(30))
   }
 

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/assertions/TopicVerifier.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/assertions/TopicVerifier.kt
@@ -44,6 +44,7 @@ class TopicVerifier<K, V>(
 
   private val log: Logger = LoggerFactory.getLogger(this::class.java)
 
+  private var inAnyOrder: Boolean = false
   private var messagePredicates = mutableListOf<Predicate<ConsumerRecord<ByteArray, ByteArray>>>()
 
   fun assertMessageKey(schemaTopic: String? = null, assertion: (K?) -> Unit): TopicVerifier<K, V> {
@@ -89,6 +90,11 @@ class TopicVerifier<K, V>(
     return this
   }
 
+  fun inAnyOrder(): TopicVerifier<K, V> {
+    this.inAnyOrder = true
+    return this
+  }
+
   fun verifyWithin(timeout: Duration) {
     val predicates = messagePredicates.toList()
     if (predicates.isEmpty()) {
@@ -98,15 +104,38 @@ class TopicVerifier<K, V>(
     try {
       Awaitility.await().atMost(timeout).until {
         consumer.kafkaConsumer.poll(Duration.ofMillis(500)).forEach { receivedMessages.add(it) }
-        val messages = receivedMessages.toList()
-        messages.size == predicates.size &&
-            predicates.foldIndexed(true) { i, prev, predicate ->
-              prev && predicate.test(messages[i])
+        val messages = receivedMessages.toList().toMutableList()
+
+        if (messages.size != predicates.size) {
+          return@until false
+        }
+
+        if (inAnyOrder) {
+          var queue = predicates.toList()
+          while (true) {
+            val predicate = queue.firstOrNull()
+            if (predicate == null) {
+              break
             }
+
+            val matched = messages.find { predicate.test(it) }
+            if (matched == null) {
+              return@until false
+            }
+
+            messages.remove(matched)
+            queue = queue.drop(1)
+          }
+
+          true
+        } else {
+          predicates.foldIndexed(true) { i, prev, predicate -> prev && predicate.test(messages[i]) }
+        }
       }
     } catch (e: ConditionTimeoutException) {
       throw AssertionError(
-          "Timeout of ${timeout.toMillis()}s reached: could not verify all ${predicates.size} predicate(s) on received messages")
+          "Timeout of ${timeout.toMillis()}s reached: could not verify all ${predicates.size} predicate(s) on received messages",
+      )
     }
   }
 


### PR DESCRIPTION
This PR adds a verify in any order feature for topic verifier to reduce the amount of flakiness in CI.