### PR TITLE
ci: include lts releases in pr and main builds

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -18,8 +18,6 @@ enum class JavaPlatform(
   JDK_17(JavaVersion.V_17, platformITVersions = listOf("7.7.0"))
 }
 
-val DEFAULT_NEO4J_VERSION = Neo4jVersion.V_2025
-
 class Build(
     name: String,
     forPullRequests: Boolean,

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -2,6 +2,7 @@ package builds
 
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.Project
+import jetbrains.buildServer.configs.kotlin.ReuseBuilds
 import jetbrains.buildServer.configs.kotlin.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.sequential
 import jetbrains.buildServer.configs.kotlin.toId
@@ -104,7 +105,8 @@ class Build(
               }
             }
 
-            dependentBuildType(complete)
+            dependentBuildType(
+                complete, reuse = if (forCompatibility) ReuseBuilds.NO else ReuseBuilds.SUCCESSFUL)
             if (!forPullRequests && !forCompatibility)
                 dependentBuildType(Release("${name}-release", "release", DEFAULT_JAVA_VERSION))
           }

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -21,8 +21,8 @@ enum class JavaPlatform(
 class Build(
     name: String,
     forPullRequests: Boolean,
-    forCompatibility: Boolean = false,
     neo4jVersions: Set<Neo4jVersion>,
+    forCompatibility: Boolean = false,
     customizeCompletion: BuildType.() -> Unit = {}
 ) :
     Project(
@@ -73,29 +73,27 @@ class Build(
                       )
                       dependentBuildType(collectArtifacts(packaging))
 
-                      parallel {
-                        java.platformITVersions.forEach { confluentPlatformVersion ->
-                          dependentBuildType(
-                              IntegrationTests(
-                                  "${name}-integration-tests-${java.javaVersion.version}-${confluentPlatformVersion}-${neo4jVersion.version}",
-                                  "integration tests (${java.javaVersion.version}, ${confluentPlatformVersion}, ${neo4jVersion.version})",
-                                  java.javaVersion,
-                                  confluentPlatformVersion,
-                                  neo4jVersion,
-                              ) {
-                                dependencies {
-                                  artifacts(packaging) {
-                                    artifactRules =
-                                        """
+                      java.platformITVersions.forEach { confluentPlatformVersion ->
+                        dependentBuildType(
+                            IntegrationTests(
+                                "${name}-integration-tests-${java.javaVersion.version}-${confluentPlatformVersion}-${neo4jVersion.version}",
+                                "integration tests (${java.javaVersion.version}, ${confluentPlatformVersion}, ${neo4jVersion.version})",
+                                java.javaVersion,
+                                confluentPlatformVersion,
+                                neo4jVersion,
+                            ) {
+                              dependencies {
+                                artifacts(packaging) {
+                                  artifactRules =
+                                      """
                                     +:packages/*.jar => docker/plugins
                                     -:packages/*-kc-oss.jar
                                     """
-                                            .trimIndent()
-                                  }
+                                          .trimIndent()
                                 }
-                              },
-                          )
-                        }
+                              }
+                            },
+                        )
                       }
                     }
                   }

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -60,6 +60,7 @@ class Build(
                       ),
                   )
 
+                  println("neo4jVersions = $neo4jVersions")
                   neo4jVersions.forEach { neo4jVersion ->
                     {
                       dependentBuildType(

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -60,6 +60,8 @@ class Build(
                       ),
                   )
 
+                  dependentBuildType(collectArtifacts(packaging))
+
                   neo4jVersions.forEach { neo4jVersion ->
                     dependentBuildType(
                         Maven(
@@ -70,7 +72,6 @@ class Build(
                             neo4jVersion,
                         ),
                     )
-                    dependentBuildType(collectArtifacts(packaging))
 
                     java.platformITVersions.forEach { confluentPlatformVersion ->
                       dependentBuildType(

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -134,7 +134,7 @@ class Build(
                 firstSuccessAfterFailure = true
                 buildProbablyHanging = true
 
-                branchFilter = "+:update-ci"
+                branchFilter = "+:main"
 
                 notifierSettings = slackNotifier {
                   connection = SLACK_CONNECTION_ID

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -65,8 +65,8 @@ class Build(
                   neo4jVersions.forEach { neo4jVersion ->
                     dependentBuildType(
                         Maven(
-                            "${name}-unit-tests-${java.javaVersion.version}",
-                            "unit tests (${java.javaVersion.version})",
+                            "${name}-unit-tests-${java.javaVersion.version}-${neo4jVersion.version}",
+                            "unit tests (${java.javaVersion.version}, ${neo4jVersion.version})",
                             "test",
                             java.javaVersion,
                             neo4jVersion,

--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -60,42 +60,39 @@ class Build(
                       ),
                   )
 
-                  println("neo4jVersions = $neo4jVersions")
                   neo4jVersions.forEach { neo4jVersion ->
-                    {
-                      dependentBuildType(
-                          Maven(
-                              "${name}-unit-tests-${java.javaVersion.version}",
-                              "unit tests (${java.javaVersion.version})",
-                              "test",
-                              java.javaVersion,
-                              neo4jVersion,
-                          ),
-                      )
-                      dependentBuildType(collectArtifacts(packaging))
+                    dependentBuildType(
+                        Maven(
+                            "${name}-unit-tests-${java.javaVersion.version}",
+                            "unit tests (${java.javaVersion.version})",
+                            "test",
+                            java.javaVersion,
+                            neo4jVersion,
+                        ),
+                    )
+                    dependentBuildType(collectArtifacts(packaging))
 
-                      java.platformITVersions.forEach { confluentPlatformVersion ->
-                        dependentBuildType(
-                            IntegrationTests(
-                                "${name}-integration-tests-${java.javaVersion.version}-${confluentPlatformVersion}-${neo4jVersion.version}",
-                                "integration tests (${java.javaVersion.version}, ${confluentPlatformVersion}, ${neo4jVersion.version})",
-                                java.javaVersion,
-                                confluentPlatformVersion,
-                                neo4jVersion,
-                            ) {
-                              dependencies {
-                                artifacts(packaging) {
-                                  artifactRules =
-                                      """
+                    java.platformITVersions.forEach { confluentPlatformVersion ->
+                      dependentBuildType(
+                          IntegrationTests(
+                              "${name}-integration-tests-${java.javaVersion.version}-${confluentPlatformVersion}-${neo4jVersion.version}",
+                              "integration tests (${java.javaVersion.version}, ${confluentPlatformVersion}, ${neo4jVersion.version})",
+                              java.javaVersion,
+                              confluentPlatformVersion,
+                              neo4jVersion,
+                          ) {
+                            dependencies {
+                              artifacts(packaging) {
+                                artifactRules =
+                                    """
                                     +:packages/*.jar => docker/plugins
                                     -:packages/*-kc-oss.jar
                                     """
-                                          .trimIndent()
-                                }
+                                        .trimIndent()
                               }
-                            },
-                        )
-                      }
+                            }
+                          },
+                      )
                     }
                   }
                 }

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -27,7 +27,7 @@ const val DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.2.9"
 
 // Look into Root Project's settings -> Connections
 const val SLACK_CONNECTION_ID = "PROJECT_EXT_83"
-const val SLACK_CHANNEL = "#C05R4RURYLA" // #team-connectors-feed
+const val SLACK_CHANNEL = "#team-connectors-feed"
 
 // Look into Root Project's settings -> Connections
 const val ECR_CONNECTION_ID = "PROJECT_EXT_124"
@@ -65,7 +65,7 @@ object Neo4jKafkaConnectorVcs :
 
           name = "neo4j-kafka-connector"
           url = "git@github.com:neo4j/neo4j-kafka-connector.git"
-          branch = "refs/heads/main"
+          branch = "refs/heads/update-ci"
           branchSpec = "refs/heads/*"
 
           authMethod = defaultPrivateKey { userName = "git" }

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -6,6 +6,7 @@ import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.CompoundStage
 import jetbrains.buildServer.configs.kotlin.FailureAction
 import jetbrains.buildServer.configs.kotlin.Requirements
+import jetbrains.buildServer.configs.kotlin.ReuseBuilds
 import jetbrains.buildServer.configs.kotlin.buildFeatures.PullRequests
 import jetbrains.buildServer.configs.kotlin.buildFeatures.commitStatusPublisher
 import jetbrains.buildServer.configs.kotlin.buildFeatures.dockerRegistryConnections
@@ -108,10 +109,11 @@ fun BuildFeatures.loginToECR() = dockerRegistryConnections {
   loginToRegistry = on { dockerRegistryId = ECR_CONNECTION_ID }
 }
 
-fun CompoundStage.dependentBuildType(bt: BuildType) =
+fun CompoundStage.dependentBuildType(bt: BuildType, reuse: ReuseBuilds = ReuseBuilds.SUCCESSFUL) =
     buildType(bt) {
       onDependencyCancel = FailureAction.CANCEL
       onDependencyFailure = FailureAction.FAIL_TO_START
+      reuseBuilds = reuse
     }
 
 fun collectArtifacts(buildType: BuildType): BuildType {

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -65,8 +65,8 @@ object Neo4jKafkaConnectorVcs :
           id("Connectors_Neo4jKafkaConnector_Build")
 
           name = "neo4j-kafka-connector"
-          url = "git@github.com:ali-ince/neo4j-kafka-connector.git"
-          branch = "refs/heads/update-ci"
+          url = "git@github.com:neo4j/neo4j-kafka-connector.git"
+          branch = "refs/heads/main"
           branchSpec = "refs/heads/*"
 
           authMethod = defaultPrivateKey { userName = "git" }

--- a/.teamcity/builds/Common.kt
+++ b/.teamcity/builds/Common.kt
@@ -65,7 +65,7 @@ object Neo4jKafkaConnectorVcs :
           id("Connectors_Neo4jKafkaConnector_Build")
 
           name = "neo4j-kafka-connector"
-          url = "git@github.com:neo4j/neo4j-kafka-connector.git"
+          url = "git@github.com:ali-ince/neo4j-kafka-connector.git"
           branch = "refs/heads/update-ci"
           branchSpec = "refs/heads/*"
 

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -1,10 +1,7 @@
 import builds.Build
 import builds.Neo4jKafkaConnectorVcs
 import builds.Neo4jVersion
-import builds.SLACK_CHANNEL
-import builds.SLACK_CONNECTION_ID
 import jetbrains.buildServer.configs.kotlin.Project
-import jetbrains.buildServer.configs.kotlin.buildFeatures.notifications
 import jetbrains.buildServer.configs.kotlin.project
 import jetbrains.buildServer.configs.kotlin.triggers.schedule
 import jetbrains.buildServer.configs.kotlin.triggers.vcs
@@ -21,24 +18,30 @@ project {
   vcsRoot(Neo4jKafkaConnectorVcs)
 
   subProject(
-      Build(name = "main", forPullRequests = false) {
-        triggers {
-          vcs {
-            this.branchFilter = "+:main"
-            this.triggerRules =
-                """
+      Build(
+          name = "main",
+          neo4jVersions = setOf(Neo4jVersion.V_4_4, Neo4jVersion.V_5, Neo4jVersion.V_2025),
+          forPullRequests = false) {
+            triggers {
+              vcs {
+                this.branchFilter = "+:update-ci"
+                this.triggerRules =
+                    """
               -:comment=^build.*release version.*:**
               -:comment=^build.*update version.*:**
               """
-                    .trimIndent()
-          }
-        }
-      })
+                        .trimIndent()
+              }
+            }
+          })
 
   subProject(
-      Build(name = "pull-request", forPullRequests = true) {
-        triggers { vcs { this.branchFilter = "+:pull/*" } }
-      })
+      Build(
+          name = "pull-request",
+          neo4jVersions = setOf(Neo4jVersion.V_4_4, Neo4jVersion.V_5, Neo4jVersion.V_2025),
+          forPullRequests = true) {
+            triggers { vcs { this.branchFilter = "+:pull/*" } }
+          })
 
   subProject(
       Project {
@@ -51,7 +54,7 @@ project {
                   name = "${neo4j.version}",
                   forPullRequests = false,
                   forCompatibility = true,
-                  neo4jVersion = neo4j) {
+                  neo4jVersions = setOf(neo4j)) {
                     triggers {
                       vcs { enabled = false }
 
@@ -62,24 +65,7 @@ project {
                           minute = 0
                         }
                         triggerBuild = always()
-                      }
-                    }
-
-                    features {
-                      notifications {
-                        buildFailedToStart = true
-                        buildFailed = true
-                        firstFailureAfterSuccess = true
-                        firstSuccessAfterFailure = true
-                        buildProbablyHanging = true
-
-                        branchFilter = "+:main"
-
-                        notifierSettings = slackNotifier {
-                          connection = SLACK_CONNECTION_ID
-                          sendTo = SLACK_CHANNEL
-                          messageFormat = simpleMessageFormat()
-                        }
+                        dependencies { triggerBuild = always() }
                       }
                     }
                   })

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -59,13 +59,12 @@ project {
                       vcs { enabled = false }
 
                       schedule {
-                        branchFilter = "+:main"
+                        branchFilter = "+:update-ci"
                         schedulingPolicy = daily {
                           hour = 8
                           minute = 0
                         }
                         triggerBuild = always()
-                        dependencies { triggerBuild = always() }
                       }
                     }
                   })

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -24,7 +24,7 @@ project {
           forPullRequests = false) {
             triggers {
               vcs {
-                this.branchFilter = "+:update-ci"
+                this.branchFilter = "+:main"
                 this.triggerRules =
                     """
               -:comment=^build.*release version.*:**
@@ -59,7 +59,7 @@ project {
                       vcs { enabled = false }
 
                       schedule {
-                        branchFilter = "+:update-ci"
+                        branchFilter = "+:main"
                         schedulingPolicy = daily {
                           hour = 8
                           minute = 0


### PR DESCRIPTION
This PR;

- adds Neo4j LTS releases (4.4 and 5.26) to the main and PR builds
- fixes notification to refer to the channel name
- forces snapshot dependencies of compatibility builds to always re-build
- make build failure notifications available to main builds as well.