### PR TITLE
ci: retry package acquisition during apt install

### DIFF
--- a/.teamcity/builds/IntegrationTests.kt
+++ b/.teamcity/builds/IntegrationTests.kt
@@ -54,7 +54,7 @@ class IntegrationTests(
                 #!/bin/bash -eu
                 # TODO: publish custom image instead
                 apt-get update
-                apt-get install --yes ruby-full ruby-bundler build-essential
+                apt-get install -o Acquire::Retries=10 --yes ruby-full ruby-bundler build-essential
                 bundle install
                 curl -fsSL https://get.docker.com | sh
                 dip compose up -d neo4j zookeeper broker schema-registry control-center
@@ -87,7 +87,7 @@ class IntegrationTests(
                 #!/bin/bash -eu
                 # TODO: publish custom image instead
                 apt-get update
-                apt-get install --yes ruby-full ruby-bundler build-essential
+                apt-get install -o Acquire::Retries=10 --yes ruby-full ruby-bundler build-essential
                 bundle install
                 curl -fsSL https://get.docker.com | sh
                 mkdir diagnostics
@@ -109,7 +109,7 @@ class IntegrationTests(
                 #!/bin/bash -eu
                 # TODO: publish custom image instead
                 apt-get update
-                apt-get install --yes ruby-full ruby-bundler build-essential
+                apt-get install -o Acquire::Retries=10 --yes ruby-full ruby-bundler build-essential
                 bundle install
                 curl -fsSL https://get.docker.com | sh
                 dip compose down --rmi local


### PR DESCRIPTION
This PR adds `-o Acquire::Retries=10` arguments to `apt-get install` as a workaround to 503 errors for the build pipeline.