### PR TITLE
test: create database with cdc and wait for indexes

### DIFF
--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceKeyStrategyIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceKeyStrategyIT.kt
@@ -181,6 +181,7 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
       session: Session
   ) {
     session.run("CREATE CONSTRAINT FOR (ts:TestSource) REQUIRE ts.name IS NODE KEY").consume()
+    session.run("CALL db.awaitIndexes()").consume()
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
 
     TopicVerifier.createForMap(consumer)
@@ -241,6 +242,7 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
       session: Session
   ) {
     session.run("CREATE CONSTRAINT FOR ()-[to:TO]-() REQUIRE to.name IS RELATIONSHIP KEY").consume()
+    session.run("CALL db.awaitIndexes()").consume()
     session.run("CREATE (:Source)-[:TO {name: 'somewhere'}]->(:Destination)").consume()
 
     TopicVerifier.createForMap(consumer)

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceNodesIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceNodesIT.kt
@@ -431,6 +431,7 @@ abstract class Neo4jCdcSourceNodesIT {
     session
         .run("CREATE CONSTRAINT employedId FOR (n:Employee) REQUIRE n.employeeId IS NODE KEY")
         .consume()
+    session.run("CALL db.awaitIndexes()").consume()
 
     session
         .run("CREATE (:TestSource:Employee {id: 1, name: 'John', employeeId: 456})", mapOf())
@@ -513,6 +514,7 @@ abstract class Neo4jCdcSourceNodesIT {
   ) {
     session.run("CREATE CONSTRAINT FOR (n:TestSource) REQUIRE (n.prop1, n.prop2) IS KEY").consume()
     session.run("CREATE CONSTRAINT FOR (n:TestSource) REQUIRE n.prop1 IS KEY").consume()
+    session.run("CALL db.awaitIndexes()").consume()
     session
         .run(
             "CREATE (n:TestSource) SET n = ${'$'}props",

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceRelationshipsIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceRelationshipsIT.kt
@@ -429,6 +429,7 @@ abstract class Neo4jCdcSourceRelationshipsIT {
         .run(
             "CREATE CONSTRAINT employedRole FOR ()-[r:EMPLOYED]->() REQUIRE r.role IS RELATIONSHIP KEY")
         .consume()
+    session.run("CALL db.awaitIndexes()").consume()
 
     session.run("CREATE (:Person)-[:EMPLOYED {id: 1, role: 'SWE'}]->(:Company)").consume()
 
@@ -519,6 +520,7 @@ abstract class Neo4jCdcSourceRelationshipsIT {
         .run(
             "CREATE CONSTRAINT employedRole FOR ()-[r:EMPLOYED]->() REQUIRE r.id IS RELATIONSHIP KEY")
         .consume()
+    session.run("CALL db.awaitIndexes()").consume()
 
     session.run("CREATE (:Person)-[:EMPLOYED {id: 1, role: 'SWE'}]->(:Company)").consume()
 

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DatabaseSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DatabaseSupport.kt
@@ -22,11 +22,13 @@ object DatabaseSupport {
 
   internal const val DEFAULT_DATABASE = "neo4j"
 
-  internal fun Session.createDatabase(database: String): Session {
+  internal fun Session.createDatabase(database: String, withCdc: Boolean = false): Session {
     if (database == DEFAULT_DATABASE) {
       return this
     }
-    this.run("CREATE DATABASE \$db_name WAIT 30 SECONDS", mapOf("db_name" to database))
+    this.run(
+        "CREATE DATABASE \$db_name OPTIONS { txLogEnrichment: '${if (withCdc) { "FULL" } else "OFF"}' } WAIT 30 SECONDS",
+        mapOf("db_name" to database))
     return this
   }
 
@@ -35,13 +37,6 @@ object DatabaseSupport {
       return this
     }
     this.run("DROP DATABASE \$db_name WAIT 30 SECONDS", mapOf("db_name" to database))
-    return this
-  }
-
-  internal fun Session.enableCdc(database: String = "neo4j"): Session {
-    this.run(
-        "ALTER DATABASE \$db_name SET OPTION txLogEnrichment \"FULL\" WAIT 30 SECONDS",
-        mapOf("db_name" to database))
     return this
   }
 }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtension.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtension.kt
@@ -37,7 +37,6 @@ import org.neo4j.connectors.kafka.testing.AnnotationSupport
 import org.neo4j.connectors.kafka.testing.AnnotationValueResolver
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.createDatabase
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.dropDatabase
-import org.neo4j.connectors.kafka.testing.DatabaseSupport.enableCdc
 import org.neo4j.connectors.kafka.testing.ParameterResolvers
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverterResolver
 import org.neo4j.connectors.kafka.testing.kafka.ConsumerResolver
@@ -241,10 +240,8 @@ internal class Neo4jSourceExtension(
     )
     createDriver().use { driver ->
       driver.session(SessionConfig.forDatabase("system")).use { session ->
-        session.createDatabase(neo4jDatabase)
-        if (sourceAnnotation.strategy == SourceStrategy.CDC) {
-          session.enableCdc(neo4jDatabase)
-        }
+        session.createDatabase(
+            neo4jDatabase, withCdc = sourceAnnotation.strategy == SourceStrategy.CDC)
       }
 
       // want to make sure that CDC is functional before running the test


### PR DESCRIPTION
This PR updates the tests so that databases are created with CDC on upfront, and also adds calls for db.awaitIndexes on tests with constraints.

testing if this has any affect on flaky behaviour.