### PR TITLE
build: upgrade cdc client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <build-resources.version>2024-12.1</build-resources.version>
         <byte-buddy.version>1.17.5</byte-buddy.version>
         <caniuse-neo4j-detection.version>1.3.0</caniuse-neo4j-detection.version>
-        <cdc.version>1.0.13</cdc.version>
+        <cdc.version>1.0.14</cdc.version>
         <commons-collections4.version>4.5.0</commons-collections4.version>
         <commons-lang3.version>3.17.0</commons-lang3.version>
         <hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
This PR upgrades cdc-client dependency to its latest release 1.0.14.