### PR TITLE
ci: fix compat build scheduling and notifications

### DIFF
--- a/.teamcity/builds/Build.kt
+++ b/.teamcity/builds/Build.kt
@@ -130,8 +130,7 @@ class Build(
               notifications {
                 buildFailedToStart = true
                 buildFailed = true
-                firstFailureAfterSuccess = true
-                firstSuccessAfterFailure = true
+                buildFinishedSuccessfully = true
                 buildProbablyHanging = true
 
                 branchFilter = "+:main"

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -65,6 +65,9 @@ project {
                           minute = 0
                         }
                         triggerBuild = always()
+                        withPendingChangesOnly = false
+                        enforceCleanCheckout = true
+                        enforceCleanCheckoutForDependencies = true
                       }
                     }
                   })


### PR DESCRIPTION
This PR fixes CI so that compat builds run every day without checking for changes and also notifies on each day.