### PR TITLE
fix: re-throw exceptions if errant reporter is not set

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ./conf:/tmp/conf
     environment:
+      NEO4J_PLUGINS: "[ \"apoc\" ]"
       NEO4J_AUTH: neo4j/password
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
       NEO4J_server_memory_heap_max__size: "4G"

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
@@ -70,7 +70,14 @@ class Neo4jSinkTask : SinkTask() {
       if (unhandled.size > 1) {
         unhandled.forEach { m -> processMessages(handler, listOf(m)) }
       } else {
-        unhandled.forEach { m -> context.errantRecordReporter()?.report(m.record, e)?.get() }
+        unhandled.forEach { m ->
+          val reporter = context.errantRecordReporter()
+          if (reporter != null) {
+            reporter.report(m.record, e).get()
+          } else {
+            throw e
+          }
+        }
       }
     }
   }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSink.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSink.kt
@@ -41,6 +41,7 @@ annotation class Neo4jSink(
     val nodePattern: Array<NodePatternStrategy> = [],
     val relationshipPattern: Array<RelationshipPatternStrategy> = [],
     val cud: Array<CudStrategy> = [],
+    val excludeErrorHandling: Boolean = false,
     val errorTolerance: String = "none",
     val errorDlqTopic: String = "",
     val enableErrorHeaders: Boolean = false,

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkExtension.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkExtension.kt
@@ -246,6 +246,7 @@ internal class Neo4jSinkExtension(
             valueConverter = keyValueConverterResolver.resolveValueConverter(context),
             topics = topics.distinct(),
             strategies = strategies,
+            excludeErrorHandling = sinkAnnotation.excludeErrorHandling,
             errorTolerance = errorTolerance.resolve(sinkAnnotation),
             errorDlqTopic = topicRegistry.resolveTopic(errorDlqTopic.resolve(sinkAnnotation)),
             enableErrorHeaders = sinkAnnotation.enableErrorHeaders)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistration.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistration.kt
@@ -33,6 +33,7 @@ class Neo4jSinkRegistration(
     neo4jUser: String,
     neo4jPassword: String,
     neo4jDatabase: String,
+    excludeErrorHandling: Boolean = false,
     retryTimeout: Duration = (-1).milliseconds,
     retryMaxDelay: Duration = 1000.milliseconds,
     errorTolerance: String = "none",
@@ -64,18 +65,20 @@ class Neo4jSinkRegistration(
                       put("connector.class", "org.neo4j.connectors.kafka.sink.Neo4jConnector")
                       put("key.converter", keyConverter.className)
                       put("value.converter", valueConverter.className)
-                      put("errors.retry.timeout", retryTimeout.inWholeMilliseconds)
-                      put("errors.retry.delay.max.ms", retryMaxDelay.inWholeMilliseconds)
-                      put("errors.tolerance", errorTolerance)
-                      if (errorDlqTopic.trim().isNotEmpty()) {
-                        put("errors.deadletterqueue.topic.name", errorDlqTopic)
-                        put(
-                            "errors.deadletterqueue.topic.replication.factor",
-                            DLQ_TOPIC_REPLICATION_FACTOR)
+                      if (!excludeErrorHandling) {
+                        put("errors.retry.timeout", retryTimeout.inWholeMilliseconds)
+                        put("errors.retry.delay.max.ms", retryMaxDelay.inWholeMilliseconds)
+                        put("errors.tolerance", errorTolerance)
+                        if (errorDlqTopic.trim().isNotEmpty()) {
+                          put("errors.deadletterqueue.topic.name", errorDlqTopic)
+                          put(
+                              "errors.deadletterqueue.topic.replication.factor",
+                              DLQ_TOPIC_REPLICATION_FACTOR)
+                        }
+                        put("errors.deadletterqueue.context.headers.enable", enableErrorHeaders)
+                        put("errors.log.enable", enableErrorLog)
+                        put("errors.log.include.messages", includeMessagesInErrorLog)
                       }
-                      put("errors.deadletterqueue.context.headers.enable", enableErrorHeaders)
-                      put("errors.log.enable", enableErrorLog)
-                      put("errors.log.include.messages", includeMessagesInErrorLog)
                       put("neo4j.uri", neo4jUri)
                       put("neo4j.authentication.type", "BASIC")
                       put("neo4j.authentication.basic.username", neo4jUser)


### PR DESCRIPTION
This PR fixes a bug where caught exceptions are silently ignored when no error handling configuration is done in the connector.