### PR TITLE
build: upgrade kafka connect deps and parallelize tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,11 @@
         <!-- keep the next two in sync: https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
         <!-- as well as versions in the docker-compose.yml file -->
         <!-- refer to https://www.confluent.io/previous-versions/ for previous versions of Confluent Platform -->
-        <kafka-schema-registry.version>7.4.7</kafka-schema-registry.version>
+        <kafka-schema-registry.version>7.8.0</kafka-schema-registry.version>
         <!-- although our baseline version is 3.1, kafka connect below 3.4 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-25194 -->
+        <!-- although our baseline version is 3.1, kafka connect below 3.8 is vulnerable to https://www.cve.org/CVERecord?id=CVE-2023-43642 -->
         <!-- so we set the version to the first version that the vulnerability is resolved -->
-        <kafka.version>3.4.1</kafka.version>
+        <kafka.version>3.8.1</kafka.version>
         <kotest-assertions-core-jvm.version>5.9.1</kotest-assertions-core-jvm.version>
         <kotlin.coroutines.version>1.9.0</kotlin.coroutines.version>
         <kotlin.version>2.1.0</kotlin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -56,9 +56,11 @@
         <junit-jupiter.version>5.11.3</junit-jupiter.version>
         <!-- keep the next two in sync: https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
         <!-- as well as versions in the docker-compose.yml file -->
-        <kafka-schema-registry.version>7.2.9</kafka-schema-registry.version>
-        <!-- kafka connect below 3.4 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-25194 -->
-        <kafka.version>3.8.1</kafka.version>
+        <!-- refer to https://www.confluent.io/previous-versions/ for previous versions of Confluent Platform -->
+        <kafka-schema-registry.version>7.4.7</kafka-schema-registry.version>
+        <!-- although our baseline version is 3.1, kafka connect below 3.4 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-25194 -->
+        <!-- so we set the version to the first version that the vulnerability is resolved -->
+        <kafka.version>3.4.1</kafka.version>
         <kotest-assertions-core-jvm.version>5.9.1</kotest-assertions-core-jvm.version>
         <kotlin.coroutines.version>1.9.0</kotlin.coroutines.version>
         <kotlin.version>2.1.0</kotlin.version>
@@ -537,6 +539,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <forkCount>4</forkCount>
                     <includes>
                         <include>**/*IT.*</include>
                     </includes>


### PR DESCRIPTION
This PR;

- updates kafka version to the earliest secure version that is under Confluent support,
- adds forkCount configuration to failsafe so that we can have ITs to run (hopefully) faster.