### PR TITLE
build: remove explicit joda dependency

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,3 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 npx --no -- commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 ./mvnw sortpom:sort spotless:apply

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <hamcrest.version>3.0</hamcrest.version>
         <jackson.version>2.18.2</jackson.version>
         <java.version>11</java.version>
-        <joda-time.version>2.13.0</joda-time.version>
         <jreleaser-maven-plugin.version>1.16.0</jreleaser-maven-plugin.version>
         <junit-jupiter.version>5.11.4</junit-jupiter.version>
         <!-- keep the next two in sync: https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
@@ -206,12 +205,6 @@
                 <groupId>io.kotest</groupId>
                 <artifactId>kotest-assertions-core-jvm</artifactId>
                 <version>${kotest-assertions-core-jvm.version}</version>
-            </dependency>
-            <dependency>
-                <!-- dependency of confluent serializers -->
-                <groupId>joda-time</groupId>
-                <artifactId>joda-time</artifactId>
-                <version>${joda-time.version}</version>
             </dependency>
             <dependency>
                 <groupId>net.bytebuddy</groupId>


### PR DESCRIPTION
This PR removes explicit `joda-time:joda-time:jar` dependency declaration so that we rely on the transient dependency introduced by `io.confluent:kafka-connect-json-schema-converter:jar`