### PR TITLE
test: update label assertions

### DIFF
--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaFromStreamsMessageIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaFromStreamsMessageIT.kt
@@ -17,6 +17,7 @@
 package org.neo4j.connectors.kafka.sink
 
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -130,7 +131,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
 
       result.get("n").asNode() should
           {
-            it.labels() shouldBe listOf("Person", "Employee")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Person", "Employee")
             it.asMap() shouldBe
                 mapOf(
                     "id" to 5L,
@@ -321,7 +322,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
 
       result.get("n").asNode() should
           {
-            it.labels() shouldBe listOf("Person", "Employee")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Person", "Employee")
             it.asMap() shouldBe
                 mapOf(
                     "first_name" to "john",

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaIT.kt
@@ -17,6 +17,7 @@
 package org.neo4j.connectors.kafka.sink
 
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -129,7 +130,7 @@ abstract class Neo4jCdcSchemaIT {
 
       result.get("n").asNode() should
           {
-            it.labels() shouldBe listOf("Person", "Employee")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Person", "Employee")
             it.asMap() shouldBe
                 mapOf(
                     "id" to 5L,

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSourceIdFromStreamsMessageIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSourceIdFromStreamsMessageIT.kt
@@ -17,6 +17,7 @@
 package org.neo4j.connectors.kafka.sink
 
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -80,7 +81,7 @@ class Neo4jCdcSourceIdFromStreamsMessageIT {
 
       result.get("n").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person1", "id" to 1L, "name" to "john")
           }
     }
@@ -129,7 +130,8 @@ class Neo4jCdcSourceIdFromStreamsMessageIT {
 
       result.get("n").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person", "Employee")
+            it.labels().toList() shouldContainExactlyInAnyOrder
+                listOf("SourceEvent", "Person", "Employee")
             it.asMap() shouldBe
                 mapOf(
                     "sourceId" to "person1",
@@ -222,12 +224,12 @@ class Neo4jCdcSourceIdFromStreamsMessageIT {
           }
       result.get("start").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person1", "name" to "john", "surname" to "doe")
           }
       result.get("end").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person2", "name" to "mary", "surname" to "doe")
           }
     }
@@ -290,12 +292,12 @@ class Neo4jCdcSourceIdFromStreamsMessageIT {
           }
       result.get("start").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person1", "name" to "john", "surname" to "doe")
           }
       result.get("end").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person2", "name" to "mary", "surname" to "doe")
           }
     }
@@ -426,13 +428,13 @@ class Neo4jCdcSourceIdFromStreamsMessageIT {
       result.get("r").asRelationship() should { it.asMap() shouldBe mapOf("sourceId" to "knows1") }
       result.get("start").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe
                 mapOf("sourceId" to "person1", "id" to 1L, "name" to "john", "surname" to "doe")
           }
       result.get("end").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe
                 mapOf("sourceId" to "person2", "id" to 2L, "name" to "mary", "surname" to "doe")
           }

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSourceIdIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSourceIdIT.kt
@@ -17,6 +17,7 @@
 package org.neo4j.connectors.kafka.sink
 
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -124,7 +125,8 @@ abstract class Neo4jCdcSourceIdIT {
 
       result.get("n").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person", "Employee")
+            it.labels().toList() shouldContainExactlyInAnyOrder
+                listOf("SourceEvent", "Person", "Employee")
             it.asMap() shouldBe
                 mapOf(
                     "sourceId" to "person1",
@@ -217,12 +219,12 @@ abstract class Neo4jCdcSourceIdIT {
           }
       result.get("start").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person1", "name" to "john", "surname" to "doe")
           }
       result.get("end").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person2", "name" to "mary", "surname" to "doe")
           }
     }
@@ -279,12 +281,12 @@ abstract class Neo4jCdcSourceIdIT {
           }
       result.get("start").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person1", "name" to "john", "surname" to "doe")
           }
       result.get("end").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe mapOf("sourceId" to "person2", "name" to "mary", "surname" to "doe")
           }
     }
