### PR TITLE
build: override netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <mockito.version>5.14.2</mockito.version>
         <neo4j-cypher-dsl.version>2022.11.0</neo4j-cypher-dsl.version>
         <neo4j-java-driver.version>4.4.18</neo4j-java-driver.version>
+        <netty.version>4.1.115.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- to match what is shipped with the Kafka Connect version used in our integration test environment -->
         <protobuf.version>3.24.4</protobuf.version>
@@ -95,6 +96,13 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <version>${jackson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
This PR overrides netty version which is a transient dependency from neo4j driver.