### PR TITLE
feat: support kafka connect built-in types

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/DynamicTypes.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/DynamicTypes.kt
@@ -16,7 +16,10 @@
  */
 package org.neo4j.connectors.kafka.data
 
+import java.math.BigDecimal
+import java.math.BigInteger
 import java.nio.ByteBuffer
+import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -27,9 +30,13 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalQueries
 import kotlin.reflect.KClass
+import org.apache.kafka.connect.data.Date
+import org.apache.kafka.connect.data.Decimal
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.data.Time
+import org.apache.kafka.connect.data.Timestamp
 import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.driver.Values
 import org.neo4j.driver.types.IsoDuration
@@ -38,6 +45,16 @@ import org.neo4j.driver.types.Point
 import org.neo4j.driver.types.Relationship
 
 object DynamicTypes {
+  val MILLIS_PER_DAY = 24 * 60 * 60 * 1000
+
+  private val PROTOBUF_DECIMAL_TYPE = "confluent.type.Decimal"
+
+  private val PROTOBUF_DATE_TYPE = "google.type.Date"
+
+  private val PROTOBUF_TIME_TYPE = "google.type.TimeOfDay"
+
+  private val PROTOBUF_TIMESTAMP_TYPE = "google.protobuf.Timestamp"
+
   fun toConnectValue(schema: Schema, value: Any?): Any? {
     if (value == null) {
       return null
@@ -158,166 +175,251 @@ object DynamicTypes {
       return null
     }
 
-    return when (schema.type()) {
-      Schema.Type.BOOLEAN -> value as Boolean?
-      Schema.Type.INT8 -> value as Byte?
-      Schema.Type.INT16 -> value as Short?
-      Schema.Type.INT32 -> value as Int?
-      Schema.Type.INT64 -> value as Long?
-      Schema.Type.FLOAT32 -> value as Float?
-      Schema.Type.FLOAT64 -> value as Double?
-      Schema.Type.BYTES ->
+    // check for Kafka Connect types first
+    return when (schema.name()) {
+      Date.LOGICAL_NAME ->
           when (value) {
-            is ByteArray -> value
-            is ByteBuffer -> value.array()
-            else -> throw IllegalArgumentException("unsupported bytes type ${value.javaClass.name}")
+            is java.util.Date -> LocalDate.ofEpochDay(Date.fromLogical(schema, value).toLong())
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported Kafka Connect date type ${value.javaClass.name}")
           }
-      Schema.Type.STRING -> {
-        val parsedValue =
-            when {
-              SimpleTypes.LOCALDATE.matches(schema) ->
-                  (value as String?)?.let {
-                    DateTimeFormatter.ISO_DATE.parse(it) { parsed -> LocalDate.from(parsed) }
-                  }
-              SimpleTypes.LOCALTIME.matches(schema) ->
-                  (value as String?)?.let {
-                    DateTimeFormatter.ISO_TIME.parse(it) { parsed -> LocalTime.from(parsed) }
-                  }
-              SimpleTypes.LOCALDATETIME.matches(schema) ->
-                  (value as String?)?.let {
-                    DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
-                      LocalDateTime.from(parsed)
-                    }
-                  }
-              SimpleTypes.ZONEDDATETIME.matches(schema) ->
-                  (value as String?)?.let {
-                    DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
-                      val zoneId = parsed.query(TemporalQueries.zone())
-                      if (zoneId is ZoneOffset) {
-                        OffsetDateTime.from(parsed)
-                      } else {
-                        ZonedDateTime.from(parsed)
-                      }
-                    }
-                  }
-              SimpleTypes.OFFSETTIME.matches(schema) ->
-                  (value as String?)?.let {
-                    DateTimeFormatter.ISO_TIME.parse(it) { parsed -> OffsetTime.from(parsed) }
-                  }
-              else -> value
-            }
-        when (parsedValue) {
-          is String -> parsedValue
-          is Char -> parsedValue.toString()
-          is CharArray -> parsedValue.concatToString()
-          is CharSequence -> parsedValue.toString()
-          is LocalDate -> parsedValue
-          is LocalTime -> parsedValue
-          is LocalDateTime -> parsedValue
-          is OffsetDateTime -> parsedValue
-          is ZonedDateTime -> parsedValue
-          is OffsetTime -> parsedValue
-          else ->
-              throw IllegalArgumentException(
-                  "Unsupported string schema type: ${value.javaClass.name}")
-        }
-      }
-      Schema.Type.STRUCT ->
-          when {
-            PropertyType.schema.matches(schema) -> PropertyType.fromConnectValue(value as Struct?)
-            SimpleTypes.DURATION.matches(schema) ->
-                (value as Struct?)
-                    ?.let {
-                      Values.isoDuration(
-                          it.getInt64(MONTHS),
-                          it.getInt64(DAYS),
-                          it.getInt64(SECONDS),
-                          it.getInt32(NANOS))
-                    }
-                    ?.asIsoDuration()
-            SimpleTypes.POINT.matches(schema) ->
-                (value as Struct?)
-                    ?.let {
-                      when (val dimension = it.getInt8(DIMENSION)) {
-                        TWO_D ->
-                            Values.point(it.getInt32(SR_ID), it.getFloat64(X), it.getFloat64(Y))
-                        THREE_D ->
-                            Values.point(
-                                it.getInt32(SR_ID),
-                                it.getFloat64(X),
-                                it.getFloat64(Y),
-                                it.getFloat64(Z))
-                        else ->
-                            throw IllegalArgumentException("unsupported dimension value $dimension")
-                      }
-                    }
-                    ?.asPoint()
-            else -> {
-              val result = mutableMapOf<String, Any?>()
-              val struct = value as Struct
-
-              for (field in schema.fields()) {
-                val fieldValue =
-                    fromConnectValue(field.schema(), struct.get(field), skipNullValuesInMaps)
-
-                if (fieldValue != null || !skipNullValuesInMaps) {
-                  result[field.name()] = fieldValue
-                }
-              }
-
-              if (result.isNotEmpty() &&
-                  result.keys.all { it.startsWith("e") && it.substring(1).toIntOrNull() != null }) {
-                result
-                    .mapKeys { it.key.substring(1).toInt() }
-                    .entries
-                    .sortedBy { it.key }
-                    .map { it.value }
-                    .toList()
-              } else {
-                result
-              }
-            }
+      PROTOBUF_DATE_TYPE ->
+          when (value) {
+            is Struct ->
+                LocalDate.of(value.getInt32("year"), value.getInt32("month"), value.getInt32("day"))
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported protobuf date type ${value.javaClass.name}")
           }
-      Schema.Type.ARRAY -> {
-        val result = mutableListOf<Any?>()
-
-        when {
-          value.javaClass.isArray ->
-              for (i in 0 ..< java.lang.reflect.Array.getLength(value)) {
-                result.add(
-                    fromConnectValue(
-                        schema.valueSchema(),
-                        java.lang.reflect.Array.get(value, i),
-                        skipNullValuesInMaps))
-              }
-          value is Iterable<*> ->
-              for (element in value) {
-                result.add(fromConnectValue(schema.valueSchema(), element, skipNullValuesInMaps))
-              }
-          else -> throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
-        }
-
-        result.toList()
-      }
-      Schema.Type.MAP -> {
-        val result = mutableMapOf<String, Any?>()
-        val map = value as Map<*, *>
-
-        for (entry in map.entries) {
-          if (entry.key !is String) {
-            throw IllegalArgumentException(
-                "invalid key type (${entry.key?.javaClass?.name} in map value")
+      Time.LOGICAL_NAME ->
+          when (value) {
+            is java.util.Date -> LocalTime.ofInstant(value.toInstant(), ZoneOffset.UTC)
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported Kafka Connect time type ${value.javaClass.name}")
           }
-
-          result[entry.key as String] =
-              fromConnectValue(schema.valueSchema(), entry.value, skipNullValuesInMaps)
-        }
-
-        result
-      }
+      PROTOBUF_TIME_TYPE ->
+          when (value) {
+            is Struct ->
+                LocalTime.of(
+                    value.getInt32("hours"),
+                    value.getInt32("minutes"),
+                    value.getInt32("seconds"),
+                    value.getInt32("nanos"))
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported protobuf time type ${value.javaClass.name}")
+          }
+      Timestamp.LOGICAL_NAME ->
+          when (value) {
+            is java.util.Date ->
+                LocalDateTime.ofInstant(
+                    Instant.ofEpochMilli(Timestamp.fromLogical(schema, value).toLong()),
+                    ZoneOffset.UTC)
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported Kafka Connect time type ${value.javaClass.name}")
+          }
+      PROTOBUF_TIMESTAMP_TYPE ->
+          when (value) {
+            is Struct ->
+                LocalDateTime.ofEpochSecond(
+                    value.getInt64("seconds"), value.getInt32("nanos"), ZoneOffset.UTC)
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported protobuf timestamp type ${value.javaClass.name}")
+          }
+      Decimal.LOGICAL_NAME, ->
+          // because Neo4j does not have a built-in DECIMAL value, and converting the incoming
+          // decimal
+          // value into a double might end-up in value loss, we explicitly represent these decimal
+          // values as strings so the user can consciously decide what to do with them.
+          when (value) {
+            is BigDecimal -> value.toString()
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported Kafka Connect decimal type ${value.javaClass.name}")
+          }
+      PROTOBUF_DECIMAL_TYPE ->
+          when (value) {
+            is Struct ->
+                BigDecimal(BigInteger(value.getBytes("value")), value.getInt32("scale")).toString()
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported protobuf decimal type ${value.javaClass.name}")
+          }
       else ->
-          throw IllegalArgumentException(
-              "unsupported schema ($schema) and value type (${value.javaClass.name})")
+          when (schema.type()) {
+            Schema.Type.BOOLEAN -> value as Boolean?
+            Schema.Type.INT8 -> value as Byte?
+            Schema.Type.INT16 -> value as Short?
+            Schema.Type.INT32 -> value as Int?
+            Schema.Type.INT64 -> value as Long?
+            Schema.Type.FLOAT32 -> value as Float?
+            Schema.Type.FLOAT64 -> value as Double?
+            Schema.Type.BYTES ->
+                when (value) {
+                  is ByteArray -> value
+                  is ByteBuffer -> value.array()
+                  else ->
+                      throw IllegalArgumentException(
+                          "unsupported bytes type ${value.javaClass.name}")
+                }
+            Schema.Type.STRING -> {
+              val parsedValue =
+                  when {
+                    SimpleTypes.LOCALDATE.matches(schema) ->
+                        (value as String?)?.let {
+                          DateTimeFormatter.ISO_DATE.parse(it) { parsed -> LocalDate.from(parsed) }
+                        }
+                    SimpleTypes.LOCALTIME.matches(schema) ->
+                        (value as String?)?.let {
+                          DateTimeFormatter.ISO_TIME.parse(it) { parsed -> LocalTime.from(parsed) }
+                        }
+                    SimpleTypes.LOCALDATETIME.matches(schema) ->
+                        (value as String?)?.let {
+                          DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
+                            LocalDateTime.from(parsed)
+                          }
+                        }
+                    SimpleTypes.ZONEDDATETIME.matches(schema) ->
+                        (value as String?)?.let {
+                          DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
+                            val zoneId = parsed.query(TemporalQueries.zone())
+                            if (zoneId is ZoneOffset) {
+                              OffsetDateTime.from(parsed)
+                            } else {
+                              ZonedDateTime.from(parsed)
+                            }
+                          }
+                        }
+                    SimpleTypes.OFFSETTIME.matches(schema) ->
+                        (value as String?)?.let {
+                          DateTimeFormatter.ISO_TIME.parse(it) { parsed -> OffsetTime.from(parsed) }
+                        }
+                    else -> value
+                  }
+              when (parsedValue) {
+                is String -> parsedValue
+                is Char -> parsedValue.toString()
+                is CharArray -> parsedValue.concatToString()
+                is CharSequence -> parsedValue.toString()
+                is LocalDate -> parsedValue
+                is LocalTime -> parsedValue
+                is LocalDateTime -> parsedValue
+                is OffsetDateTime -> parsedValue
+                is ZonedDateTime -> parsedValue
+                is OffsetTime -> parsedValue
+                else ->
+                    throw IllegalArgumentException(
+                        "Unsupported string schema type: ${value.javaClass.name}")
+              }
+            }
+            Schema.Type.STRUCT ->
+                when {
+                  PropertyType.schema.matches(schema) ->
+                      PropertyType.fromConnectValue(value as Struct?)
+                  SimpleTypes.DURATION.matches(schema) ->
+                      (value as Struct?)
+                          ?.let {
+                            Values.isoDuration(
+                                it.getInt64(MONTHS),
+                                it.getInt64(DAYS),
+                                it.getInt64(SECONDS),
+                                it.getInt32(NANOS))
+                          }
+                          ?.asIsoDuration()
+                  SimpleTypes.POINT.matches(schema) ->
+                      (value as Struct?)
+                          ?.let {
+                            when (val dimension = it.getInt8(DIMENSION)) {
+                              TWO_D ->
+                                  Values.point(
+                                      it.getInt32(SR_ID), it.getFloat64(X), it.getFloat64(Y))
+                              THREE_D ->
+                                  Values.point(
+                                      it.getInt32(SR_ID),
+                                      it.getFloat64(X),
+                                      it.getFloat64(Y),
+                                      it.getFloat64(Z))
+                              else ->
+                                  throw IllegalArgumentException(
+                                      "unsupported dimension value $dimension")
+                            }
+                          }
+                          ?.asPoint()
+                  else -> {
+                    val result = mutableMapOf<String, Any?>()
+                    val struct = value as Struct
+
+                    for (field in schema.fields()) {
+                      val fieldValue =
+                          fromConnectValue(field.schema(), struct.get(field), skipNullValuesInMaps)
+
+                      if (fieldValue != null || !skipNullValuesInMaps) {
+                        result[field.name()] = fieldValue
+                      }
+                    }
+
+                    if (result.isNotEmpty() &&
+                        result.keys.all {
+                          it.startsWith("e") && it.substring(1).toIntOrNull() != null
+                        }) {
+                      result
+                          .mapKeys { it.key.substring(1).toInt() }
+                          .entries
+                          .sortedBy { it.key }
+                          .map { it.value }
+                          .toList()
+                    } else {
+                      result
+                    }
+                  }
+                }
+            Schema.Type.ARRAY -> {
+              val result = mutableListOf<Any?>()
+
+              when {
+                value.javaClass.isArray ->
+                    for (i in 0 ..< java.lang.reflect.Array.getLength(value)) {
+                      result.add(
+                          fromConnectValue(
+                              schema.valueSchema(),
+                              java.lang.reflect.Array.get(value, i),
+                              skipNullValuesInMaps))
+                    }
+                value is Iterable<*> ->
+                    for (element in value) {
+                      result.add(
+                          fromConnectValue(schema.valueSchema(), element, skipNullValuesInMaps))
+                    }
+                else ->
+                    throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
+              }
+
+              result.toList()
+            }
+            Schema.Type.MAP -> {
+              val result = mutableMapOf<String, Any?>()
+              val map = value as Map<*, *>
+
+              for (entry in map.entries) {
+                if (entry.key !is String) {
+                  throw IllegalArgumentException(
+                      "invalid key type (${entry.key?.javaClass?.name} in map value")
+                }
+
+                result[entry.key as String] =
+                    fromConnectValue(schema.valueSchema(), entry.value, skipNullValuesInMaps)
+              }
+
+              result
+            }
+            else ->
+                throw IllegalArgumentException(
+                    "unsupported schema ($schema) and value type (${value.javaClass.name})")
+          }
     }
   }
 

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/DynamicTypes.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/DynamicTypes.kt
@@ -177,78 +177,14 @@ object DynamicTypes {
 
     // check for Kafka Connect types first
     return when (schema.name()) {
-      Date.LOGICAL_NAME ->
-          when (value) {
-            is java.util.Date -> LocalDate.ofEpochDay(Date.fromLogical(schema, value).toLong())
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported Kafka Connect date type ${value.javaClass.name}")
-          }
-      PROTOBUF_DATE_TYPE ->
-          when (value) {
-            is Struct ->
-                LocalDate.of(value.getInt32("year"), value.getInt32("month"), value.getInt32("day"))
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported protobuf date type ${value.javaClass.name}")
-          }
-      Time.LOGICAL_NAME ->
-          when (value) {
-            is java.util.Date -> LocalTime.ofInstant(value.toInstant(), ZoneOffset.UTC)
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported Kafka Connect time type ${value.javaClass.name}")
-          }
-      PROTOBUF_TIME_TYPE ->
-          when (value) {
-            is Struct ->
-                LocalTime.of(
-                    value.getInt32("hours"),
-                    value.getInt32("minutes"),
-                    value.getInt32("seconds"),
-                    value.getInt32("nanos"))
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported protobuf time type ${value.javaClass.name}")
-          }
-      Timestamp.LOGICAL_NAME ->
-          when (value) {
-            is java.util.Date ->
-                LocalDateTime.ofInstant(
-                    Instant.ofEpochMilli(Timestamp.fromLogical(schema, value).toLong()),
-                    ZoneOffset.UTC)
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported Kafka Connect time type ${value.javaClass.name}")
-          }
-      PROTOBUF_TIMESTAMP_TYPE ->
-          when (value) {
-            is Struct ->
-                LocalDateTime.ofEpochSecond(
-                    value.getInt64("seconds"), value.getInt32("nanos"), ZoneOffset.UTC)
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported protobuf timestamp type ${value.javaClass.name}")
-          }
-      Decimal.LOGICAL_NAME, ->
-          // because Neo4j does not have a built-in DECIMAL value, and converting the incoming
-          // decimal
-          // value into a double might end-up in value loss, we explicitly represent these decimal
-          // values as strings so the user can consciously decide what to do with them.
-          when (value) {
-            is BigDecimal -> value.toString()
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported Kafka Connect decimal type ${value.javaClass.name}")
-          }
-      PROTOBUF_DECIMAL_TYPE ->
-          when (value) {
-            is Struct ->
-                BigDecimal(BigInteger(value.getBytes("value")), value.getInt32("scale")).toString()
-            else ->
-                throw IllegalArgumentException(
-                    "unsupported protobuf decimal type ${value.javaClass.name}")
-          }
+      Date.LOGICAL_NAME -> fromConnectDate(value, schema)
+      PROTOBUF_DATE_TYPE -> fromProtobufDate(value)
+      Time.LOGICAL_NAME -> fromConnectTime(value)
+      PROTOBUF_TIME_TYPE -> fromProtobufTime(value)
+      Timestamp.LOGICAL_NAME -> fromConnectTimestamp(value, schema)
+      PROTOBUF_TIMESTAMP_TYPE -> fromProtobufTimestamp(value)
+      Decimal.LOGICAL_NAME, -> fromConnectDecimal(value)
+      PROTOBUF_DECIMAL_TYPE -> fromProtobufDecimal(value)
       else ->
           when (schema.type()) {
             Schema.Type.BOOLEAN -> value as Boolean?
@@ -258,170 +194,282 @@ object DynamicTypes {
             Schema.Type.INT64 -> value as Long?
             Schema.Type.FLOAT32 -> value as Float?
             Schema.Type.FLOAT64 -> value as Double?
-            Schema.Type.BYTES ->
-                when (value) {
-                  is ByteArray -> value
-                  is ByteBuffer -> value.array()
-                  else ->
-                      throw IllegalArgumentException(
-                          "unsupported bytes type ${value.javaClass.name}")
-                }
-            Schema.Type.STRING -> {
-              val parsedValue =
-                  when {
-                    SimpleTypes.LOCALDATE.matches(schema) ->
-                        (value as String?)?.let {
-                          DateTimeFormatter.ISO_DATE.parse(it) { parsed -> LocalDate.from(parsed) }
-                        }
-                    SimpleTypes.LOCALTIME.matches(schema) ->
-                        (value as String?)?.let {
-                          DateTimeFormatter.ISO_TIME.parse(it) { parsed -> LocalTime.from(parsed) }
-                        }
-                    SimpleTypes.LOCALDATETIME.matches(schema) ->
-                        (value as String?)?.let {
-                          DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
-                            LocalDateTime.from(parsed)
-                          }
-                        }
-                    SimpleTypes.ZONEDDATETIME.matches(schema) ->
-                        (value as String?)?.let {
-                          DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
-                            val zoneId = parsed.query(TemporalQueries.zone())
-                            if (zoneId is ZoneOffset) {
-                              OffsetDateTime.from(parsed)
-                            } else {
-                              ZonedDateTime.from(parsed)
-                            }
-                          }
-                        }
-                    SimpleTypes.OFFSETTIME.matches(schema) ->
-                        (value as String?)?.let {
-                          DateTimeFormatter.ISO_TIME.parse(it) { parsed -> OffsetTime.from(parsed) }
-                        }
-                    else -> value
-                  }
-              when (parsedValue) {
-                is String -> parsedValue
-                is Char -> parsedValue.toString()
-                is CharArray -> parsedValue.concatToString()
-                is CharSequence -> parsedValue.toString()
-                is LocalDate -> parsedValue
-                is LocalTime -> parsedValue
-                is LocalDateTime -> parsedValue
-                is OffsetDateTime -> parsedValue
-                is ZonedDateTime -> parsedValue
-                is OffsetTime -> parsedValue
-                else ->
-                    throw IllegalArgumentException(
-                        "Unsupported string schema type: ${value.javaClass.name}")
-              }
-            }
-            Schema.Type.STRUCT ->
-                when {
-                  PropertyType.schema.matches(schema) ->
-                      PropertyType.fromConnectValue(value as Struct?)
-                  SimpleTypes.DURATION.matches(schema) ->
-                      (value as Struct?)
-                          ?.let {
-                            Values.isoDuration(
-                                it.getInt64(MONTHS),
-                                it.getInt64(DAYS),
-                                it.getInt64(SECONDS),
-                                it.getInt32(NANOS))
-                          }
-                          ?.asIsoDuration()
-                  SimpleTypes.POINT.matches(schema) ->
-                      (value as Struct?)
-                          ?.let {
-                            when (val dimension = it.getInt8(DIMENSION)) {
-                              TWO_D ->
-                                  Values.point(
-                                      it.getInt32(SR_ID), it.getFloat64(X), it.getFloat64(Y))
-                              THREE_D ->
-                                  Values.point(
-                                      it.getInt32(SR_ID),
-                                      it.getFloat64(X),
-                                      it.getFloat64(Y),
-                                      it.getFloat64(Z))
-                              else ->
-                                  throw IllegalArgumentException(
-                                      "unsupported dimension value $dimension")
-                            }
-                          }
-                          ?.asPoint()
-                  else -> {
-                    val result = mutableMapOf<String, Any?>()
-                    val struct = value as Struct
-
-                    for (field in schema.fields()) {
-                      val fieldValue =
-                          fromConnectValue(field.schema(), struct.get(field), skipNullValuesInMaps)
-
-                      if (fieldValue != null || !skipNullValuesInMaps) {
-                        result[field.name()] = fieldValue
-                      }
-                    }
-
-                    if (result.isNotEmpty() &&
-                        result.keys.all {
-                          it.startsWith("e") && it.substring(1).toIntOrNull() != null
-                        }) {
-                      result
-                          .mapKeys { it.key.substring(1).toInt() }
-                          .entries
-                          .sortedBy { it.key }
-                          .map { it.value }
-                          .toList()
-                    } else {
-                      result
-                    }
-                  }
-                }
-            Schema.Type.ARRAY -> {
-              val result = mutableListOf<Any?>()
-
-              when {
-                value.javaClass.isArray ->
-                    for (i in 0 ..< java.lang.reflect.Array.getLength(value)) {
-                      result.add(
-                          fromConnectValue(
-                              schema.valueSchema(),
-                              java.lang.reflect.Array.get(value, i),
-                              skipNullValuesInMaps))
-                    }
-                value is Iterable<*> ->
-                    for (element in value) {
-                      result.add(
-                          fromConnectValue(schema.valueSchema(), element, skipNullValuesInMaps))
-                    }
-                else ->
-                    throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
-              }
-
-              result.toList()
-            }
-            Schema.Type.MAP -> {
-              val result = mutableMapOf<String, Any?>()
-              val map = value as Map<*, *>
-
-              for (entry in map.entries) {
-                if (entry.key !is String) {
-                  throw IllegalArgumentException(
-                      "invalid key type (${entry.key?.javaClass?.name} in map value")
-                }
-
-                result[entry.key as String] =
-                    fromConnectValue(schema.valueSchema(), entry.value, skipNullValuesInMaps)
-              }
-
-              result
-            }
+            Schema.Type.BYTES -> fromBytes(value)
+            Schema.Type.STRING -> fromString(schema, value)
+            Schema.Type.STRUCT -> fromStruct(schema, value, skipNullValuesInMaps)
+            Schema.Type.ARRAY -> fromArray(value, schema, skipNullValuesInMaps)
+            Schema.Type.MAP -> fromMap(value, schema, skipNullValuesInMaps)
             else ->
                 throw IllegalArgumentException(
                     "unsupported schema ($schema) and value type (${value.javaClass.name})")
           }
     }
   }