@@ -402,13 +404,13 @@ abstract class Neo4jCdcSourceIdIT {
       result.get("r").asRelationship() should { it.asMap() shouldBe mapOf("sourceId" to "knows1") }
       result.get("start").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe
                 mapOf("sourceId" to "person1", "id" to 1L, "name" to "john", "surname" to "doe")
           }
       result.get("end").asNode() should
           {
-            it.labels() shouldBe listOf("SourceEvent", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("SourceEvent", "Person")
             it.asMap() shouldBe
                 mapOf("sourceId" to "person2", "id" to 2L, "name" to "mary", "surname" to "doe")
           }

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
@@ -18,6 +18,7 @@ package org.neo4j.connectors.kafka.sink
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.Test
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.connectors.kafka.data.DynamicTypes
 import org.neo4j.connectors.kafka.data.PropertyType
-import org.neo4j.connectors.kafka.data.PropertyType.schema
 import org.neo4j.connectors.kafka.testing.DateSupport
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.createNodeKeyConstraint
@@ -88,7 +88,7 @@ abstract class Neo4jCudIT {
         .get("n")
         .asNode() should
         {
-          it.labels() shouldBe listOf("Foo", "Bar")
+          it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
           it.asMap() shouldBe mapOf("id" to 1L, "foo" to "foo-value")
         }
   }
@@ -118,7 +118,7 @@ abstract class Neo4jCudIT {
         .get("n")
         .asNode() should
         {
-          it.labels() shouldBe listOf("Foo", "Bar")
+          it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
           it.asMap() shouldBe mapOf("id" to 1L, "foo" to "foo-value")
         }
   }
@@ -174,7 +174,7 @@ abstract class Neo4jCudIT {
         .get("n")
         .asNode() should
         {
-          it.labels() shouldBe listOf("Foo", "Bar")
+          it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
           it.asMap() shouldBe
               mapOf(
                   "id" to 1L,
@@ -241,7 +241,7 @@ abstract class Neo4jCudIT {
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).single().get("n").asNode() should
           {
-            it.labels() shouldBe listOf("Foo", "Bar")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
             it.asMap() shouldBe
                 mapOf(
                     "id" to 1L,
@@ -311,7 +311,7 @@ abstract class Neo4jCudIT {
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).single().get("n").asNode() should
           {
-            it.labels() shouldBe listOf("Foo", "Bar")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
             it.asMap() shouldBe
                 mapOf(
                     "id" to 1L,
@@ -611,7 +611,7 @@ abstract class Neo4jCudIT {
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).single().get("n").asNode() should
           {
-            it.labels() shouldBe listOf("Foo", "Bar")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
             it.asMap() shouldBe mapOf("id" to 1L, "foo" to "foo-value-new")
           }
     }
@@ -699,7 +699,7 @@ abstract class Neo4jCudIT {
         .get("n")
         .asNode() should
         {
-          it.labels() shouldBe listOf("Foo", "Bar")
+          it.labels().toList() shouldContainExactlyInAnyOrder listOf("Foo", "Bar")
           it.asMap() shouldBe
               mapOf(
                   "id" to 1L,

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
@@ -18,6 +18,7 @@ package org.neo4j.connectors.kafka.sink
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.nondeterministic.eventually
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import java.math.BigDecimal
@@ -234,7 +235,7 @@ abstract class Neo4jNodePatternIT {
         .get("n")
         .asNode() should
         {
-          it.labels() shouldBe listOf("User", "Person")
+          it.labels().toList() shouldContainExactlyInAnyOrder listOf("User", "Person")
           it.asMap() shouldBe mapOf("id" to 1L, "name" to "john", "surname" to "doe")
         }
   }

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
@@ -19,6 +19,7 @@ package org.neo4j.connectors.kafka.sink
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -546,7 +547,7 @@ abstract class Neo4jRelationshipPatternIT {
 
       result.get("u").asNode() should
           {
-            it.labels() shouldBe listOf("User", "Person")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("User", "Person")
             it.asMap() shouldBe mapOf("id" to 1L)
           }
 
@@ -554,7 +555,7 @@ abstract class Neo4jRelationshipPatternIT {
 
       result.get("p").asNode() should
           {
-            it.labels() shouldBe listOf("Product", "Item")
+            it.labels().toList() shouldContainExactlyInAnyOrder listOf("Product", "Item")
             it.asMap() shouldBe mapOf("id" to 2L)
           }
     }


### PR DESCRIPTION
Updated label assertions to use `shouldContainExactlyInAnyOrder` aiming to eliminate possible test failures because of inconsistent label ordering from the database results.