### PR TITLE
build: revert kafka schema registry version

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -7,15 +7,13 @@ import jetbrains.buildServer.configs.kotlin.triggers.vcs
 
 enum class JavaPlatform(
     val javaVersion: JavaVersion = DEFAULT_JAVA_VERSION,
-    val schemaRegistryVersion: String = DEFAULT_CONFLUENT_PLATFORM_VERSION,
     val platformITVersions: List<String> = listOf(DEFAULT_CONFLUENT_PLATFORM_VERSION)
 ) {
   JDK_11(
       JavaVersion.V_11,
-      schemaRegistryVersion = "7.2.9",
       platformITVersions = listOf("7.2.9", "7.7.0"),
   ),
-  JDK_17(JavaVersion.V_17, schemaRegistryVersion = "7.7.0", platformITVersions = listOf("7.7.0"))
+  JDK_17(JavaVersion.V_17, platformITVersions = listOf("7.7.0"))
 }
 
 class Build(
@@ -44,7 +42,6 @@ class Build(
                         "package",
                         "package",
                         it.javaVersion,
-                        it.schemaRegistryVersion,
                         "-pl :packaging -am -DskipTests",
                     )
 
@@ -55,7 +52,6 @@ class Build(
                           "build",
                           "test-compile",
                           it.javaVersion,
-                          it.schemaRegistryVersion,
                       ),
                   )
                   dependentBuildType(
@@ -64,7 +60,6 @@ class Build(
                           "unit tests",
                           "test",
                           it.javaVersion,
-                          it.schemaRegistryVersion,
                       ),
                   )
                   dependentBuildType(collectArtifacts(packaging))

--- a/.teamcity/builds/IntegrationTests.kt
+++ b/.teamcity/builds/IntegrationTests.kt
@@ -65,7 +65,7 @@ class IntegrationTests(
             maven {
               this.goals = "verify"
               this.runnerArgs =
-                  "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} -Dkafka-schema-registry.version=$platformVersion -DskipUnitTests"
+                  "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} -DskipUnitTests"
 
               // this is the settings name we uploaded to Connectors project
               userSettingsSelection = "github"

--- a/.teamcity/builds/Maven.kt
+++ b/.teamcity/builds/Maven.kt
@@ -10,7 +10,6 @@ class Maven(
     name: String,
     goals: String,
     javaVersion: JavaVersion,
-    schemaRegistryVersion: String,
     args: String? = null
 ) :
     BuildType({
@@ -23,7 +22,7 @@ class Maven(
         commonMaven(javaVersion) {
           this.goals = goals
           this.runnerArgs =
-              "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} -Dkafka-schema-registry.version=$schemaRegistryVersion ${args ?: ""}"
+              "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} ${args ?: ""}"
         }
       }
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <!-- keep the next two in sync: https://docs.confluent.io/platform/current/installation/versions-interoperability.html -->
         <!-- as well as versions in the docker-compose.yml file -->
         <!-- refer to https://www.confluent.io/previous-versions/ for previous versions of Confluent Platform -->
-        <kafka-schema-registry.version>7.9.0</kafka-schema-registry.version>
+        <kafka-schema-registry.version>7.8.1</kafka-schema-registry.version>
         <!-- although our baseline version is 3.1, kafka connect below 3.4 is vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-25194 -->
         <!-- although our baseline version is 3.1, kafka connect below 3.8 is vulnerable to https://www.cve.org/CVERecord?id=CVE-2023-43642 -->
         <!-- so we set the version to the first version that the vulnerability is resolved -->


### PR DESCRIPTION
This PR reverts Kafka schema registry version bump and removes schemaRegistryVersion from maven build