+
+  private fun fromMap(
+      value: Any,
+      schema: Schema,
+      skipNullValuesInMaps: Boolean
+  ): MutableMap<String, Any?> {
+    val result = mutableMapOf<String, Any?>()
+    val map = value as Map<*, *>
+
+    for (entry in map.entries) {
+      if (entry.key !is String) {
+        throw IllegalArgumentException(
+            "invalid key type (${entry.key?.javaClass?.name} in map value",
+        )
+      }
+
+      result[entry.key as String] =
+          fromConnectValue(schema.valueSchema(), entry.value, skipNullValuesInMaps)
+    }
+
+    return result
+  }
+
+  private fun fromArray(value: Any, schema: Schema, skipNullValuesInMaps: Boolean): List<Any?> {
+    val result = mutableListOf<Any?>()
+
+    when {
+      value.javaClass.isArray ->
+          for (i in 0 ..< java.lang.reflect.Array.getLength(value)) {
+            result.add(
+                fromConnectValue(
+                    schema.valueSchema(),
+                    java.lang.reflect.Array.get(value, i),
+                    skipNullValuesInMaps,
+                ),
+            )
+          }
+      value is Iterable<*> ->
+          for (element in value) {
+            result.add(
+                fromConnectValue(schema.valueSchema(), element, skipNullValuesInMaps),
+            )
+          }
+      else -> throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
+    }
+
+    return result.toList()
+  }
+
+  private fun fromStruct(schema: Schema, value: Any, skipNullValuesInMaps: Boolean): Any? =
+      when {
+        PropertyType.schema.matches(schema) -> PropertyType.fromConnectValue(value as Struct?)
+        SimpleTypes.POINT.matches(schema) ->
+            (value as Struct?)
+                ?.let {
+                  when (val dimension = it.getInt8(DIMENSION)) {
+                    TWO_D ->
+                        Values.point(
+                            it.getInt32(SR_ID),
+                            it.getFloat64(X),
+                            it.getFloat64(Y),
+                        )
+                    THREE_D ->
+                        Values.point(
+                            it.getInt32(SR_ID),
+                            it.getFloat64(X),
+                            it.getFloat64(Y),
+                            it.getFloat64(Z),
+                        )
+                    else ->
+                        throw IllegalArgumentException(
+                            "unsupported dimension value $dimension",
+                        )
+                  }
+                }
+                ?.asPoint()
+        SimpleTypes.DURATION.matches(schema) ->
+            (value as Struct?)
+                ?.let {
+                  Values.isoDuration(
+                      it.getInt64(MONTHS),
+                      it.getInt64(DAYS),
+                      it.getInt64(SECONDS),
+                      it.getInt32(NANOS),
+                  )
+                }
+                ?.asIsoDuration()
+        else -> {
+          val result = mutableMapOf<String, Any?>()
+          val struct = value as Struct
+
+          for (field in schema.fields()) {
+            val fieldValue =
+                fromConnectValue(field.schema(), struct.get(field), skipNullValuesInMaps)
+
+            if (fieldValue != null || !skipNullValuesInMaps) {
+              result[field.name()] = fieldValue
+            }
+          }
+
+          if (result.isNotEmpty() &&
+              result.keys.all { it.startsWith("e") && it.substring(1).toIntOrNull() != null }) {
+            result
+                .mapKeys { it.key.substring(1).toInt() }
+                .entries
+                .sortedBy { it.key }
+                .map { it.value }
+                .toList()
+          } else {
+            result
+          }
+        }
+      }
+
+  private fun fromString(schema: Schema, value: Any): Any {
+    val parsedValue =
+        when {
+          SimpleTypes.LOCALDATE.matches(schema) ->
+              (value as String?)?.let {
+                DateTimeFormatter.ISO_DATE.parse(it) { parsed -> LocalDate.from(parsed) }
+              }
+          SimpleTypes.LOCALTIME.matches(schema) ->
+              (value as String?)?.let {
+                DateTimeFormatter.ISO_TIME.parse(it) { parsed -> LocalTime.from(parsed) }
+              }
+          SimpleTypes.LOCALDATETIME.matches(schema) ->
+              (value as String?)?.let {
+                DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed -> LocalDateTime.from(parsed) }
+              }
+          SimpleTypes.ZONEDDATETIME.matches(schema) ->
+              (value as String?)?.let {
+                DateTimeFormatter.ISO_DATE_TIME.parse(it) { parsed ->
+                  val zoneId = parsed.query(TemporalQueries.zone())
+                  if (zoneId is ZoneOffset) {
+                    OffsetDateTime.from(parsed)
+                  } else {
+                    ZonedDateTime.from(parsed)
+                  }
+                }
+              }
+          SimpleTypes.OFFSETTIME.matches(schema) ->
+              (value as String?)?.let {
+                DateTimeFormatter.ISO_TIME.parse(it) { parsed -> OffsetTime.from(parsed) }
+              }
+          else -> value
+        }
+    return when (parsedValue) {
+      is String -> parsedValue
+      is Char -> parsedValue.toString()
+      is CharArray -> parsedValue.concatToString()
+      is CharSequence -> parsedValue.toString()
+      is LocalDate -> parsedValue
+      is LocalTime -> parsedValue
+      is LocalDateTime -> parsedValue
+      is OffsetDateTime -> parsedValue
+      is ZonedDateTime -> parsedValue
+      is OffsetTime -> parsedValue
+      else ->
+          throw IllegalArgumentException(
+              "Unsupported string schema type: ${value.javaClass.name}",
+          )
+    }
+  }
+
+  private fun fromBytes(value: Any): ByteArray? =
+      when (value) {
+        is ByteArray -> value
+        is ByteBuffer -> value.array()
+        else ->
+            throw IllegalArgumentException(
+                "unsupported bytes type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromProtobufDecimal(value: Any): String =
+      when (value) {
+        is Struct ->
+            BigDecimal(BigInteger(value.getBytes("value")), value.getInt32("scale")).toString()
+        else ->
+            throw IllegalArgumentException(
+                "unsupported protobuf decimal type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromConnectDecimal(value: Any): String =
+      // because Neo4j does not have a built-in DECIMAL value, and converting the incoming decimal
+      // value into a double might end-up in value loss, we explicitly represent these decimal
+      // values as strings so the user can consciously decide what to do with them.
+      when (value) {
+        is BigDecimal -> value.toString()
+        else ->
+            throw IllegalArgumentException(
+                "unsupported Kafka Connect decimal type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromProtobufTimestamp(value: Any): LocalDateTime? =
+      when (value) {
+        is Struct ->
+            LocalDateTime.ofEpochSecond(
+                value.getInt64("seconds"),
+                value.getInt32("nanos"),
+                ZoneOffset.UTC,
+            )
+        else ->
+            throw IllegalArgumentException(
+                "unsupported protobuf timestamp type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromConnectTimestamp(value: Any, schema: Schema): LocalDateTime? =
+      when (value) {
+        is java.util.Date ->
+            LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(Timestamp.fromLogical(schema, value).toLong()),
+                ZoneOffset.UTC,
+            )
+        else ->
+            throw IllegalArgumentException(
+                "unsupported Kafka Connect time type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromProtobufTime(value: Any): LocalTime? =
+      when (value) {
+        is Struct ->
+            LocalTime.of(
+                value.getInt32("hours"),
+                value.getInt32("minutes"),
+                value.getInt32("seconds"),
+                value.getInt32("nanos"),
+            )
+        else ->
+            throw IllegalArgumentException(
+                "unsupported protobuf time type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromConnectTime(value: Any): LocalTime? =
+      when (value) {
+        is java.util.Date -> LocalTime.ofInstant(value.toInstant(), ZoneOffset.UTC)
+        else ->
+            throw IllegalArgumentException(
+                "unsupported Kafka Connect time type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromProtobufDate(value: Any): LocalDate? =
+      when (value) {
+        is Struct ->
+            LocalDate.of(value.getInt32("year"), value.getInt32("month"), value.getInt32("day"))
+        else ->
+            throw IllegalArgumentException(
+                "unsupported protobuf date type ${value.javaClass.name}",
+            )
+      }
+
+  private fun fromConnectDate(value: Any, schema: Schema): LocalDate? =
+      when (value) {
+        is java.util.Date -> LocalDate.ofEpochDay(Date.fromLogical(schema, value).toLong())
+        else ->
+            throw IllegalArgumentException(
+                "unsupported Kafka Connect date type ${value.javaClass.name}",
+            )
+      }
 
   fun toConnectSchema(
       payloadMode: PayloadMode,

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCompactTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCompactTest.kt
@@ -30,7 +30,6 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import org.apache.kafka.connect.data.Date
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCompactTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCompactTest.kt
@@ -30,6 +30,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
+import org.apache.kafka.connect.data.Date
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.data
+
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+import org.apache.kafka.connect.data.Date
+import org.apache.kafka.connect.data.Decimal
+import org.apache.kafka.connect.data.Time
+import org.apache.kafka.connect.data.Timestamp
+import org.junit.jupiter.api.Test
+import org.neo4j.connectors.kafka.data.DynamicTypes.MILLIS_PER_DAY
+
+class DynamicTypesTest {
+  @Test
+  fun `kafka connect date values should be returned as local date`() {
+    DynamicTypes.fromConnectValue(
+        Date.SCHEMA,
+        java.util.Date(LocalDate.of(2000, 1, 1).toEpochDay() * MILLIS_PER_DAY)) shouldBe
+        LocalDate.of(2000, 1, 1)
+  }
+
+  @Test
+  fun `kafka connect time values should be returned as local time`() {
+    DynamicTypes.fromConnectValue(
+        Time.SCHEMA,
+        java.util.Date(
+            OffsetDateTime.of(
+                    LocalDate.EPOCH, LocalTime.of(23, 59, 59, 999_000_000), ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli())) shouldBe LocalTime.of(23, 59, 59, 999_000_000)
+  }
+
+  @Test
+  fun `kafka connect timestamp values should be returned as local time`() {
+    DynamicTypes.fromConnectValue(
+        Timestamp.SCHEMA,
+        java.util.Date(
+            OffsetDateTime.of(
+                    LocalDate.of(2000, 1, 1), LocalTime.of(23, 59, 59, 999_000_000), ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli())) shouldBe LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999_000_000)
+  }
+
+  @Test
+  fun `kafka connect decimal values should be returned as string`() {
+    DynamicTypes.fromConnectValue(
+        Decimal.schema(4), BigDecimal(BigInteger("12345678901234567890"), 4)) shouldBe
+        "1234567890123456.7890"
+    DynamicTypes.fromConnectValue(
+        Decimal.schema(6), BigDecimal(BigInteger("12345678901234567890"), 6)) shouldBe
+        "12345678901234.567890"
+    DynamicTypes.fromConnectValue(
+        Decimal.schema(6), BigDecimal(BigInteger("123456000000"), 6)) shouldBe "123456.000000"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <netty.version>4.1.116.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- to match what is shipped with the Kafka Connect version used in our integration test environment -->
-        <protobuf.version>3.24.4</protobuf.version>
+        <protobuf.version>3.25.5</protobuf.version>
         <reactor.version>2024.0.1</reactor.version>
         <slf4j.version>1.7.36</slf4j.version>
         <sortpom-maven-plugin.version>4.0.0</sortpom-maven-plugin.version>

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
@@ -20,15 +20,23 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
 import kotlin.time.Duration.Companion.seconds
+import org.apache.kafka.connect.data.Date
+import org.apache.kafka.connect.data.Decimal
 import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.SchemaBuilder
 import org.apache.kafka.connect.data.Struct
+import org.apache.kafka.connect.data.Time
+import org.apache.kafka.connect.data.Timestamp
 import org.junit.jupiter.api.Test
 import org.neo4j.connectors.kafka.data.DynamicTypes
 import org.neo4j.connectors.kafka.data.PropertyType
 import org.neo4j.connectors.kafka.data.PropertyType.schema
+import org.neo4j.connectors.kafka.testing.DateSupport
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.format.KafkaConverter
 import org.neo4j.connectors.kafka.testing.format.KeyValueConverter
@@ -628,6 +636,62 @@ abstract class Neo4jCudIT {
           .get("count")
           .asLong() shouldBe 1000
     }
+  }
+
+  @Neo4jSink(cud = [CudStrategy(TOPIC)])
+  @Test
+  fun `should create node from struct with connect types`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session
+  ) = runTest {
+    session.run("CREATE CONSTRAINT FOR (n:Foo) REQUIRE n.id IS KEY").consume()
+    session.run("CREATE CONSTRAINT FOR (n:Bar) REQUIRE n.id IS KEY").consume()
+
+    val propertiesSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("height", Decimal.schema(2))
+            .field("dob", Date.SCHEMA)
+            .field("tob", Time.SCHEMA)
+            .field("tsob", Timestamp.SCHEMA)
+            .build()
+    val createNodeSchema =
+        SchemaBuilder.struct()
+            .field("type", Schema.STRING_SCHEMA)
+            .field("op", Schema.STRING_SCHEMA)
+            .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA))
+            .field("properties", propertiesSchema)
+            .build()
+
+    producer.publish(
+        valueSchema = createNodeSchema,
+        value =
+            Struct(createNodeSchema)
+                .put("type", "node")
+                .put("op", "create")
+                .put("labels", listOf("Foo", "Bar"))
+                .put(
+                    "properties",
+                    Struct(propertiesSchema)
+                        .put("id", 1L)
+                        .put("height", BigDecimal.valueOf(185, 2))
+                        .put("dob", DateSupport.date(1978, 1, 15))
+                        .put("tob", DateSupport.time(7, 45, 12, 999))
+                        .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999))))
+
+    eventually(30.seconds) { session.run("MATCH (n) RETURN n", emptyMap()).single() }
+        .get("n")
+        .asNode() should
+        {
+          it.labels() shouldBe listOf("Foo", "Bar")
+          it.asMap() shouldBe
+              mapOf(
+                  "id" to 1L,
+                  "height" to "1.85",
+                  "dob" to LocalDate.of(1978, 1, 15),
+                  "tob" to LocalTime.of(7, 45, 12, 999000000),
+                  "tsob" to LocalDateTime.of(1978, 1, 15, 7, 45, 12, 999000000))
+        }
   }
 
   @Neo4jSink(cud = [CudStrategy(TOPIC)])

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DateSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DateSupport.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.testing
+
+import java.util.Calendar
+import java.util.Date
+import java.util.TimeZone
+
+object DateSupport {
+  val UTC = TimeZone.getTimeZone("UTC")
+
+  fun date(year: Int, month: Int, day: Int): Date {
+    val calendar = Calendar.getInstance(UTC)
+    calendar.set(year, month - 1, day, 0, 0, 0)
+    calendar.set(Calendar.MILLISECOND, 0)
+    return calendar.time
+  }
+
+  fun time(hour: Int, minute: Int, second: Int, millis: Int): Date {
+    val calendar = Calendar.getInstance(UTC)
+    calendar.set(1970, 0, 1, hour, minute, second)
+    calendar.set(Calendar.MILLISECOND, millis)
+    return calendar.time
+  }
+
+  fun timestamp(
+      year: Int,
+      month: Int,
+      day: Int,
+      hour: Int,
+      minute: Int,
+      second: Int,
+      millis: Int
+  ): Date {
+    val calendar = Calendar.getInstance(UTC)
+    calendar.set(year, month - 1, day, hour, minute, second)
+    calendar.set(Calendar.MILLISECOND, millis)
+    return calendar.time
+  }
+}


### PR DESCRIPTION
This PR adds support for the following built-in kafka connect types in sink connector.

- decimal
- date
- time
- timestamp.

resolves #254.