### PR TITLE
refactor: payload mode owns schema and value generation

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfiguration.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfiguration.kt
@@ -55,7 +55,7 @@ enum class AuthenticationType {
   BASIC,
   KERBEROS,
   BEARER,
-  CUSTOM
+  CUSTOM,
 }
 
 open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val type: ConnectorType) :
@@ -112,7 +112,8 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
               AuthTokens.basic(
                   getString(AUTHENTICATION_BASIC_USERNAME),
                   getPassword(AUTHENTICATION_BASIC_PASSWORD).value(),
-                  getString(AUTHENTICATION_BASIC_REALM))
+                  getString(AUTHENTICATION_BASIC_REALM),
+              )
           AuthenticationType.KERBEROS ->
               AuthTokens.kerberos(getPassword(AUTHENTICATION_KERBEROS_TICKET).value())
           AuthenticationType.BEARER ->
@@ -122,16 +123,14 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
                   getString(AUTHENTICATION_CUSTOM_PRINCIPAL),
                   getPassword(AUTHENTICATION_CUSTOM_CREDENTIALS).value(),
                   getString(AUTHENTICATION_CUSTOM_REALM),
-                  getString(AUTHENTICATION_CUSTOM_SCHEME))
+                  getString(AUTHENTICATION_CUSTOM_SCHEME),
+              )
         }
 
   internal val trustStrategy
     get(): TrustStrategy {
       val strategy: TrustStrategy =
-          when (ConfigUtils.getEnum<Strategy>(
-              this,
-              SECURITY_TRUST_STRATEGY,
-          )) {
+          when (ConfigUtils.getEnum<Strategy>(this, SECURITY_TRUST_STRATEGY)) {
             null -> TrustStrategy.trustSystemCertificates()
             Strategy.TRUST_ALL_CERTIFICATES -> TrustStrategy.trustAllCertificates()
             Strategy.TRUST_SYSTEM_CA_SIGNED_CERTIFICATES -> TrustStrategy.trustSystemCertificates()
@@ -159,13 +158,19 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
 
     config.withUserAgent(userAgent(type.description, userAgentComment()))
     config.withConnectionAcquisitionTimeout(
-        connectionAcquisitionTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        connectionAcquisitionTimeout.inWholeMilliseconds,
+        TimeUnit.MILLISECONDS,
+    )
     config.withConnectionTimeout(connectionTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
     config.withMaxConnectionPoolSize(maxConnectionPoolSize)
     config.withConnectionLivenessCheckTimeout(
-        idleTimeBeforeTest.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        idleTimeBeforeTest.inWholeMilliseconds,
+        TimeUnit.MILLISECONDS,
+    )
     config.withMaxConnectionLifetime(
-        maxConnectionLifetime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        maxConnectionLifetime.inWholeMilliseconds,
+        TimeUnit.MILLISECONDS,
+    )
     config.withMaxTransactionRetryTime(maxRetryTime.inWholeMilliseconds, TimeUnit.MILLISECONDS)
 
     if (uri.none { it.scheme.endsWith("+s", true) || it.scheme.endsWith("+ssc", true) }) {
@@ -195,7 +200,8 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
         when (type) {
           ConnectorType.SOURCE -> AccessMode.READ
           ConnectorType.SINK -> AccessMode.WRITE
-        })
+        }
+    )
 
     return config.build()
   }
@@ -210,7 +216,8 @@ open class Neo4jConfiguration(configDef: ConfigDef, originals: Map<*, *>, val ty
                 if (metadata.isNotEmpty()) {
                   this["metadata"] = metadata
                 }
-              })
+              }
+          )
           .build()
 
   open fun telemetryData(): Map<String, Any> = emptyMap()

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationDeclarations.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationDeclarations.kt
@@ -38,14 +38,16 @@ fun ConfigDef.defineConnectionSettings(): ConfigDef =
               group = Groups.CONNECTION.title
               validator =
                   Validators.uri("neo4j", "neo4j+s", "neo4j+ssc", "bolt", "bolt+s", "bolt+ssc")
-            })
+            }
+        )
         .define(
             ConfigKeyBuilder.of(Neo4jConfiguration.DATABASE, ConfigDef.Type.STRING) {
               importance = Importance.HIGH
               defaultValue = ""
               group = Groups.CONNECTION.title
               validator = ConfigDef.NonNullValidator()
-            })
+            }
+        )
         .define(
             ConfigKeyBuilder.of(Neo4jConfiguration.AUTHENTICATION_TYPE, ConfigDef.Type.STRING) {
               importance = Importance.HIGH
@@ -53,106 +55,143 @@ fun ConfigDef.defineConnectionSettings(): ConfigDef =
               group = Groups.CONNECTION.title
               validator = Validators.enum(AuthenticationType::class.java)
               recommender = Recommenders.enum(AuthenticationType::class.java)
-            })
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_BASIC_USERNAME, ConfigDef.Type.STRING) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.BASIC.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_BASIC_USERNAME,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.BASIC.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_BASIC_PASSWORD, ConfigDef.Type.PASSWORD) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.BASIC.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_BASIC_PASSWORD,
+                ConfigDef.Type.PASSWORD,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.BASIC.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_BASIC_REALM, ConfigDef.Type.STRING) {
-                  importance = Importance.LOW
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.BASIC.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_BASIC_REALM,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.LOW
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.BASIC.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_KERBEROS_TICKET, ConfigDef.Type.PASSWORD) {
-                  group = Groups.CONNECTION.title
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.KERBEROS.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_KERBEROS_TICKET,
+                ConfigDef.Type.PASSWORD,
+            ) {
+              group = Groups.CONNECTION.title
+              importance = Importance.HIGH
+              defaultValue = ""
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.KERBEROS.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_BEARER_TOKEN, ConfigDef.Type.PASSWORD) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.BEARER.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_BEARER_TOKEN,
+                ConfigDef.Type.PASSWORD,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.BEARER.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_CUSTOM_SCHEME, ConfigDef.Type.STRING) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.CUSTOM.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_CUSTOM_SCHEME,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.CUSTOM.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_CUSTOM_PRINCIPAL, ConfigDef.Type.STRING) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.CUSTOM.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_CUSTOM_PRINCIPAL,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.CUSTOM.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_CUSTOM_CREDENTIALS, ConfigDef.Type.PASSWORD) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.CUSTOM.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_CUSTOM_CREDENTIALS,
+                ConfigDef.Type.PASSWORD,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.CUSTOM.toString()),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.AUTHENTICATION_CUSTOM_REALM, ConfigDef.Type.STRING) {
-                  importance = Importance.HIGH
-                  defaultValue = ""
-                  group = Groups.CONNECTION.title
-                  recommender =
-                      Recommenders.visibleIf(
-                          Neo4jConfiguration.AUTHENTICATION_TYPE,
-                          Predicate.isEqual(AuthenticationType.CUSTOM.toString()))
-                })
+                Neo4jConfiguration.AUTHENTICATION_CUSTOM_REALM,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.HIGH
+              defaultValue = ""
+              group = Groups.CONNECTION.title
+              recommender =
+                  Recommenders.visibleIf(
+                      Neo4jConfiguration.AUTHENTICATION_TYPE,
+                      Predicate.isEqual(AuthenticationType.CUSTOM.toString()),
+                  )
+            }
+        )
 
 fun ConfigDef.defineEncryptionSettings(): ConfigDef =
     this.define(
@@ -175,8 +214,11 @@ fun ConfigDef.defineEncryptionSettings(): ConfigDef =
                                 else -> throw ConfigException("Must be a String or a List")
                               }
                             }
-                          }))
-            })
+                          },
+                      ),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(Neo4jConfiguration.SECURITY_TRUST_STRATEGY, ConfigDef.Type.STRING) {
               importance = Importance.LOW
@@ -197,35 +239,47 @@ fun ConfigDef.defineEncryptionSettings(): ConfigDef =
                                 else -> throw ConfigException("Must be a String or a List")
                               }
                             }
-                          }),
+                          },
+                      ),
                       Recommenders.visibleIf(
-                          Neo4jConfiguration.SECURITY_ENCRYPTED, Predicate.isEqual(true)))
-            })
+                          Neo4jConfiguration.SECURITY_ENCRYPTED,
+                          Predicate.isEqual(true),
+                      ),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.SECURITY_HOST_NAME_VERIFICATION_ENABLED, ConfigDef.Type.STRING) {
-                  importance = Importance.LOW
-                  defaultValue = "true"
-                  group = Groups.CONNECTION_TLS.title
-                  validator = Validators.bool()
-                  recommender =
-                      Recommenders.and(
-                          Recommenders.bool(),
-                          Recommenders.visibleIf(
-                              Neo4jConfiguration.URI,
-                              object : Predicate<Any?> {
-                                override fun test(t: Any?): Boolean {
-                                  return when (t) {
-                                    null -> false
-                                    is String -> URI(t).scheme in arrayOf("bolt", "neo4j")
-                                    is List<*> -> t.any { test(it) }
-                                    else -> throw ConfigException("Must be a String or a List")
-                                  }
-                                }
-                              }),
-                          Recommenders.visibleIf(
-                              Neo4jConfiguration.SECURITY_ENCRYPTED, Predicate.isEqual(true)))
-                })
+                Neo4jConfiguration.SECURITY_HOST_NAME_VERIFICATION_ENABLED,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.LOW
+              defaultValue = "true"
+              group = Groups.CONNECTION_TLS.title
+              validator = Validators.bool()
+              recommender =
+                  Recommenders.and(
+                      Recommenders.bool(),
+                      Recommenders.visibleIf(
+                          Neo4jConfiguration.URI,
+                          object : Predicate<Any?> {
+                            override fun test(t: Any?): Boolean {
+                              return when (t) {
+                                null -> false
+                                is String -> URI(t).scheme in arrayOf("bolt", "neo4j")
+                                is List<*> -> t.any { test(it) }
+                                else -> throw ConfigException("Must be a String or a List")
+                              }
+                            }
+                          },
+                      ),
+                      Recommenders.visibleIf(
+                          Neo4jConfiguration.SECURITY_ENCRYPTED,
+                          Predicate.isEqual(true),
+                      ),
+                  )
+            }
+        )
         .define(
             ConfigKeyBuilder.of(Neo4jConfiguration.SECURITY_CERT_FILES, ConfigDef.Type.LIST) {
               importance = Importance.LOW
@@ -245,14 +299,19 @@ fun ConfigDef.defineEncryptionSettings(): ConfigDef =
                                 else -> throw ConfigException("Must be a String or a List")
                               }
                             }
-                          }),
+                          },
+                      ),
                       Recommenders.visibleIf(
-                          Neo4jConfiguration.SECURITY_ENCRYPTED, Predicate.isEqual(true)),
+                          Neo4jConfiguration.SECURITY_ENCRYPTED,
+                          Predicate.isEqual(true),
+                      ),
                       Recommenders.visibleIf(
                           Neo4jConfiguration.SECURITY_TRUST_STRATEGY,
-                          Predicate.isEqual(
-                              Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES.toString())))
-            })
+                          Predicate.isEqual(Strategy.TRUST_CUSTOM_CA_SIGNED_CERTIFICATES.toString()),
+                      ),
+                  )
+            }
+        )
 
 fun ConfigDef.definePoolSettings(): ConfigDef =
     this.define(
@@ -262,55 +321,68 @@ fun ConfigDef.definePoolSettings(): ConfigDef =
                   Config.defaultConfig().connectionTimeoutMillis().milliseconds.toSimpleString()
               group = Groups.CONNECTION_ADVANCED.title
               validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-            })
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE, ConfigDef.Type.INT) {
-                  importance = Importance.LOW
-                  defaultValue = Config.defaultConfig().maxConnectionPoolSize()
-                  group = Groups.CONNECTION_ADVANCED.title
-                  validator = Range.atLeast(1)
-                })
+                Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE,
+                ConfigDef.Type.INT,
+            ) {
+              importance = Importance.LOW
+              defaultValue = Config.defaultConfig().maxConnectionPoolSize()
+              group = Groups.CONNECTION_ADVANCED.title
+              validator = Range.atLeast(1)
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT, ConfigDef.Type.STRING) {
-                  importance = Importance.LOW
-                  defaultValue =
-                      Config.defaultConfig()
-                          .connectionAcquisitionTimeoutMillis()
-                          .milliseconds
-                          .toSimpleString()
-                  group = Groups.CONNECTION_ADVANCED.title
-                  validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.LOW
+              defaultValue =
+                  Config.defaultConfig()
+                      .connectionAcquisitionTimeoutMillis()
+                      .milliseconds
+                      .toSimpleString()
+              group = Groups.CONNECTION_ADVANCED.title
+              validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME, ConfigDef.Type.STRING) {
-                  importance = Importance.LOW
-                  defaultValue =
-                      Config.defaultConfig()
-                          .maxConnectionLifetimeMillis()
-                          .milliseconds
-                          .toSimpleString()
-                  group = Groups.CONNECTION_ADVANCED.title
-                  validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.LOW
+              defaultValue =
+                  Config.defaultConfig().maxConnectionLifetimeMillis().milliseconds.toSimpleString()
+              group = Groups.CONNECTION_ADVANCED.title
+              validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
+            }
+        )
         .define(
             ConfigKeyBuilder.of(
-                Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST, ConfigDef.Type.STRING) {
-                  importance = Importance.LOW
-                  defaultValue = ""
-                  group = Groups.CONNECTION_ADVANCED.title
-                  validator =
-                      Validators.or(Validators.blank(), Validators.pattern(SIMPLE_DURATION_PATTERN))
-                })
+                Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST,
+                ConfigDef.Type.STRING,
+            ) {
+              importance = Importance.LOW
+              defaultValue = ""
+              group = Groups.CONNECTION_ADVANCED.title
+              validator =
+                  Validators.or(Validators.blank(), Validators.pattern(SIMPLE_DURATION_PATTERN))
+            }
+        )
 
 fun ConfigDef.defineRetrySettings(): ConfigDef =
     this.define(
         ConfigKeyBuilder.of(
-            Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT, ConfigDef.Type.STRING) {
-              importance = Importance.LOW
-              defaultValue = Neo4jConfiguration.DEFAULT_MAX_RETRY_DURATION.toSimpleString()
-              group = Groups.CONNECTION_ADVANCED.title
-              validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-            })
+            Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT,
+            ConfigDef.Type.STRING,
+        ) {
+          importance = Importance.LOW
+          defaultValue = Neo4jConfiguration.DEFAULT_MAX_RETRY_DURATION.toSimpleString()
+          group = Groups.CONNECTION_ADVANCED.title
+          validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
+        }
+    )

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/ConfigUtils.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/ConfigUtils.kt
@@ -73,7 +73,7 @@ class ConfigKeyBuilder private constructor(val name: String, val type: ConfigDef
     fun of(
         name: String,
         type: ConfigDef.Type,
-        init: ConfigKeyBuilder.() -> Unit
+        init: ConfigKeyBuilder.() -> Unit,
     ): ConfigDef.ConfigKey {
       val builder = ConfigKeyBuilder(name, type)
       init(builder)

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/Duration.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/Duration.kt
@@ -46,7 +46,8 @@ fun Duration.Companion.parseSimpleString(value: String): Duration {
   val unitIndex = value.indexOfFirst { !it.isDigit() }
   if (unitIndex == -1) {
     throw IllegalArgumentException(
-        "Invalid duration string '$value'. No unit provided. $VALID_UNITS_DESCRIPTION")
+        "Invalid duration string '$value'. No unit provided. $VALID_UNITS_DESCRIPTION"
+    )
   }
   require(unitIndex != 0) { "Missing numeric value: $value" }
 

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/Recommenders.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/Recommenders.kt
@@ -50,7 +50,7 @@ object Recommenders {
     return object : ConfigDef.Recommender {
       override fun validValues(
           name: String?,
-          parsedConfig: MutableMap<String, Any>?
+          parsedConfig: MutableMap<String, Any>?,
       ): MutableList<Any> {
         return values.toMutableList()
       }
@@ -67,7 +67,7 @@ object Recommenders {
     return object : ConfigDef.Recommender {
       override fun validValues(
           name: String?,
-          parsedConfig: MutableMap<String, Any>?
+          parsedConfig: MutableMap<String, Any>?,
       ): MutableList<Any> {
         return values.toMutableList()
       }
@@ -82,7 +82,7 @@ object Recommenders {
     return object : ConfigDef.Recommender, DependentRecommender {
       override fun validValues(
           name: String?,
-          parsedConfig: MutableMap<String, Any>?
+          parsedConfig: MutableMap<String, Any>?,
       ): MutableList<Any> = mutableListOf()
 
       override fun visible(name: String?, parsedConfig: MutableMap<String, Any>?): Boolean {
@@ -99,7 +99,7 @@ object Recommenders {
     return object : ConfigDef.Recommender {
       override fun validValues(
           name: String?,
-          parsedConfig: MutableMap<String, Any>?
+          parsedConfig: MutableMap<String, Any>?,
       ): MutableList<Any> = mutableListOf()
 
       override fun visible(name: String?, parsedConfig: MutableMap<String, Any>?): Boolean {

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/Validators.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/configuration/helpers/Validators.kt
@@ -88,7 +88,10 @@ object Validators {
         if (value is String) {
           if (values.isNotEmpty() && !values.contains(value)) {
             throw ConfigException(
-                name, value, "Must be one of: ${values.joinToString { "'$it'" }}.")
+                name,
+                value,
+                "Must be one of: ${values.joinToString { "'$it'" }}.",
+            )
           }
         } else if (value is List<*>) {
           value.forEach { ensureValid(name, it) }
@@ -101,7 +104,8 @@ object Validators {
 
   fun <T : Enum<T>> enum(cls: Class<T>, vararg exclude: T): ConfigDef.Validator {
     return string(
-        *cls.enumConstants.filterNot { exclude.contains(it) }.map { it.name }.toTypedArray())
+        *cls.enumConstants.filterNot { exclude.contains(it) }.map { it.name }.toTypedArray()
+    )
   }
 
   fun bool(): ConfigDef.Validator {
@@ -142,7 +146,10 @@ object Validators {
 
               if (schemes.isNotEmpty() && !schemes.contains(parsed.scheme)) {
                 throw ConfigException(
-                    name, value, "Scheme must be one of: ${schemes.joinToString { "'$it'" }}.")
+                    name,
+                    value,
+                    "Scheme must be one of: ${schemes.joinToString { "'$it'" }}.",
+                )
               }
             } catch (t: URISyntaxException) {
               throw ConfigException(name, value, "Must be a valid URI: ${t.message}")
@@ -189,18 +196,21 @@ object Validators {
     this.configValues()
         .first { it.name() == name }
         .let { config ->
-          if (config.visible() &&
-              (when (val value = config.value()) {
-                null -> true
-                is Int -> false
-                is Boolean -> false
-                is String -> value.isEmpty()
-                is Password -> value.value().isNullOrEmpty()
-                is List<*> -> value.isEmpty()
-                else ->
-                    throw IllegalArgumentException(
-                        "unexpected value '$value' for configuration $name")
-              })) {
+          if (
+              config.visible() &&
+                  (when (val value = config.value()) {
+                    null -> true
+                    is Int -> false
+                    is Boolean -> false
+                    is String -> value.isEmpty()
+                    is Password -> value.value().isNullOrEmpty()
+                    is List<*> -> value.isEmpty()
+                    else ->
+                        throw IllegalArgumentException(
+                            "unexpected value '$value' for configuration $name"
+                        )
+                  })
+          ) {
             config.addErrorMessage("Invalid value for configuration $name: Must not be blank.")
           }
         }

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/ChangeEventExtensions.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/ChangeEventExtensions.kt
@@ -57,7 +57,8 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
         it.put("seq", changeEvent.seq.toLong())
         it.put(
             "metadata",
-            metadataToConnectValue(changeEvent.metadata, schema.field("metadata").schema()))
+            metadataToConnectValue(changeEvent.metadata, schema.field("metadata").schema()),
+        )
         it.put("event", eventToConnectValue(changeEvent.event, schema.field("event").schema()))
       }
 
@@ -73,16 +74,23 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
           .field(
               "txStartTime",
               if (payloadMode == PayloadMode.EXTENDED) PropertyType.schema
-              else SimpleTypes.ZONEDDATETIME.schema)
+              else SimpleTypes.ZONEDDATETIME.schema,
+          )
           .field(
               "txCommitTime",
               if (payloadMode == PayloadMode.EXTENDED) PropertyType.schema
-              else SimpleTypes.ZONEDDATETIME.schema)
+              else SimpleTypes.ZONEDDATETIME.schema,
+          )
           .field(
               "txMetadata",
               toConnectSchema(
-                      payloadMode, metadata.txMetadata, optional = true, forceMapsAsStruct = true)
-                  .schema())
+                      payloadMode,
+                      metadata.txMetadata,
+                      optional = true,
+                      forceMapsAsStruct = true,
+                  )
+                  .schema(),
+          )
           .also {
             metadata.additionalEntries.forEach { entry ->
               it.field(entry.key, toConnectSchema(payloadMode, entry.value, optional = true))
@@ -104,20 +112,27 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
             DynamicTypes.toConnectValue(
                 if (payloadMode == PayloadMode.EXTENDED) PropertyType.schema
                 else SimpleTypes.ZONEDDATETIME.schema,
-                metadata.txStartTime))
+                metadata.txStartTime,
+            ),
+        )
         it.put(
             "txCommitTime",
             DynamicTypes.toConnectValue(
                 if (payloadMode == PayloadMode.EXTENDED) PropertyType.schema
                 else SimpleTypes.ZONEDDATETIME.schema,
-                metadata.txCommitTime))
+                metadata.txCommitTime,
+            ),
+        )
         it.put(
             "txMetadata",
-            DynamicTypes.toConnectValue(schema.field("txMetadata").schema(), metadata.txMetadata))
+            DynamicTypes.toConnectValue(schema.field("txMetadata").schema(), metadata.txMetadata),
+        )
 
         metadata.additionalEntries.forEach { entry ->
           it.put(
-              entry.key, DynamicTypes.toConnectValue(schema.field(entry.key).schema(), entry.value))
+              entry.key,
+              DynamicTypes.toConnectValue(schema.field(entry.key).schema(), entry.value),
+          )
         }
       }
 
@@ -127,7 +142,8 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
         is RelationshipEvent -> relationshipEventToConnectSchema(event)
         else ->
             throw IllegalArgumentException(
-                "unsupported event type in change data: ${event.javaClass.name}")
+                "unsupported event type in change data: ${event.javaClass.name}"
+            )
       }
 
   private fun eventToConnectValue(event: Event, schema: Schema): Struct =
@@ -158,7 +174,8 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
         it.put("keys", keys)
         it.put(
             "state",
-            nodeStateValue(schema.field("state").schema(), nodeEvent.before, nodeEvent.after))
+            nodeStateValue(schema.field("state").schema(), nodeEvent.before, nodeEvent.after),
+        )
       }
 
   internal fun relationshipEventToConnectSchema(relationshipEvent: RelationshipEvent): Schema =
@@ -171,12 +188,14 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
           .field("end", nodeToConnectSchema(relationshipEvent.end))
           .field("keys", schemaForKeys(relationshipEvent.keys))
           .field(
-              "state", relationshipStateSchema(relationshipEvent.before, relationshipEvent.after))
+              "state",
+              relationshipStateSchema(relationshipEvent.before, relationshipEvent.after),
+          )
           .build()
 
   internal fun relationshipEventToConnectValue(
       relationshipEvent: RelationshipEvent,
-      schema: Schema
+      schema: Schema,
   ): Struct =
       Struct(schema).also {
         val keys =
@@ -192,7 +211,11 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
         it.put(
             "state",
             relationshipStateValue(
-                schema.field("state").schema(), relationshipEvent.before, relationshipEvent.after))
+                schema.field("state").schema(),
+                relationshipEvent.before,
+                relationshipEvent.after,
+            ),
+        )
       }
 
   internal fun nodeToConnectSchema(node: Node): Schema {
@@ -231,13 +254,19 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                         field(
                             it.key,
                             toConnectSchema(
-                                payloadMode, it.value, optional = true, forceMapsAsStruct = true))
+                                payloadMode,
+                                it.value,
+                                optional = true,
+                                forceMapsAsStruct = true,
+                            ),
+                        )
                       }
                     }
                   }
                 }
                 .optional()
-                .build())
+                .build()
+        )
         .optional()
         .build()
   }
@@ -260,11 +289,13 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                               if (it.field(entry.key) == null) {
                                 it.field(
                                     entry.key,
-                                    toConnectSchema(payloadMode, entry.value, optional = true))
+                                    toConnectSchema(payloadMode, entry.value, optional = true),
+                                )
                               }
                             }
                           }
-                          .build())
+                          .build(),
+              )
             }
             .optional()
             .build()
@@ -287,8 +318,12 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                         }
                     else
                         DynamicTypes.toConnectValue(
-                            it.schema().field("properties").schema(), before.properties))
-              })
+                            it.schema().field("properties").schema(),
+                            before.properties,
+                        ),
+                )
+              },
+          )
         }
 
         if (after != null) {
@@ -304,14 +339,18 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                         }
                     else
                         DynamicTypes.toConnectValue(
-                            it.schema().field("properties").schema(), after.properties))
-              })
+                            it.schema().field("properties").schema(),
+                            after.properties,
+                        ),
+                )
+              },
+          )
         }
       }
 
   private fun relationshipStateSchema(
       before: RelationshipState?,
-      after: RelationshipState?
+      after: RelationshipState?,
   ): Schema {
     val stateSchema =
         SchemaBuilder.struct()
@@ -329,11 +368,13 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                               if (it.field(entry.key) == null) {
                                 it.field(
                                     entry.key,
-                                    toConnectSchema(payloadMode, entry.value, optional = true))
+                                    toConnectSchema(payloadMode, entry.value, optional = true),
+                                )
                               }
                             }
                           }
-                          .build())
+                          .build(),
+              )
             }
             .optional()
             .build()
@@ -344,7 +385,7 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
   private fun relationshipStateValue(
       schema: Schema,
       before: RelationshipState?,
-      after: RelationshipState?
+      after: RelationshipState?,
   ): Struct =
       Struct(schema).apply {
         if (before != null) {
@@ -359,8 +400,12 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                         }
                     else
                         DynamicTypes.toConnectValue(
-                            it.schema().field("properties").schema(), before.properties))
-              })
+                            it.schema().field("properties").schema(),
+                            before.properties,
+                        ),
+                )
+              },
+          )
         }
 
         if (after != null) {
@@ -375,8 +420,12 @@ class ChangeEventConverter(private val payloadMode: PayloadMode = PayloadMode.EX
                         }
                     else
                         DynamicTypes.toConnectValue(
-                            it.schema().field("properties").schema(), after.properties))
-              })
+                            it.schema().field("properties").schema(),
+                            after.properties,
+                        ),
+                )
+              },
+          )
         }
       }
 }
@@ -388,14 +437,12 @@ fun SchemaAndValue.extractEventSchema(): Schema {
 fun SchemaAndValue.extractEventValue(): Struct {
   val value = this.value()
   if (value !is Struct) {
-    throw IllegalArgumentException(
-        "expected value to be a struct, but got: ${value?.javaClass}",
-    )
+    throw IllegalArgumentException("expected value to be a struct, but got: ${value?.javaClass}")
   }
   val eventData = value.get("event")
   if (eventData !is Struct) {
     throw IllegalArgumentException(
-        "expected event attribute to be a struct, but got: ${value.javaClass}",
+        "expected event attribute to be a struct, but got: ${value.javaClass}"
     )
   }
   return eventData
@@ -452,11 +499,14 @@ internal fun Struct.toRelationshipEvent(): RelationshipEvent =
           getStruct("start").toNode(),
           getStruct("end").toNode(),
           DynamicTypes.fromConnectValue(
-              schema().field("keys").schema(), get("keys"), skipNullValuesInMaps = true)
-              as List<Map<String, Any>>?,
+              schema().field("keys").schema(),
+              get("keys"),
+              skipNullValuesInMaps = true,
+          ) as List<Map<String, Any>>?,
           EntityOperation.valueOf(getString("operation")),
           before,
-          after)
+          after,
+      )
     }
 
 @Suppress("UNCHECKED_CAST", "IMPLICIT_CAST_TO_ANY")
@@ -507,7 +557,7 @@ internal fun Struct.toRelationshipState(): Pair<RelationshipState?, Relationship
               }
           RelationshipState(
               DynamicTypes.fromConnectValue(propertiesField.schema(), properties, true)
-                  as Map<String, Any?>,
+                  as Map<String, Any?>
           )
         },
         getStruct("after")?.let {
@@ -520,7 +570,7 @@ internal fun Struct.toRelationshipState(): Pair<RelationshipState?, Relationship
               }
           RelationshipState(
               DynamicTypes.fromConnectValue(propertiesField.schema(), properties, true)
-                  as Map<String, Any?>,
+                  as Map<String, Any?>
           )
         },
     )

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/Headers.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/Headers.kt
@@ -32,7 +32,8 @@ object Headers {
       listOf(
           ConnectHeader(KEY_CDC_ID, SchemaAndValue(Schema.STRING_SCHEMA, event.id.id)),
           ConnectHeader(KEY_CDC_TX_ID, SchemaAndValue(Schema.INT64_SCHEMA, event.txId)),
-          ConnectHeader(KEY_CDC_TX_SEQ, SchemaAndValue(Schema.INT32_SCHEMA, event.seq)))
+          ConnectHeader(KEY_CDC_TX_SEQ, SchemaAndValue(Schema.INT32_SCHEMA, event.seq)),
+      )
 }
 
 fun SinkRecord.isCdcMessage(): Boolean =

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/PropertyConstraints.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/PropertyConstraints.kt
@@ -30,26 +30,28 @@ enum class ConstraintType(val value: String) {
   NODE_EXISTENCE("NODE_PROPERTY_EXISTENCE"),
   RELATIONSHIP_KEY("RELATIONSHIP_KEY"),
   RELATIONSHIP_UNIQUENESS("RELATIONSHIP_UNIQUENESS"),
-  RELATIONSHIP_EXISTENCE("RELATIONSHIP_PROPERTY_EXISTENCE")
+  RELATIONSHIP_EXISTENCE("RELATIONSHIP_PROPERTY_EXISTENCE"),
 }
 
 val NODE_CONSTRAINTS =
     listOf(
         ConstraintType.NODE_KEY.value,
         ConstraintType.NODE_UNIQUENESS.value,
-        ConstraintType.NODE_EXISTENCE.value)
+        ConstraintType.NODE_EXISTENCE.value,
+    )
 
 val RELATIONSHIP_CONSTRAINTS =
     listOf(
         ConstraintType.RELATIONSHIP_KEY.value,
         ConstraintType.RELATIONSHIP_UNIQUENESS.value,
-        ConstraintType.RELATIONSHIP_EXISTENCE.value)
+        ConstraintType.RELATIONSHIP_EXISTENCE.value,
+    )
 
 data class ConstraintData(
     val entityType: String,
     val constraintType: String,
     val labelOrType: String,
-    val properties: List<String>
+    val properties: List<String>,
 )
 
 fun fetchConstraintData(driver: Driver, sessionConfig: SessionConfig): List<ConstraintData> {
@@ -63,7 +65,8 @@ fun fetchConstraintData(driver: Driver, sessionConfig: SessionConfig): List<Cons
                 entityType = it.get("entityType").asString(),
                 constraintType = it.get("type").asString(),
                 labelOrType = it.get("labelsOrTypes").asList()[0].toString(),
-                properties = it.get("properties").asList().map { property -> property.toString() })
+                properties = it.get("properties").asList().map { property -> property.toString() },
+            )
           }
     }
   } catch (e: Exception) {

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/PropertyType.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/PropertyType.kt
@@ -75,7 +75,8 @@ object PropertyType {
           ZONED_DATE_TIME,
           OFFSET_TIME,
           DURATION,
-          POINT)
+          POINT,
+      )
   private val LIST_TYPE_FIELDS =
       listOf(
           BOOLEAN_LIST,
@@ -88,7 +89,8 @@ object PropertyType {
           ZONED_DATE_TIME_LIST,
           OFFSET_TIME_LIST,
           DURATION_LIST,
-          POINT_LIST)
+          POINT_LIST,
+      )
 
   internal val durationSchema: Schema =
       SchemaBuilder(Schema.Type.STRUCT)
@@ -198,7 +200,8 @@ object PropertyType {
           return asList(value, elementType)
         }
         throw IllegalArgumentException(
-            "collections with multiple element types are not supported: ${elementTypes.joinToString { it?.java?.name ?: "null" }}")
+            "collections with multiple element types are not supported: ${elementTypes.joinToString { it?.java?.name ?: "null" }}"
+        )
       }
       else -> throw IllegalArgumentException("unsupported property type: ${value.javaClass.name}")
     }
@@ -217,27 +220,33 @@ object PropertyType {
       LocalDate::class ->
           getPropertyStruct(
               LOCAL_DATE_LIST,
-              (value as List<LocalDate>).map { DateTimeFormatter.ISO_DATE.format(it) })
+              (value as List<LocalDate>).map { DateTimeFormatter.ISO_DATE.format(it) },
+          )
       LocalDateTime::class ->
           getPropertyStruct(
               LOCAL_DATE_TIME_LIST,
-              (value as List<LocalDateTime>).map { DateTimeFormatter.ISO_DATE_TIME.format(it) })
+              (value as List<LocalDateTime>).map { DateTimeFormatter.ISO_DATE_TIME.format(it) },
+          )
       LocalTime::class ->
           getPropertyStruct(
               LOCAL_TIME_LIST,
-              (value as List<LocalTime>).map { DateTimeFormatter.ISO_TIME.format(it) })
+              (value as List<LocalTime>).map { DateTimeFormatter.ISO_TIME.format(it) },
+          )
       OffsetDateTime::class ->
           getPropertyStruct(
               ZONED_DATE_TIME_LIST,
-              (value as List<OffsetDateTime>).map { DateTimeFormatter.ISO_DATE_TIME.format(it) })
+              (value as List<OffsetDateTime>).map { DateTimeFormatter.ISO_DATE_TIME.format(it) },
+          )
       ZonedDateTime::class ->
           getPropertyStruct(
               ZONED_DATE_TIME_LIST,
-              (value as List<ZonedDateTime>).map { DateTimeFormatter.ISO_DATE_TIME.format(it) })
+              (value as List<ZonedDateTime>).map { DateTimeFormatter.ISO_DATE_TIME.format(it) },
+          )
       OffsetTime::class ->
           getPropertyStruct(
               OFFSET_TIME_LIST,
-              (value as List<OffsetTime>).map { DateTimeFormatter.ISO_TIME.format(it) })
+              (value as List<OffsetTime>).map { DateTimeFormatter.ISO_TIME.format(it) },
+          )
       else -> {
         if (IsoDuration::class.java.isAssignableFrom(componentType.java)) {
           getPropertyStruct(
@@ -250,7 +259,8 @@ object PropertyType {
                         .put(DAYS, it.days())
                         .put(SECONDS, it.seconds())
                         .put(NANOS, it.nanoseconds())
-                  })
+                  },
+          )
         } else if (Point::class.java.isAssignableFrom(componentType.java)) {
           getPropertyStruct(
               POINT_LIST,
@@ -267,10 +277,12 @@ object PropertyType {
                             it.put(Z, point.z())
                           }
                         }
-                  })
+                  },
+          )
         } else {
           throw IllegalArgumentException(
-              "unsupported array type: array of ${componentType.java.name}")
+              "unsupported array type: array of ${componentType.java.name}"
+          )
         }
       }
     }
@@ -291,7 +303,8 @@ object PropertyType {
               is ByteBuffer -> bytes.array()
               else ->
                   throw IllegalArgumentException(
-                      "unsupported BYTES value: ${bytes?.javaClass?.name}")
+                      "unsupported BYTES value: ${bytes?.javaClass?.name}"
+                  )
             }
           }
           LOCAL_DATE -> parseLocalDate(it.getWithoutDefault(LOCAL_DATE) as String)
@@ -303,7 +316,8 @@ object PropertyType {
           POINT -> toPoint(it.getWithoutDefault(POINT) as Struct)
           else ->
               throw IllegalArgumentException(
-                  "unsupported simple type: $fieldType: ${it.getWithoutDefault(fieldType)?.javaClass?.name}")
+                  "unsupported simple type: $fieldType: ${it.getWithoutDefault(fieldType)?.javaClass?.name}"
+              )
         }
       }
 
@@ -324,7 +338,8 @@ object PropertyType {
             POINT_LIST -> (fieldValue as List<Struct>).map { s -> toPoint(s) }
             else ->
                 throw IllegalArgumentException(
-                    "unsupported list type: ${fieldType}: ${fieldValue.javaClass.name}")
+                    "unsupported list type: ${fieldType}: ${fieldValue.javaClass.name}"
+                )
           }
         }
       }
@@ -376,12 +391,7 @@ object PropertyType {
       when (val dimension = s.getInt8(DIMENSION)) {
         TWO_D -> Values.point(s.getInt32(SR_ID), s.getFloat64(X), s.getFloat64(Y))
         THREE_D ->
-            Values.point(
-                s.getInt32(SR_ID),
-                s.getFloat64(X),
-                s.getFloat64(Y),
-                s.getFloat64(Z),
-            )
+            Values.point(s.getInt32(SR_ID), s.getFloat64(X), s.getFloat64(Y), s.getFloat64(Z))
         else -> throw IllegalArgumentException("unsupported dimension value ${dimension}")
       }.asPoint()
 }

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/StreamsTransactionEventExtensions.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/StreamsTransactionEventExtensions.kt
@@ -58,7 +58,8 @@ object StreamsTransactionEventExtensions {
             ZonedDateTime.ofInstant(Instant.ofEpochMilli(this.meta.timestamp), ZoneOffset.UTC),
             ZonedDateTime.ofInstant(Instant.ofEpochMilli(this.meta.timestamp), ZoneOffset.UTC),
             emptyMap(),
-            emptyMap())
+            emptyMap(),
+        )
     val cdcEvent =
         when (val payload = this.payload) {
           is NodePayload -> {
@@ -97,7 +98,8 @@ object StreamsTransactionEventExtensions {
                       if (label != null) {
                         this[label] = listOf(payload.start.ids)
                       }
-                    }),
+                    },
+                ),
                 Node(
                     payload.end.id,
                     payload.end.labels ?: emptyList(),
@@ -106,11 +108,13 @@ object StreamsTransactionEventExtensions {
                       if (label != null) {
                         this[label] = listOf(payload.end.ids)
                       }
-                    }),
+                    },
+                ),
                 emptyList(),
                 cdcOperation,
                 before,
-                after)
+                after,
+            )
           }
           else ->
               throw IllegalArgumentException("unexpected payload type ${payload.javaClass.name}")
@@ -121,7 +125,8 @@ object StreamsTransactionEventExtensions {
         this.meta.txId,
         this.meta.txEventId,
         cdcMetadata,
-        cdcEvent)
+        cdcEvent,
+    )
   }
 
   private fun <T : State> extractState(event: StreamsTransactionEvent, before: T?, after: T?): T {

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/ValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/ValueConverter.kt
@@ -14,19 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.connectors.kafka.configuration
+package org.neo4j.connectors.kafka.data
 
 import org.apache.kafka.connect.data.Schema
-import org.neo4j.connectors.kafka.data.ValueConverter
-import org.neo4j.connectors.kafka.data.converter.CompactValueConverter
-import org.neo4j.connectors.kafka.data.converter.ExtendedValueConverter
 
-enum class PayloadMode(private val converter: ValueConverter) : ValueConverter {
-  EXTENDED(ExtendedValueConverter()),
-  COMPACT(CompactValueConverter());
+interface ValueConverter {
 
-  override fun schema(value: Any?, optional: Boolean, forceMapsAsStruct: Boolean): Schema =
-      converter.schema(value, optional, forceMapsAsStruct)
+  fun schema(value: Any?, optional: Boolean = false, forceMapsAsStruct: Boolean = false): Schema
 
-  override fun value(schema: Schema, value: Any?): Any? = converter.value(schema, value)
+  fun value(schema: Schema, value: Any?): Any?
 }

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.data.converter
+
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.neo4j.connectors.kafka.data.DAYS
+import org.neo4j.connectors.kafka.data.DIMENSION
+import org.neo4j.connectors.kafka.data.DynamicTypes.notNullOrEmpty
+import org.neo4j.connectors.kafka.data.MONTHS
+import org.neo4j.connectors.kafka.data.NANOS
+import org.neo4j.connectors.kafka.data.SECONDS
+import org.neo4j.connectors.kafka.data.SR_ID
+import org.neo4j.connectors.kafka.data.SimpleTypes
+import org.neo4j.connectors.kafka.data.THREE_D
+import org.neo4j.connectors.kafka.data.TWO_D
+import org.neo4j.connectors.kafka.data.ValueConverter
+import org.neo4j.connectors.kafka.data.X
+import org.neo4j.connectors.kafka.data.Y
+import org.neo4j.connectors.kafka.data.Z
+import org.neo4j.driver.types.IsoDuration
+import org.neo4j.driver.types.Node
+import org.neo4j.driver.types.Point
+import org.neo4j.driver.types.Relationship
+
+class CompactValueConverter : ValueConverter {
+
+  override fun schema(value: Any?, optional: Boolean, forceMapsAsStruct: Boolean): Schema {
+    return when (value) {
+      null -> SimpleTypes.NULL.schema(true)
+      is Boolean -> SimpleTypes.BOOLEAN.schema(optional)
+      is Float,
+      is Double -> SimpleTypes.FLOAT.schema(optional)
+
+      is Number -> SimpleTypes.LONG.schema(optional)
+      is Char,
+      is CharArray,
+      is CharSequence -> SimpleTypes.STRING.schema(optional)
+
+      is ByteBuffer,
+      is ByteArray -> SimpleTypes.BYTES.schema(optional)
+
+      is ShortArray,
+      is IntArray,
+      is LongArray ->
+          SchemaBuilder.array(Schema.INT64_SCHEMA).apply { if (optional) optional() }.build()
+
+      is FloatArray,
+      is DoubleArray ->
+          SchemaBuilder.array(Schema.FLOAT64_SCHEMA).apply { if (optional) optional() }.build()
+
+      is BooleanArray ->
+          SchemaBuilder.array(Schema.BOOLEAN_SCHEMA).apply { if (optional) optional() }.build()
+
+      is Array<*> -> {
+        val first = value.firstOrNull { it.notNullOrEmpty() }
+        val schema = schema(first, optional, forceMapsAsStruct)
+        SchemaBuilder.array(schema).apply { if (optional) optional() }.build()
+      }
+
+      is LocalDate -> SimpleTypes.LOCALDATE.schema(optional)
+      is LocalDateTime -> SimpleTypes.LOCALDATETIME.schema(optional)
+      is LocalTime -> SimpleTypes.LOCALTIME.schema(optional)
+      is OffsetDateTime -> SimpleTypes.ZONEDDATETIME.schema(optional)
+      is ZonedDateTime -> SimpleTypes.ZONEDDATETIME.schema(optional)
+      is OffsetTime -> SimpleTypes.OFFSETTIME.schema(optional)
+      is IsoDuration -> SimpleTypes.DURATION.schema(optional)
+      is Point -> SimpleTypes.POINT.schema(optional)
+      is Node ->
+          SchemaBuilder.struct()
+              .apply {
+                field("<id>", SimpleTypes.LONG.schema())
+                field("<labels>", SchemaBuilder.array(SimpleTypes.STRING.schema()).build())
+                value.keys().forEach {
+                  field(it, schema(value.get(it).asObject(), optional, forceMapsAsStruct))
+                }
+                if (optional) optional()
+              }
+              .build()
+
+      is Relationship ->
+          SchemaBuilder.struct()
+              .apply {
+                field("<id>", SimpleTypes.LONG.schema())
+                field("<type>", SimpleTypes.STRING.schema())
+                field("<start.id>", SimpleTypes.LONG.schema())
+                field("<end.id>", SimpleTypes.LONG.schema())
+                value.keys().forEach {
+                  field(it, schema(value.get(it).asObject(), optional, forceMapsAsStruct))
+                }
+                if (optional) optional()
+              }
+              .build()
+
+      is Collection<*> -> {
+        val nonEmptyElementTypes =
+            value.filter { it.notNullOrEmpty() }.map { schema(it, optional, forceMapsAsStruct) }
+        when (nonEmptyElementTypes.toSet().size) {
+          0 ->
+              SchemaBuilder.array(SimpleTypes.NULL.schema(true))
+                  .apply { if (optional) optional() }
+                  .build()
+
+          1 ->
+              SchemaBuilder.array(nonEmptyElementTypes.first())
+                  .apply { if (optional) optional() }
+                  .build()
+
+          else ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEachIndexed { i, v ->
+                      this.field("e${i}", schema(v, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+        }
+      }
+
+      is Map<*, *> -> {
+        val elementTypes =
+            value
+                .mapKeys {
+                  when (val key = it.key) {
+                    is String -> key
+                    else ->
+                        throw IllegalArgumentException(
+                            "unsupported map key type ${key?.javaClass?.name}"
+                        )
+                  }
+                }
+                .filter { e -> e.value.notNullOrEmpty() }
+                .mapValues { e -> schema(e.value, optional, forceMapsAsStruct) }
+        val valueSet = elementTypes.values.toSet()
+        when {
+          valueSet.isEmpty() ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEach {
+                      this.field(it.key as String, schema(it.value, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+
+          valueSet.singleOrNull() != null && !forceMapsAsStruct ->
+              SchemaBuilder.map(Schema.STRING_SCHEMA, elementTypes.values.first())
+                  .apply { if (optional) optional() }
+                  .build()
+
+          else ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEach {
+                      this.field(it.key as String, schema(it.value, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+        }
+      }
+
+      else -> throw IllegalArgumentException("unsupported type ${value.javaClass.name}")
+    }
+  }
+
+  override fun value(schema: Schema, value: Any?): Any? {
+    if (value == null) {
+      return null
+    }
+
+    return when (schema.type()) {
+      Schema.Type.BYTES ->
+          when (value) {
+            is ByteArray -> value
+            is ByteBuffer -> value.array()
+            else -> throw IllegalArgumentException("unsupported bytes type ${value.javaClass.name}")
+          }
+
+      Schema.Type.ARRAY ->
+          when (value) {
+            is Collection<*> -> value.map { value(schema.valueSchema(), it) }
+            is Array<*> -> value.map { value(schema.valueSchema(), it) }.toList()
+            is ShortArray -> value.map { s -> s.toLong() }.toList()
+            is IntArray -> value.map { i -> i.toLong() }.toList()
+            is FloatArray -> value.map { f -> f.toDouble() }.toList()
+            is BooleanArray -> value.toList()
+            is LongArray -> value.toList()
+            is DoubleArray -> value.toList()
+            else -> throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
+          }
+
+      Schema.Type.MAP ->
+          when (value) {
+            is Map<*, *> -> value.mapValues { value(schema.valueSchema(), it.value) }
+            else -> throw IllegalArgumentException("unsupported map type ${value.javaClass.name}")
+          }
+
+      Schema.Type.STRUCT ->
+          when (value) {
+            is IsoDuration ->
+                Struct(schema)
+                    .put(MONTHS, value.months())
+                    .put(DAYS, value.days())
+                    .put(SECONDS, value.seconds())
+                    .put(NANOS, value.nanoseconds())
+
+            is Point ->
+                Struct(schema).put(SR_ID, value.srid()).put(X, value.x()).put(Y, value.y()).also {
+                  it.put(DIMENSION, if (value.z().isNaN()) TWO_D else THREE_D)
+                  if (!value.z().isNaN()) {
+                    it.put(Z, value.z())
+                  }
+                }
+
+            is Node ->
+                Struct(schema).apply {
+                  put("<id>", value.id())
+                  put("<labels>", value.labels())
+                  value
+                      .asMap { it.asObject() }
+                      .forEach { e -> put(e.key, value(schema.field(e.key).schema(), e.value)) }
+                }
+
+            is Relationship ->
+                Struct(schema).apply {
+                  put("<id>", value.id())
+                  put("<type>", value.type())
+                  put("<start.id>", value.startNodeId())
+                  put("<end.id>", value.endNodeId())
+                  value
+                      .asMap { it.asObject() }
+                      .forEach { e -> put(e.key, value(schema.field(e.key).schema(), e.value)) }
+                }
+
+            is Map<*, *> ->
+                Struct(schema).apply {
+                  schema.fields().forEach { put(it.name(), value(it.schema(), value[it.name()])) }
+                }
+
+            is Collection<*> ->
+                Struct(schema).apply {
+                  schema.fields().forEach {
+                    put(
+                        it.name(),
+                        value(it.schema(), value.elementAt(it.name().substring(1).toInt())),
+                    )
+                  }
+                }
+
+            else ->
+                throw IllegalArgumentException("unsupported struct type ${value.javaClass.name}")
+          }
+
+      Schema.Type.STRING ->
+          when (value) {
+            is LocalDate -> DateTimeFormatter.ISO_DATE.format(value)
+            is LocalDateTime -> DateTimeFormatter.ISO_DATE_TIME.format(value)
+            is LocalTime -> DateTimeFormatter.ISO_TIME.format(value)
+            is OffsetDateTime -> DateTimeFormatter.ISO_DATE_TIME.format(value)
+            is ZonedDateTime -> DateTimeFormatter.ISO_DATE_TIME.format(value)
+            is OffsetTime -> DateTimeFormatter.ISO_TIME.format(value)
+            is String -> value
+            is Char -> value.toString()
+            is CharArray -> String(value)
+            else ->
+                throw IllegalArgumentException("unsupported string type ${value.javaClass.name}")
+          }
+
+      Schema.Type.INT64,
+      Schema.Type.FLOAT64 ->
+          when (value) {
+            is Float -> value.toDouble()
+            is Double -> value
+            is Number -> value.toLong()
+            else ->
+                throw IllegalArgumentException("unsupported numeric type ${value.javaClass.name}")
+          }
+
+      else -> value
+    }
+  }
+}

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/ExtendedValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/ExtendedValueConverter.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.data.converter
+
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZonedDateTime
+import kotlin.reflect.KClass
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.neo4j.connectors.kafka.data.DAYS
+import org.neo4j.connectors.kafka.data.DIMENSION
+import org.neo4j.connectors.kafka.data.DynamicTypes.notNullOrEmpty
+import org.neo4j.connectors.kafka.data.MONTHS
+import org.neo4j.connectors.kafka.data.NANOS
+import org.neo4j.connectors.kafka.data.PropertyType
+import org.neo4j.connectors.kafka.data.SECONDS
+import org.neo4j.connectors.kafka.data.SR_ID
+import org.neo4j.connectors.kafka.data.THREE_D
+import org.neo4j.connectors.kafka.data.TWO_D
+import org.neo4j.connectors.kafka.data.ValueConverter
+import org.neo4j.connectors.kafka.data.X
+import org.neo4j.connectors.kafka.data.Y
+import org.neo4j.connectors.kafka.data.Z
+import org.neo4j.driver.types.IsoDuration
+import org.neo4j.driver.types.Node
+import org.neo4j.driver.types.Point
+import org.neo4j.driver.types.Relationship
+
+class ExtendedValueConverter : ValueConverter {
+
+  override fun schema(value: Any?, optional: Boolean, forceMapsAsStruct: Boolean): Schema {
+    return when (value) {
+      null -> PropertyType.schema
+      is Boolean,
+      is Float,
+      is Double,
+      is Number,
+      is Char,
+      is LocalDate,
+      is LocalDateTime,
+      is LocalTime,
+      is OffsetDateTime,
+      is ZonedDateTime,
+      is OffsetTime,
+      is IsoDuration,
+      is Point,
+      is CharArray,
+      is CharSequence,
+      is ByteBuffer,
+      is ByteArray,
+      is ShortArray,
+      is IntArray,
+      is LongArray,
+      is FloatArray,
+      is DoubleArray,
+      is BooleanArray -> PropertyType.schema
+
+      is Array<*> ->
+          if (value::class.java.componentType.kotlin.isSimplePropertyType()) {
+            PropertyType.schema
+          } else {
+            val first = value.firstOrNull { it.notNullOrEmpty() }
+            val schema = schema(first, optional, forceMapsAsStruct)
+            SchemaBuilder.array(schema).apply { if (optional) optional() }.build()
+          }
+
+      is Node ->
+          SchemaBuilder.struct()
+              .apply {
+                field("<id>", Schema.INT64_SCHEMA)
+                field("<labels>", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+
+                value.keys().forEach { field(it, PropertyType.schema) }
+
+                if (optional) optional()
+              }
+              .build()
+
+      is Relationship ->
+          SchemaBuilder.struct()
+              .apply {
+                field("<id>", Schema.INT64_SCHEMA)
+                field("<type>", Schema.STRING_SCHEMA)
+                field("<start.id>", Schema.INT64_SCHEMA)
+                field("<end.id>", Schema.INT64_SCHEMA)
+
+                value.keys().forEach { field(it, PropertyType.schema) }
+
+                if (optional) optional()
+              }
+              .build()
+
+      is Collection<*> -> {
+        val elementTypes = value.map { it?.javaClass?.kotlin }.toSet()
+        if (elementTypes.isEmpty()) {
+          return PropertyType.schema
+        }
+
+        val elementType = elementTypes.singleOrNull()
+        if (elementType != null && elementType.isSimplePropertyType()) {
+          return PropertyType.schema
+        }
+
+        val nonEmptyElementTypes =
+            value.filter { it.notNullOrEmpty() }.map { schema(it, optional, forceMapsAsStruct) }
+
+        when (nonEmptyElementTypes.toSet().size) {
+          0 -> SchemaBuilder.array(PropertyType.schema).apply { if (optional) optional() }.build()
+          1 ->
+              SchemaBuilder.array(nonEmptyElementTypes.first())
+                  .apply { if (optional) optional() }
+                  .build()
+
+          else ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEachIndexed { i, v ->
+                      this.field("e${i}", schema(v, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+        }
+      }
+
+      is Map<*, *> -> {
+        val elementTypes =
+            value
+                .mapKeys {
+                  when (val key = it.key) {
+                    is String -> key
+                    else ->
+                        throw IllegalArgumentException(
+                            "unsupported map key type ${key?.javaClass?.name}"
+                        )
+                  }
+                }
+                .filter { e -> e.value.notNullOrEmpty() }
+                .mapValues { e -> schema(e.value, optional, forceMapsAsStruct) }
+
+        val elementValueTypesSet = elementTypes.values.toSet()
+        when {
+          elementValueTypesSet.isEmpty() ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEach {
+                      this.field(it.key as String, schema(it.value, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+
+          elementValueTypesSet.singleOrNull() != null && !forceMapsAsStruct ->
+              SchemaBuilder.map(Schema.STRING_SCHEMA, elementTypes.values.first())
+                  .apply { if (optional) optional() }
+                  .build()
+
+          else ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEach {
+                      this.field(it.key as String, schema(it.value, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+        }
+      }
+
+      else -> throw IllegalArgumentException("unsupported type ${value.javaClass.name}")
+    }
+  }
+
+  override fun value(schema: Schema, value: Any?): Any? {
+    if (value == null) {
+      return null
+    }
+
+    if (schema == PropertyType.schema) {
+      return PropertyType.toConnectValue(value)
+    }
+
+    return when (schema.type()) {
+      Schema.Type.ARRAY ->
+          when (value) {
+            is Collection<*> -> value.map { value(schema.valueSchema(), it) }
+            is Array<*> -> value.map { value(schema.valueSchema(), it) }.toList()
+            is ShortArray -> value.map { s -> s.toLong() }.toList()
+            is IntArray -> value.map { i -> i.toLong() }.toList()
+            is FloatArray -> value.map { f -> f.toDouble() }.toList()
+            is BooleanArray -> value.toList()
+            is LongArray -> value.toList()
+            is DoubleArray -> value.toList()
+            else -> throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
+          }
+
+      Schema.Type.MAP ->
+          when (value) {
+            is Map<*, *> -> value.mapValues { value(schema.valueSchema(), it.value) }
+            else -> throw IllegalArgumentException("unsupported map type ${value.javaClass.name}")
+          }
+
+      Schema.Type.STRUCT ->
+          when (value) {
+            is IsoDuration ->
+                Struct(schema)
+                    .put(MONTHS, value.months())
+                    .put(DAYS, value.days())
+                    .put(SECONDS, value.seconds())
+                    .put(NANOS, value.nanoseconds())
+
+            is Point ->
+                Struct(schema).put(SR_ID, value.srid()).put(X, value.x()).put(Y, value.y()).also {
+                  it.put(DIMENSION, if (value.z().isNaN()) TWO_D else THREE_D)
+                  if (!value.z().isNaN()) {
+                    it.put(Z, value.z())
+                  }
+                }
+
+            is Node ->
+                Struct(schema).apply {
+                  put("<id>", value.id())
+                  put("<labels>", value.labels())
+                  value
+                      .asMap { it.asObject() }
+                      .forEach { e -> put(e.key, value(schema.field(e.key).schema(), e.value)) }
+                }
+
+            is Relationship ->
+                Struct(schema).apply {
+                  put("<id>", value.id())
+                  put("<type>", value.type())
+                  put("<start.id>", value.startNodeId())
+                  put("<end.id>", value.endNodeId())
+                  value
+                      .asMap { it.asObject() }
+                      .forEach { e -> put(e.key, value(schema.field(e.key).schema(), e.value)) }
+                }
+
+            is Map<*, *> ->
+                Struct(schema).apply {
+                  schema.fields().forEach { put(it.name(), value(it.schema(), value[it.name()])) }
+                }
+
+            is Collection<*> ->
+                Struct(schema).apply {
+                  schema.fields().forEach {
+                    put(
+                        it.name(),
+                        value(it.schema(), value.elementAt(it.name().substring(1).toInt())),
+                    )
+                  }
+                }
+
+            else ->
+                throw IllegalArgumentException("unsupported struct type ${value.javaClass.name}")
+          }
+
+      else -> value
+    }
+  }
+
+  private fun KClass<*>.isSimplePropertyType(): Boolean =
+      when (this) {
+        Boolean::class,
+        Byte::class,
+        Short::class,
+        Int::class,
+        Long::class,
+        Float::class,
+        Double::class,
+        String::class,
+        LocalDate::class,
+        LocalDateTime::class,
+        LocalTime::class,
+        OffsetDateTime::class,
+        ZonedDateTime::class,
+        OffsetTime::class -> true
+
+        else ->
+            if (IsoDuration::class.java.isAssignableFrom(this.java)) {
+              true
+            } else if (Point::class.java.isAssignableFrom(this.java)) {
+              true
+            } else {
+              false
+            }
+      }
+}

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/JsonValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/JsonValueConverter.kt
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.data.converter
+
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import org.apache.kafka.connect.data.Schema
+import org.apache.kafka.connect.data.SchemaBuilder
+import org.apache.kafka.connect.data.Struct
+import org.neo4j.connectors.kafka.data.DAYS
+import org.neo4j.connectors.kafka.data.DIMENSION
+import org.neo4j.connectors.kafka.data.DynamicTypes.notNullOrEmpty
+import org.neo4j.connectors.kafka.data.MONTHS
+import org.neo4j.connectors.kafka.data.NANOS
+import org.neo4j.connectors.kafka.data.SECONDS
+import org.neo4j.connectors.kafka.data.SR_ID
+import org.neo4j.connectors.kafka.data.SimpleTypes
+import org.neo4j.connectors.kafka.data.THREE_D
+import org.neo4j.connectors.kafka.data.TWO_D
+import org.neo4j.connectors.kafka.data.ValueConverter
+import org.neo4j.connectors.kafka.data.X
+import org.neo4j.connectors.kafka.data.Y
+import org.neo4j.connectors.kafka.data.Z
+import org.neo4j.driver.types.IsoDuration
+import org.neo4j.driver.types.Node
+import org.neo4j.driver.types.Point
+import org.neo4j.driver.types.Relationship
+
+class CompactValueConverter : ValueConverter {
+
+  override fun schema(value: Any?, optional: Boolean, forceMapsAsStruct: Boolean): Schema {
+    return when (value) {
+      null -> SimpleTypes.NULL.schema(true)
+      is Boolean -> SimpleTypes.BOOLEAN.schema(optional)
+      is Float,
+      is Double -> SimpleTypes.FLOAT.schema(optional)
+
+      is Number -> SimpleTypes.LONG.schema(optional)
+      is Char,
+      is CharArray,
+      is CharSequence -> SimpleTypes.STRING.schema(optional)
+
+      is ByteBuffer,
+      is ByteArray -> SimpleTypes.BYTES.schema(optional)
+
+      is ShortArray,
+      is IntArray,
+      is LongArray ->
+          SchemaBuilder.array(Schema.INT64_SCHEMA).apply { if (optional) optional() }.build()
+
+      is FloatArray,
+      is DoubleArray ->
+          SchemaBuilder.array(Schema.FLOAT64_SCHEMA).apply { if (optional) optional() }.build()
+
+      is BooleanArray ->
+          SchemaBuilder.array(Schema.BOOLEAN_SCHEMA).apply { if (optional) optional() }.build()
+
+      is Array<*> -> {
+        val first = value.firstOrNull { it.notNullOrEmpty() }
+        val schema = schema(first, optional, forceMapsAsStruct)
+        SchemaBuilder.array(schema).apply { if (optional) optional() }.build()
+      }
+
+      is LocalDate -> SimpleTypes.LOCALDATE.schema(optional)
+      is LocalDateTime -> SimpleTypes.LOCALDATETIME.schema(optional)
+      is LocalTime -> SimpleTypes.LOCALTIME.schema(optional)
+      is OffsetDateTime -> SimpleTypes.ZONEDDATETIME.schema(optional)
+      is ZonedDateTime -> SimpleTypes.ZONEDDATETIME.schema(optional)
+      is OffsetTime -> SimpleTypes.OFFSETTIME.schema(optional)
+      is IsoDuration -> SimpleTypes.DURATION.schema(optional)
+      is Point -> SimpleTypes.POINT.schema(optional)
+      is Node ->
+          SchemaBuilder.struct()
+              .apply {
+                field("<id>", SimpleTypes.LONG.schema())
+                field("<labels>", SchemaBuilder.array(SimpleTypes.STRING.schema()).build())
+                value.keys().forEach {
+                  field(it, schema(value.get(it).asObject(), optional, forceMapsAsStruct))
+                }
+                if (optional) optional()
+              }
+              .build()
+
+      is Relationship ->
+          SchemaBuilder.struct()
+              .apply {
+                field("<id>", SimpleTypes.LONG.schema())
+                field("<type>", SimpleTypes.STRING.schema())
+                field("<start.id>", SimpleTypes.LONG.schema())
+                field("<end.id>", SimpleTypes.LONG.schema())
+                value.keys().forEach {
+                  field(it, schema(value.get(it).asObject(), optional, forceMapsAsStruct))
+                }
+                if (optional) optional()
+              }
+              .build()
+
+      is Collection<*> -> {
+        val nonEmptyElementTypes =
+            value.filter { it.notNullOrEmpty() }.map { schema(it, optional, forceMapsAsStruct) }
+        when (nonEmptyElementTypes.toSet().size) {
+          0 ->
+              SchemaBuilder.array(SimpleTypes.NULL.schema(true))
+                  .apply { if (optional) optional() }
+                  .build()
+
+          1 ->
+              SchemaBuilder.array(nonEmptyElementTypes.first())
+                  .apply { if (optional) optional() }
+                  .build()
+
+          else ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEachIndexed { i, v ->
+                      this.field("e${i}", schema(v, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+        }
+      }
+
+      is Map<*, *> -> {
+        val elementTypes =
+            value
+                .mapKeys {
+                  when (val key = it.key) {
+                    is String -> key
+                    else ->
+                        throw IllegalArgumentException(
+                            "unsupported map key type ${key?.javaClass?.name}"
+                        )
+                  }
+                }
+                .filter { e -> e.value.notNullOrEmpty() }
+                .mapValues { e -> schema(e.value, optional, forceMapsAsStruct) }
+        val valueSet = elementTypes.values.toSet()
+        when {
+          valueSet.isEmpty() ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEach {
+                      this.field(it.key as String, schema(it.value, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+
+          valueSet.singleOrNull() != null && !forceMapsAsStruct ->
+              SchemaBuilder.map(Schema.STRING_SCHEMA, elementTypes.values.first())
+                  .apply { if (optional) optional() }
+                  .build()
+
+          else ->
+              SchemaBuilder.struct()
+                  .apply {
+                    value.forEach {
+                      this.field(it.key as String, schema(it.value, optional, forceMapsAsStruct))
+                    }
+                  }
+                  .apply { if (optional) optional() }
+                  .build()
+        }
+      }
+
+      else -> throw IllegalArgumentException("unsupported type ${value.javaClass.name}")
+    }
+  }
+
+  override fun value(schema: Schema, value: Any?): Any? {
+    if (value == null) {
+      return null
+    }
+
+    return when (schema.type()) {
+      Schema.Type.BYTES ->
+          when (value) {
+            is ByteArray -> value
+            is ByteBuffer -> value.array()
+            else -> throw IllegalArgumentException("unsupported bytes type ${value.javaClass.name}")
+          }
+
+      Schema.Type.ARRAY ->
+          when (value) {
+            is Collection<*> -> value.map { value(schema.valueSchema(), it) }
+            is Array<*> -> value.map { value(schema.valueSchema(), it) }.toList()
+            is ShortArray -> value.map { s -> s.toLong() }.toList()
+            is IntArray -> value.map { i -> i.toLong() }.toList()
+            is FloatArray -> value.map { f -> f.toDouble() }.toList()
+            is BooleanArray -> value.toList()
+            is LongArray -> value.toList()
+            is DoubleArray -> value.toList()
+            else -> throw IllegalArgumentException("unsupported array type ${value.javaClass.name}")
+          }
+
+      Schema.Type.MAP ->
+          when (value) {
+            is Map<*, *> -> value.mapValues { value(schema.valueSchema(), it.value) }
+            else -> throw IllegalArgumentException("unsupported map type ${value.javaClass.name}")
+          }
+
+      Schema.Type.STRUCT ->
+          when (value) {
+            is IsoDuration ->
+                Struct(schema)
+                    .put(MONTHS, value.months())
+                    .put(DAYS, value.days())
+                    .put(SECONDS, value.seconds())
+                    .put(NANOS, value.nanoseconds())
+
+            is Point ->
+                Struct(schema).put(SR_ID, value.srid()).put(X, value.x()).put(Y, value.y()).also {
+                  it.put(DIMENSION, if (value.z().isNaN()) TWO_D else THREE_D)
+                  if (!value.z().isNaN()) {
+                    it.put(Z, value.z())
+                  }
+                }
+
+            is Node ->
+                Struct(schema).apply {
+                  put("<id>", value.id())
+                  put("<labels>", value.labels())
+                  value
+                      .asMap { it.asObject() }
+                      .forEach { e -> put(e.key, value(schema.field(e.key).schema(), e.value)) }
+                }
+
+            is Relationship ->
+                Struct(schema).apply {
+                  put("<id>", value.id())
+                  put("<type>", value.type())
+                  put("<start.id>", value.startNodeId())
+                  put("<end.id>", value.endNodeId())
+                  value
+                      .asMap { it.asObject() }
+                      .forEach { e -> put(e.key, value(schema.field(e.key).schema(), e.value)) }
+                }
+
+            is Map<*, *> ->
+                Struct(schema).apply {
+                  schema.fields().forEach { put(it.name(), value(it.schema(), value[it.name()])) }
+                }
+
+            is Collection<*> ->
+                Struct(schema).apply {
+                  schema.fields().forEach {
+                    put(
+                        it.name(),
+                        value(it.schema(), value.elementAt(it.name().substring(1).toInt())),
+                    )
+                  }
+                }
+
+            else ->
+                throw IllegalArgumentException("unsupported struct type ${value.javaClass.name}")
+          }
+
+      Schema.Type.STRING ->
+          when (value) {
+            is LocalDate -> DateTimeFormatter.ISO_DATE.format(value)
+            is LocalDateTime -> DateTimeFormatter.ISO_DATE_TIME.format(value)
+            is LocalTime -> DateTimeFormatter.ISO_TIME.format(value)
+            is OffsetDateTime -> DateTimeFormatter.ISO_DATE_TIME.format(value)
+            is ZonedDateTime -> DateTimeFormatter.ISO_DATE_TIME.format(value)
+            is OffsetTime -> DateTimeFormatter.ISO_TIME.format(value)
+            is String -> value
+            is Char -> value.toString()
+            is CharArray -> String(value)
+            else ->
+                throw IllegalArgumentException("unsupported string type ${value.javaClass.name}")
+          }
+
+      Schema.Type.INT64,
+      Schema.Type.FLOAT64 ->
+          when (value) {
+            is Float -> value.toDouble()
+            is Double -> value
+            is Number -> value.toLong()
+            else ->
+                throw IllegalArgumentException("unsupported numeric type ${value.javaClass.name}")
+          }
+
+      else -> value
+    }
+  }
+}

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/events/StreamsEvent.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/events/StreamsEvent.kt
@@ -19,7 +19,7 @@ package org.neo4j.connectors.kafka.events
 enum class OperationType {
   created,
   updated,
-  deleted
+  deleted,
 }
 
 data class Meta(
@@ -29,18 +29,18 @@ data class Meta(
     val txEventId: Int,
     val txEventsCount: Int,
     val operation: OperationType,
-    val source: Map<String, Any> = emptyMap()
+    val source: Map<String, Any> = emptyMap(),
 )
 
 enum class EntityType {
   node,
-  relationship
+  relationship,
 }
 
 data class RelationshipNodeChange(
     val id: String,
     val labels: List<String>?,
-    val ids: Map<String, Any>
+    val ids: Map<String, Any>,
 )
 
 abstract class RecordChange {
@@ -63,7 +63,7 @@ data class NodePayload(
     override val id: String,
     override val before: NodeChange?,
     override val after: NodeChange?,
-    override val type: EntityType = EntityType.node
+    override val type: EntityType = EntityType.node,
 ) : Payload()
 
 data class RelationshipPayload(
@@ -73,29 +73,29 @@ data class RelationshipPayload(
     override val before: RelationshipChange?,
     override val after: RelationshipChange?,
     val label: String,
-    override val type: EntityType = EntityType.relationship
+    override val type: EntityType = EntityType.relationship,
 ) : Payload()
 
 enum class StreamsConstraintType {
   UNIQUE,
   NODE_PROPERTY_EXISTS,
-  RELATIONSHIP_PROPERTY_EXISTS
+  RELATIONSHIP_PROPERTY_EXISTS,
 }
 
 enum class RelKeyStrategy {
   DEFAULT,
-  ALL
+  ALL,
 }
 
 data class Constraint(
     val label: String?,
     val properties: Set<String>,
-    val type: StreamsConstraintType
+    val type: StreamsConstraintType,
 )
 
 data class Schema(
     val properties: Map<String, String> = emptyMap(),
-    val constraints: List<Constraint> = emptyList()
+    val constraints: List<Constraint> = emptyList(),
 )
 
 open class StreamsEvent(open val payload: Any)
@@ -103,13 +103,13 @@ open class StreamsEvent(open val payload: Any)
 data class StreamsTransactionEvent(
     val meta: Meta,
     override val payload: Payload,
-    val schema: Schema
+    val schema: Schema,
 ) : StreamsEvent(payload)
 
 data class StreamsTransactionNodeEvent(
     val meta: Meta,
     val payload: NodePayload,
-    val schema: Schema
+    val schema: Schema,
 ) {
   fun toStreamsTransactionEvent() = StreamsTransactionEvent(this.meta, this.payload, this.schema)
 }
@@ -117,7 +117,7 @@ data class StreamsTransactionNodeEvent(
 data class StreamsTransactionRelationshipEvent(
     val meta: Meta,
     val payload: RelationshipPayload,
-    val schema: Schema
+    val schema: Schema,
 ) {
   fun toStreamsTransactionEvent() = StreamsTransactionEvent(this.meta, this.payload, this.schema)
 }

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/MapUtils.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/MapUtils.kt
@@ -29,7 +29,8 @@ object MapUtils {
               it as T
             } else {
               throw InvalidDataException(
-                  "Elements of '$key' is not an instance of ${T::class.simpleName}")
+                  "Elements of '$key' is not an instance of ${T::class.simpleName}"
+              )
             }
           }
       else -> throw InvalidDataException("Map element '$key' is not an instance of Iterable")
@@ -44,11 +45,13 @@ object MapUtils {
               .map {
                 if (!K::class.isInstance(it.key)) {
                   throw InvalidDataException(
-                      "Keys of '$key' is not an instance of ${K::class.simpleName}")
+                      "Keys of '$key' is not an instance of ${K::class.simpleName}"
+                  )
                 }
                 if (!V::class.isInstance(it.value)) {
                   throw InvalidDataException(
-                      "Values of '$key' is not an instance of ${V::class.simpleName}")
+                      "Values of '$key' is not an instance of ${V::class.simpleName}"
+                  )
                 }
 
                 (it.key as K) to (it.value as V)
@@ -71,7 +74,7 @@ object MapUtils {
   @Suppress("UNCHECKED_CAST")
   fun Map<String, Any?>.flatten(
       map: Map<String, Any?> = this,
-      prefix: String = ""
+      prefix: String = "",
   ): Map<String, Any?> {
     return map.flatMap {
           val key = it.key

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/PropertiesUtil.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/PropertiesUtil.kt
@@ -29,13 +29,17 @@ class PropertiesUtil {
 
     init {
       properties.load(
-          PropertiesUtil::class.java.getResourceAsStream("/neo4j-configuration.properties"))
+          PropertiesUtil::class.java.getResourceAsStream("/neo4j-configuration.properties")
+      )
       properties.load(
-          PropertiesUtil::class.java.getResourceAsStream("/neo4j-source-configuration.properties"))
+          PropertiesUtil::class.java.getResourceAsStream("/neo4j-source-configuration.properties")
+      )
       properties.load(
-          PropertiesUtil::class.java.getResourceAsStream("/neo4j-sink-configuration.properties"))
+          PropertiesUtil::class.java.getResourceAsStream("/neo4j-sink-configuration.properties")
+      )
       properties.load(
-          PropertiesUtil::class.java.getResourceAsStream("/kafka-connect-version.properties"))
+          PropertiesUtil::class.java.getResourceAsStream("/kafka-connect-version.properties")
+      )
       VERSION =
           try {
             properties.getProperty("version", DEFAULT_VERSION).trim()

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/Telemetry.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/Telemetry.kt
@@ -38,12 +38,16 @@ object Telemetry {
   fun userAgent(
       type: String,
       comment: String = "",
-      provider: EnvironmentProvider = SystemEnvironmentProvider
+      provider: EnvironmentProvider = SystemEnvironmentProvider,
   ): String {
     return String.format(
         "%s %s (%s) %s %s",
         connectorInformation(
-            type, VersionUtil.version(Neo4jConfiguration::class.java), comment, provider),
+            type,
+            VersionUtil.version(Neo4jConfiguration::class.java),
+            comment,
+            provider,
+        ),
         kafkaConnectInformation(),
         platform(),
         neo4jDriverVersion(),
@@ -65,14 +69,15 @@ object Telemetry {
       type: String,
       version: String = "",
       comment: String = "",
-      provider: EnvironmentProvider = SystemEnvironmentProvider
+      provider: EnvironmentProvider = SystemEnvironmentProvider,
   ): String {
     return String.format(
         "%s-%s%s%s",
         if (runningInConfluentCloud(provider)) "confluent-cloud" else "kafka",
         type,
         if (version.isEmpty()) "" else "/$version",
-        if (comment.isEmpty()) "" else " ($comment)")
+        if (comment.isEmpty()) "" else " ($comment)",
+    )
   }
 
   internal fun kafkaConnectInformation(): String {

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/Neo4jConfigurationTest.kt
@@ -48,7 +48,8 @@ class Neo4jConfigurationTest {
       Neo4jConfiguration(
           Neo4jConfiguration.config(),
           mapOf(Neo4jConfiguration.URI to "bolt+routing://localhost"),
-          type)
+          type,
+      )
     } shouldHaveMessage
         "Invalid value bolt+routing://localhost for configuration neo4j.uri: Scheme must be one of: 'neo4j', 'neo4j+s', 'neo4j+ssc', 'bolt', 'bolt+s', 'bolt+ssc'."
 
@@ -56,7 +57,8 @@ class Neo4jConfigurationTest {
       Neo4jConfiguration(
           Neo4jConfiguration.config(),
           mapOf(Neo4jConfiguration.URI to "neo4j://localhost,https://localhost"),
-          type)
+          type,
+      )
     } shouldHaveMessage
         "Invalid value https://localhost for configuration neo4j.uri: Scheme must be one of: 'neo4j', 'neo4j+s', 'neo4j+ssc', 'bolt', 'bolt+s', 'bolt+ssc'."
 
@@ -65,8 +67,10 @@ class Neo4jConfigurationTest {
           Neo4jConfiguration.config(),
           mapOf(
               Neo4jConfiguration.URI to "bolt://localhost",
-              Neo4jConfiguration.AUTHENTICATION_TYPE to "unsupported"),
-          type)
+              Neo4jConfiguration.AUTHENTICATION_TYPE to "unsupported",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value unsupported for configuration neo4j.authentication.type: Must be one of: 'NONE', 'BASIC', 'KERBEROS', 'BEARER', 'CUSTOM'."
 
@@ -76,8 +80,10 @@ class Neo4jConfigurationTest {
           mapOf(
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
-              Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5"),
-          type)
+              Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value 5 for configuration neo4j.max-retry-time: Must match pattern '(\\d+(ms|s|m|h|d))+'."
 
@@ -88,8 +94,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.URI to "bolt://localhost",
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
-              Neo4jConfiguration.CONNECTION_TIMEOUT to "1"),
-          type)
+              Neo4jConfiguration.CONNECTION_TIMEOUT to "1",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value 1 for configuration neo4j.connection-timeout: Must match pattern '(\\d+(ms|s|m|h|d))+'."
 
@@ -101,8 +109,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
-              Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 0),
-          type)
+              Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 0,
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value 0 for configuration neo4j.pool.max-connection-pool-size: Value must be at least 1"
 
@@ -115,8 +125,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.MAX_TRANSACTION_RETRY_TIMEOUT to "5s",
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
-              Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5k"),
-          type)
+              Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5k",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value 5k for configuration neo4j.pool.connection-acquisition-timeout: Must match pattern '(\\d+(ms|s|m|h|d))+'."
 
@@ -130,8 +142,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.CONNECTION_TIMEOUT to "1m",
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
-              Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST to "1ns"),
-          type)
+              Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST to "1ns",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value 1ns for configuration neo4j.pool.idle-time-before-connection-test: Must match pattern '(\\d+(ms|s|m|h|d))+'."
 
@@ -146,8 +160,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.POOL_MAX_CONNECTION_POOL_SIZE to 5,
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
               Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST to "1h",
-              Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME to "1w"),
-          type)
+              Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME to "1w",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value 1w for configuration neo4j.pool.max-connection-lifetime: Must match pattern '(\\d+(ms|s|m|h|d))+'."
 
@@ -163,8 +179,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.POOL_CONNECTION_ACQUISITION_TIMEOUT to "5m",
               Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST to "1h",
               Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME to "8h",
-              Neo4jConfiguration.SECURITY_ENCRYPTED to "enabled"),
-          type)
+              Neo4jConfiguration.SECURITY_ENCRYPTED to "enabled",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value enabled for configuration neo4j.security.encrypted: Must be one of: 'true', 'false'."
 
@@ -181,8 +199,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.POOL_IDLE_TIME_BEFORE_TEST to "1h",
               Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME to "8h",
               Neo4jConfiguration.SECURITY_ENCRYPTED to "true",
-              Neo4jConfiguration.SECURITY_TRUST_STRATEGY to "unknown"),
-          type)
+              Neo4jConfiguration.SECURITY_TRUST_STRATEGY to "unknown",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value unknown for configuration neo4j.security.trust-strategy: Must be one of: 'TRUST_ALL_CERTIFICATES', 'TRUST_CUSTOM_CA_SIGNED_CERTIFICATES', 'TRUST_SYSTEM_CA_SIGNED_CERTIFICATES'."
 
@@ -200,8 +220,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.POOL_MAX_CONNECTION_LIFETIME to "8h",
               Neo4jConfiguration.SECURITY_ENCRYPTED to "true",
               Neo4jConfiguration.SECURITY_TRUST_STRATEGY to "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES",
-              Neo4jConfiguration.SECURITY_HOST_NAME_VERIFICATION_ENABLED to "disabled"),
-          type)
+              Neo4jConfiguration.SECURITY_HOST_NAME_VERIFICATION_ENABLED to "disabled",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value disabled for configuration neo4j.security.hostname-verification-enabled: Must be one of: 'true', 'false'."
 
@@ -220,8 +242,10 @@ class Neo4jConfigurationTest {
               Neo4jConfiguration.SECURITY_ENCRYPTED to "true",
               Neo4jConfiguration.SECURITY_TRUST_STRATEGY to "TRUST_CUSTOM_CA_SIGNED_CERTIFICATES",
               Neo4jConfiguration.SECURITY_HOST_NAME_VERIFICATION_ENABLED to "false",
-              Neo4jConfiguration.SECURITY_CERT_FILES to "non-existing-file.txt"),
-          type)
+              Neo4jConfiguration.SECURITY_CERT_FILES to "non-existing-file.txt",
+          ),
+          type,
+      )
     } shouldHaveMessage
         "Invalid value non-existing-file.txt for configuration neo4j.security.cert-files: Must be an absolute path."
   }
@@ -247,8 +271,10 @@ class Neo4jConfigurationTest {
                 Neo4jConfiguration.SECURITY_ENCRYPTED to "true",
                 Neo4jConfiguration.SECURITY_TRUST_STRATEGY to "TRUST_CUSTOM_CA_SIGNED_CERTIFICATES",
                 Neo4jConfiguration.SECURITY_HOST_NAME_VERIFICATION_ENABLED to "false",
-                Neo4jConfiguration.SECURITY_CERT_FILES to "${f1.absolutePath},${f2.absolutePath}"),
-            type)
+                Neo4jConfiguration.SECURITY_CERT_FILES to "${f1.absolutePath},${f2.absolutePath}",
+            ),
+            type,
+        )
 
     assertEquals(listOf(URI("bolt://localhost")), config.uris)
     assertEquals(AuthTokens.none(), config.authenticationToken)
@@ -272,8 +298,10 @@ class Neo4jConfigurationTest {
             Neo4jConfiguration.config(),
             mapOf(
                 Neo4jConfiguration.URI to "bolt://localhost",
-                Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE"),
-            ConnectorType.SINK)
+                Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
+            ),
+            ConnectorType.SINK,
+        )
         .run { assertEquals(AuthTokens.none(), this.authenticationToken) }
 
     Neo4jConfiguration(
@@ -283,8 +311,10 @@ class Neo4jConfigurationTest {
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "BASIC",
                 Neo4jConfiguration.AUTHENTICATION_BASIC_USERNAME to "neo4j",
                 Neo4jConfiguration.AUTHENTICATION_BASIC_PASSWORD to "password",
-                Neo4jConfiguration.AUTHENTICATION_BASIC_REALM to "realm"),
-            ConnectorType.SINK)
+                Neo4jConfiguration.AUTHENTICATION_BASIC_REALM to "realm",
+            ),
+            ConnectorType.SINK,
+        )
         .run {
           assertEquals(AuthTokens.basic("neo4j", "password", "realm"), this.authenticationToken)
         }
@@ -294,8 +324,10 @@ class Neo4jConfigurationTest {
             mapOf(
                 Neo4jConfiguration.URI to "bolt://localhost",
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "KERBEROS",
-                Neo4jConfiguration.AUTHENTICATION_KERBEROS_TICKET to "ticket"),
-            ConnectorType.SINK)
+                Neo4jConfiguration.AUTHENTICATION_KERBEROS_TICKET to "ticket",
+            ),
+            ConnectorType.SINK,
+        )
         .run { assertEquals(AuthTokens.kerberos("ticket"), this.authenticationToken) }
 
     Neo4jConfiguration(
@@ -303,8 +335,10 @@ class Neo4jConfigurationTest {
             mapOf(
                 Neo4jConfiguration.URI to "bolt://localhost",
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "BEARER",
-                Neo4jConfiguration.AUTHENTICATION_BEARER_TOKEN to "token"),
-            ConnectorType.SINK)
+                Neo4jConfiguration.AUTHENTICATION_BEARER_TOKEN to "token",
+            ),
+            ConnectorType.SINK,
+        )
         .run { assertEquals(AuthTokens.bearer("token"), this.authenticationToken) }
 
     Neo4jConfiguration(
@@ -317,10 +351,13 @@ class Neo4jConfigurationTest {
                 Neo4jConfiguration.AUTHENTICATION_CUSTOM_REALM to "realm",
                 Neo4jConfiguration.AUTHENTICATION_CUSTOM_SCHEME to "scheme",
             ),
-            ConnectorType.SINK)
+            ConnectorType.SINK,
+        )
         .run {
           assertEquals(
-              AuthTokens.custom("principal", "creds", "realm", "scheme"), this.authenticationToken)
+              AuthTokens.custom("principal", "creds", "realm", "scheme"),
+              this.authenticationToken,
+          )
         }
   }
 

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/ConfigKeyBuilderTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/ConfigKeyBuilderTest.kt
@@ -41,7 +41,8 @@ class ConfigKeyBuilderTest {
               Recommenders.and(
                   Recommenders.visibleIf("neo4j.other") { true },
                   Recommenders.visibleIf("neo4j.another") { true },
-                  Recommenders.enum(AuthenticationType::class.java))
+                  Recommenders.enum(AuthenticationType::class.java),
+              )
         }
         .dependents shouldContainExactly listOf("neo4j.other", "neo4j.another")
   }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/DurationTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/DurationTest.kt
@@ -43,7 +43,8 @@ class DurationTest {
     assertEquals(65.seconds + 550.milliseconds, Duration.parseSimpleString("65s550ms"))
     assertEquals(
         1.days + 23.hours + 59.minutes + 59.seconds + 10.milliseconds,
-        Duration.parseSimpleString("1d23h59m59s10ms"))
+        Duration.parseSimpleString("1d23h59m59s10ms"),
+    )
     assertEquals(2.days, Duration.parseSimpleString("1d23h59m60s"))
   }
 

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/RecommendersTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/RecommendersTest.kt
@@ -31,7 +31,8 @@ class RecommendersTest {
     Recommenders.and(
             Recommenders.enum(ConnectorType::class.java),
             Recommenders.visibleIf("test.1", Predicate.isEqual("a")),
-            Recommenders.visibleIf("test.2", Predicate.isEqual("b")))
+            Recommenders.visibleIf("test.2", Predicate.isEqual("b")),
+        )
         .apply {
           assertEquals(listOf("SINK", "SOURCE"), this.validValues("my.property", mapOf()))
 
@@ -48,15 +49,21 @@ class RecommendersTest {
       assertTrue(this.visible("my.property", emptyMap()))
       assertEquals(
           listOf("NONE", "BASIC", "KERBEROS", "BEARER", "CUSTOM"),
-          this.validValues("my.property", mapOf()))
+          this.validValues("my.property", mapOf()),
+      )
     }
 
     Recommenders.enum(
-            AuthenticationType::class.java, AuthenticationType.NONE, AuthenticationType.CUSTOM)
+            AuthenticationType::class.java,
+            AuthenticationType.NONE,
+            AuthenticationType.CUSTOM,
+        )
         .apply {
           assertTrue(this.visible("my.property", emptyMap()))
           assertEquals(
-              listOf("BASIC", "KERBEROS", "BEARER"), this.validValues("my.property", mapOf()))
+              listOf("BASIC", "KERBEROS", "BEARER"),
+              this.validValues("my.property", mapOf()),
+          )
         }
   }
 
@@ -99,7 +106,10 @@ class RecommendersTest {
           // dependent is multiple values, one empty
           assertTrue(
               this.visible(
-                  "my.property", mapOf("test.1" to "value", "test.2" to "value", "test.3" to "")))
+                  "my.property",
+                  mapOf("test.1" to "value", "test.2" to "value", "test.3" to ""),
+              )
+          )
         }
   }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/ValidatorsTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/configuration/helpers/ValidatorsTest.kt
@@ -48,7 +48,8 @@ class ValidatorsTest {
           Validators.and(
                   ConfigDef.Validator { name, value ->
                     throw ConfigException(name, value, "Invalid data")
-                  })
+                  }
+              )
               .ensureValid("my.property", "abc")
         }
         .also {
@@ -60,7 +61,8 @@ class ValidatorsTest {
                   ConfigDef.Validator { _, _ -> run {} },
                   ConfigDef.Validator { name, value ->
                     throw ConfigException(name, value, "Invalid data")
-                  })
+                  },
+              )
               .ensureValid("my.property", "abc")
         }
         .also {
@@ -77,7 +79,8 @@ class ValidatorsTest {
               ConfigDef.Validator { _, _ -> run {} },
               ConfigDef.Validator { name, value ->
                 throw ConfigException(name, value, "Invalid data")
-              })
+              },
+          )
           .ensureValid("my.property", "value")
       Validators.or(ConfigDef.Validator { _, _ -> run {} }, ConfigDef.Validator { _, _ -> run {} })
           .ensureValid("my.property", "value")
@@ -90,12 +93,15 @@ class ValidatorsTest {
                   },
                   ConfigDef.Validator { name, value ->
                     throw ConfigException(name, value, "Invalid data 2")
-                  })
+                  },
+              )
               .ensureValid("my.property", "abc")
         }
         .also {
           assertEquals(
-              "Invalid value abc for configuration my.property: Invalid data 2", it.message)
+              "Invalid value abc for configuration my.property: Invalid data 2",
+              it.message,
+          )
         }
   }
 
@@ -109,7 +115,9 @@ class ValidatorsTest {
     assertFailsWith(ConfigException::class) { Validators.blank().ensureValid("my.property", "abc") }
         .also {
           assertEquals(
-              "Invalid value abc for configuration my.property: Must be blank.", it.message)
+              "Invalid value abc for configuration my.property: Must be blank.",
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -117,7 +125,9 @@ class ValidatorsTest {
         }
         .also {
           assertEquals(
-              "Invalid value [abc] for configuration my.property: Must be empty.", it.message)
+              "Invalid value [abc] for configuration my.property: Must be empty.",
+              it.message,
+          )
         }
   }
 
@@ -130,7 +140,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value $v for configuration my.property: Must be a String or a List.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -141,7 +152,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value SAML for configuration my.property: Must be one of: 'NONE', 'BASIC'.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -164,7 +176,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value $v for configuration my.property: Must be a String or a List.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -177,7 +190,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value SAML for configuration my.property: Must be one of: 'NONE', 'BASIC', 'KERBEROS', 'BEARER', 'CUSTOM'.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -199,7 +213,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value $v for configuration my.property: Must be a String or a List.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -210,7 +225,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value abc for configuration my.property: Must match pattern '\\d+'.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -230,7 +246,8 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value $v for configuration my.property: Must be a String or a List.",
-                it.message)
+                it.message,
+            )
           }
     }
 
@@ -239,7 +256,9 @@ class ValidatorsTest {
         }
         .also {
           assertEquals(
-              "Invalid value  for configuration my.property: Must not be blank.", it.message)
+              "Invalid value  for configuration my.property: Must not be blank.",
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -247,7 +266,9 @@ class ValidatorsTest {
         }
         .also {
           assertEquals(
-              "Invalid value [] for configuration my.property: Must not be empty.", it.message)
+              "Invalid value [] for configuration my.property: Must not be empty.",
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -258,7 +279,8 @@ class ValidatorsTest {
     listOf(
             "ftp://localhost/a.tar",
             listOf("ftp://localhost/a.tar"),
-            listOf("http://localhost", "ftp://localhost/a.tar"))
+            listOf("http://localhost", "ftp://localhost/a.tar"),
+        )
         .forEach { v ->
           assertFailsWith(ConfigException::class) {
                 Validators.uri("http", "https").apply { this.ensureValid("my.property", v) }
@@ -266,7 +288,8 @@ class ValidatorsTest {
               .also {
                 assertEquals(
                     "Invalid value ftp://localhost/a.tar for configuration my.property: Scheme must be one of: 'http', 'https'.",
-                    it.message)
+                    it.message,
+                )
               }
         }
 
@@ -286,14 +309,17 @@ class ValidatorsTest {
           .also {
             assertEquals(
                 "Invalid value $v for configuration my.property: Must be a String or a List.",
-                it.message)
+                it.message,
+            )
           }
     }
 
     assertFailsWith(ConfigException::class) { Validators.file().ensureValid("my.property", "") }
         .also {
           assertEquals(
-              "Invalid value  for configuration my.property: Must not be blank.", it.message)
+              "Invalid value  for configuration my.property: Must not be blank.",
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -301,7 +327,9 @@ class ValidatorsTest {
         }
         .also {
           assertEquals(
-              "Invalid value [] for configuration my.property: Must not be empty.", it.message)
+              "Invalid value [] for configuration my.property: Must not be empty.",
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -310,7 +338,8 @@ class ValidatorsTest {
         .also {
           assertEquals(
               "Invalid value deneme.txt for configuration my.property: Must be an absolute path.",
-              it.message)
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -319,7 +348,8 @@ class ValidatorsTest {
         .also {
           assertEquals(
               "Invalid value deneme.txt for configuration my.property: Must be an absolute path.",
-              it.message)
+              it.message,
+          )
         }
 
     assertFailsWith(ConfigException::class) {
@@ -345,7 +375,9 @@ class ValidatorsTest {
             listOf(
                 ConfigValue("BOOL_CONFIG", null as Boolean?, emptyList(), mutableListOf()).also {
                   it.visible(true)
-                }))
+                }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("BOOL_CONFIG")
 
@@ -357,7 +389,9 @@ class ValidatorsTest {
             listOf(
                 ConfigValue("INT_CONFIG", null as Int?, emptyList(), mutableListOf()).also {
                   it.visible(true)
-                }))
+                }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("INT_CONFIG")
 
@@ -370,7 +404,9 @@ class ValidatorsTest {
               listOf(
                   ConfigValue("STRING_CONFIG", s, emptyList(), mutableListOf()).also {
                     it.visible(true)
-                  }))
+                  }
+              )
+          )
           .apply {
             validateNonEmptyIfVisible("STRING_CONFIG")
 
@@ -384,7 +420,9 @@ class ValidatorsTest {
               listOf(
                   ConfigValue("PASSWORD_CONFIG", s, emptyList(), mutableListOf()).also {
                     it.visible(true)
-                  }))
+                  }
+              )
+          )
           .apply {
             validateNonEmptyIfVisible("PASSWORD_CONFIG")
 
@@ -398,7 +436,9 @@ class ValidatorsTest {
               listOf(
                   ConfigValue("LIST_CONFIG", s, emptyList(), mutableListOf()).also {
                     it.visible(true)
-                  }))
+                  }
+              )
+          )
           .apply {
             validateNonEmptyIfVisible("LIST_CONFIG")
 
@@ -414,7 +454,9 @@ class ValidatorsTest {
             listOf(
                 ConfigValue("BOOL_CONFIG", true, emptyList(), mutableListOf()).also {
                   it.visible(true)
-                }))
+                }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("BOOL_CONFIG")
 
@@ -425,7 +467,9 @@ class ValidatorsTest {
             listOf(
                 ConfigValue("INT_CONFIG", 10_000, emptyList(), mutableListOf()).also {
                   it.visible(true)
-                }))
+                }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("INT_CONFIG")
 
@@ -436,7 +480,9 @@ class ValidatorsTest {
             listOf(
                 ConfigValue("STRING_CONFIG", "value", emptyList(), mutableListOf()).also {
                   it.visible(true)
-                }))
+                }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("STRING_CONFIG")
 
@@ -446,7 +492,9 @@ class ValidatorsTest {
     Config(
             listOf(
                 ConfigValue("PASSWORD_CONFIG", Password("value"), emptyList(), mutableListOf())
-                    .also { it.visible(true) }))
+                    .also { it.visible(true) }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("PASSWORD_CONFIG")
 
@@ -457,7 +505,9 @@ class ValidatorsTest {
             listOf(
                 ConfigValue("LIST_CONFIG", listOf("value"), emptyList(), mutableListOf()).also {
                   it.visible(true)
-                }))
+                }
+            )
+        )
         .apply {
           validateNonEmptyIfVisible("LIST_CONFIG")
 

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/ChangeEventExtensionsTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/ChangeEventExtensionsTest.kt
@@ -57,11 +57,15 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 null,
                 NodeState(
                     listOf("Label1", "Label2"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"))))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"),
+                ),
+            ),
+        )
 
     schema.nestedSchema("id") shouldBe Schema.STRING_SCHEMA
     schema.nestedSchema("txId") shouldBe Schema.INT64_SCHEMA
@@ -83,7 +87,8 @@ class ChangeEventExtensionsTest {
                     .field("user", PropertyType.schema)
                     .field("app", PropertyType.schema)
                     .optional()
-                    .build())
+                    .build(),
+            )
             .build()
 
     value.get("id") shouldBe change.id.id
@@ -101,12 +106,14 @@ class ChangeEventExtensionsTest {
             .put("txStartTime", change.metadata.txStartTime.let { PropertyType.toConnectValue(it) })
             .put(
                 "txCommitTime",
-                change.metadata.txCommitTime.let { PropertyType.toConnectValue(it) })
+                change.metadata.txCommitTime.let { PropertyType.toConnectValue(it) },
+            )
             .put(
                 "txMetadata",
                 Struct(schema.nestedSchema("metadata.txMetadata"))
                     .put("user", PropertyType.toConnectValue("app_user"))
-                    .put("app", PropertyType.toConnectValue("hr")))
+                    .put("app", PropertyType.toConnectValue("hr")),
+            )
   }
 
   @Test
@@ -120,11 +127,15 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 null,
                 NodeState(
                     listOf("Label1", "Label2"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"))))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"),
+                ),
+            ),
+        )
 
     schema.nestedSchema("id") shouldBe Schema.STRING_SCHEMA
     schema.nestedSchema("txId") shouldBe Schema.INT64_SCHEMA
@@ -146,7 +157,8 @@ class ChangeEventExtensionsTest {
                     .field("user", Schema.OPTIONAL_STRING_SCHEMA)
                     .field("app", Schema.OPTIONAL_STRING_SCHEMA)
                     .optional()
-                    .build())
+                    .build(),
+            )
             .build()
 
     value.get("id") shouldBe change.id.id
@@ -163,15 +175,18 @@ class ChangeEventExtensionsTest {
             .put("captureMode", change.metadata.captureMode.name)
             .put(
                 "txStartTime",
-                change.metadata.txStartTime.let { DateTimeFormatter.ISO_DATE_TIME.format(it) })
+                change.metadata.txStartTime.let { DateTimeFormatter.ISO_DATE_TIME.format(it) },
+            )
             .put(
                 "txCommitTime",
-                change.metadata.txCommitTime.let { DateTimeFormatter.ISO_DATE_TIME.format(it) })
+                change.metadata.txCommitTime.let { DateTimeFormatter.ISO_DATE_TIME.format(it) },
+            )
             .put(
                 "txMetadata",
                 Struct(schema.nestedSchema("metadata.txMetadata"))
                     .put("user", "app_user")
-                    .put("app", "hr"))
+                    .put("app", "hr"),
+            )
   }
 
   @Test
@@ -185,11 +200,15 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 null,
                 NodeState(
                     listOf("Label1", "Label2"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"))))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"),
+                ),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -207,20 +226,25 @@ class ChangeEventExtensionsTest {
                                     .field("name", PropertyType.schema)
                                     .field("surname", PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "Label2",
                         SchemaBuilder.array(
                                 SchemaBuilder.struct()
                                     .field("id", PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -230,21 +254,24 @@ class ChangeEventExtensionsTest {
                             .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
                             .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -261,12 +288,17 @@ class ChangeEventExtensionsTest {
                         listOf(
                             Struct(schema.nestedSchema("event.keys.Label1").valueSchema())
                                 .put("name", PropertyType.toConnectValue("john"))
-                                .put("surname", PropertyType.toConnectValue("doe"))))
+                                .put("surname", PropertyType.toConnectValue("doe"))
+                        ),
+                    )
                     .put(
                         "Label2",
                         listOf(
                             Struct(schema.nestedSchema("event.keys.Label2").valueSchema())
-                                .put("id", PropertyType.toConnectValue(5L)))))
+                                .put("id", PropertyType.toConnectValue(5L))
+                        ),
+                    ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -279,7 +311,11 @@ class ChangeEventExtensionsTest {
                                 mapOf(
                                     "id" to PropertyType.toConnectValue(5L),
                                     "name" to PropertyType.toConnectValue("john"),
-                                    "surname" to PropertyType.toConnectValue("doe")))))
+                                    "surname" to PropertyType.toConnectValue("doe"),
+                                ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -296,11 +332,15 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 null,
                 NodeState(
                     listOf("Label1", "Label2"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"))))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"),
+                ),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -318,20 +358,25 @@ class ChangeEventExtensionsTest {
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "Label2",
                         SchemaBuilder.array(
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -345,9 +390,11 @@ class ChangeEventExtensionsTest {
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
@@ -358,10 +405,13 @@ class ChangeEventExtensionsTest {
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -378,11 +428,14 @@ class ChangeEventExtensionsTest {
                         listOf(
                             Struct(schema.nestedValueSchema("event.keys.Label1"))
                                 .put("name", "john")
-                                .put("surname", "doe")))
+                                .put("surname", "doe")
+                        ),
+                    )
                     .put(
                         "Label2",
-                        listOf(
-                            Struct(schema.nestedValueSchema("event.keys.Label2")).put("id", 5L))))
+                        listOf(Struct(schema.nestedValueSchema("event.keys.Label2")).put("id", 5L)),
+                    ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -395,7 +448,10 @@ class ChangeEventExtensionsTest {
                                 Struct(schema.nestedSchema("event.state.after.properties"))
                                     .put("id", 5L)
                                     .put("name", "john")
-                                    .put("surname", "doe"))))
+                                    .put("surname", "doe"),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -412,13 +468,18 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 NodeState(
                     listOf("Label1", "Label2"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe")),
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"),
+                ),
                 NodeState(
                     listOf("Label1", "Label2", "Label3"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L))))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L),
+                ),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -436,20 +497,25 @@ class ChangeEventExtensionsTest {
                                     .field("name", PropertyType.schema)
                                     .field("surname", PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "Label2",
                         SchemaBuilder.array(
                                 SchemaBuilder.struct()
                                     .field("id", PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -459,21 +525,24 @@ class ChangeEventExtensionsTest {
                             .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
                             .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -490,12 +559,17 @@ class ChangeEventExtensionsTest {
                         listOf(
                             Struct(schema.nestedSchema("event.keys.Label1").valueSchema())
                                 .put("name", PropertyType.toConnectValue("john"))
-                                .put("surname", PropertyType.toConnectValue("doe"))))
+                                .put("surname", PropertyType.toConnectValue("doe"))
+                        ),
+                    )
                     .put(
                         "Label2",
                         listOf(
                             Struct(schema.nestedSchema("event.keys.Label2").valueSchema())
-                                .put("id", PropertyType.toConnectValue(5L)))))
+                                .put("id", PropertyType.toConnectValue(5L))
+                        ),
+                    ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -508,7 +582,10 @@ class ChangeEventExtensionsTest {
                                 mapOf(
                                     "id" to PropertyType.toConnectValue(5L),
                                     "name" to PropertyType.toConnectValue("john"),
-                                    "surname" to PropertyType.toConnectValue("doe"))))
+                                    "surname" to PropertyType.toConnectValue("doe"),
+                                ),
+                            ),
+                    )
                     .put(
                         "after",
                         Struct(schema.nestedSchema("event.state.after"))
@@ -519,7 +596,11 @@ class ChangeEventExtensionsTest {
                                     "id" to PropertyType.toConnectValue(5L),
                                     "name" to PropertyType.toConnectValue("john"),
                                     "surname" to PropertyType.toConnectValue("doe"),
-                                    "age" to PropertyType.toConnectValue(25L)))))
+                                    "age" to PropertyType.toConnectValue(25L),
+                                ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -536,13 +617,18 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 NodeState(
                     listOf("Label1", "Label2"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe")),
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe"),
+                ),
                 NodeState(
                     listOf("Label1", "Label2", "Label3"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L))))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L),
+                ),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -560,20 +646,25 @@ class ChangeEventExtensionsTest {
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "Label2",
                         SchemaBuilder.array(
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -588,9 +679,11 @@ class ChangeEventExtensionsTest {
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
@@ -602,10 +695,13 @@ class ChangeEventExtensionsTest {
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -622,11 +718,14 @@ class ChangeEventExtensionsTest {
                         listOf(
                             Struct(schema.nestedValueSchema("event.keys.Label1"))
                                 .put("name", "john")
-                                .put("surname", "doe")))
+                                .put("surname", "doe")
+                        ),
+                    )
                     .put(
                         "Label2",
-                        listOf(
-                            Struct(schema.nestedValueSchema("event.keys.Label2")).put("id", 5L))))
+                        listOf(Struct(schema.nestedValueSchema("event.keys.Label2")).put("id", 5L)),
+                    ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -639,7 +738,9 @@ class ChangeEventExtensionsTest {
                                 Struct(schema.nestedSchema("event.state.before.properties"))
                                     .put("id", 5L)
                                     .put("name", "john")
-                                    .put("surname", "doe")))
+                                    .put("surname", "doe"),
+                            ),
+                    )
                     .put(
                         "after",
                         Struct(schema.nestedSchema("event.state.after"))
@@ -650,7 +751,10 @@ class ChangeEventExtensionsTest {
                                     .put("id", 5L)
                                     .put("name", "john")
                                     .put("surname", "doe")
-                                    .put("age", 25L))))
+                                    .put("age", 25L),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -667,11 +771,15 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2", "Label3"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 NodeState(
                     listOf("Label1", "Label2", "Label3"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L)),
-                null))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L),
+                ),
+                null,
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -689,20 +797,25 @@ class ChangeEventExtensionsTest {
                                     .field("name", PropertyType.schema)
                                     .field("surname", PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "Label2",
                         SchemaBuilder.array(
                                 SchemaBuilder.struct()
                                     .field("id", PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -712,21 +825,24 @@ class ChangeEventExtensionsTest {
                             .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
                             .field("labels", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -743,12 +859,17 @@ class ChangeEventExtensionsTest {
                         listOf(
                             Struct(schema.nestedSchema("event.keys.Label1").valueSchema())
                                 .put("name", PropertyType.toConnectValue("john"))
-                                .put("surname", PropertyType.toConnectValue("doe"))))
+                                .put("surname", PropertyType.toConnectValue("doe"))
+                        ),
+                    )
                     .put(
                         "Label2",
                         listOf(
                             Struct(schema.nestedSchema("event.keys.Label2").valueSchema())
-                                .put("id", PropertyType.toConnectValue(5L)))))
+                                .put("id", PropertyType.toConnectValue(5L))
+                        ),
+                    ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -762,7 +883,11 @@ class ChangeEventExtensionsTest {
                                     "id" to PropertyType.toConnectValue(5L),
                                     "name" to PropertyType.toConnectValue("john"),
                                     "surname" to PropertyType.toConnectValue("doe"),
-                                    "age" to PropertyType.toConnectValue(25L)))))
+                                    "age" to PropertyType.toConnectValue(25L),
+                                ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -779,11 +904,15 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2", "Label3"),
                 mapOf(
                     "Label1" to listOf(mapOf("name" to "john", "surname" to "doe")),
-                    "Label2" to listOf(mapOf("id" to 5L))),
+                    "Label2" to listOf(mapOf("id" to 5L)),
+                ),
                 NodeState(
                     listOf("Label1", "Label2", "Label3"),
-                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L)),
-                null))
+                    mapOf("id" to 5L, "name" to "john", "surname" to "doe", "age" to 25L),
+                ),
+                null,
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -801,20 +930,25 @@ class ChangeEventExtensionsTest {
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "Label2",
                         SchemaBuilder.array(
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -829,9 +963,11 @@ class ChangeEventExtensionsTest {
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
@@ -843,10 +979,13 @@ class ChangeEventExtensionsTest {
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                     .field("surname", Schema.OPTIONAL_STRING_SCHEMA)
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -863,11 +1002,14 @@ class ChangeEventExtensionsTest {
                         listOf(
                             Struct(schema.nestedValueSchema("event.keys.Label1"))
                                 .put("name", "john")
-                                .put("surname", "doe")))
+                                .put("surname", "doe")
+                        ),
+                    )
                     .put(
                         "Label2",
-                        listOf(
-                            Struct(schema.nestedValueSchema("event.keys.Label2")).put("id", 5L))))
+                        listOf(Struct(schema.nestedValueSchema("event.keys.Label2")).put("id", 5L)),
+                    ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -881,7 +1023,10 @@ class ChangeEventExtensionsTest {
                                     .put("id", 5L)
                                     .put("name", "john")
                                     .put("surname", "doe")
-                                    .put("age", 25L))))
+                                    .put("age", 25L),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -896,15 +1041,21 @@ class ChangeEventExtensionsTest {
                 "rel-0",
                 "WORKS_FOR",
                 Node(
-                    "node-0", listOf("Person"), mapOf("Person" to listOf(mapOf("name" to "john")))),
+                    "node-0",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
                 Node(
                     "node-1",
                     listOf("Company"),
-                    mapOf("Company" to listOf(mapOf("name" to "acme corp")))),
+                    mapOf("Company" to listOf(mapOf("name" to "acme corp"))),
+                ),
                 listOf(mapOf("id" to 5L)),
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(1999, 12, 31)))))
+                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(1999, 12, 31))),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -926,12 +1077,16 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", PropertyType.schema)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "end",
                 SchemaBuilder.struct()
@@ -946,18 +1101,24 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", PropertyType.schema)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "keys",
                 SchemaBuilder.array(
-                        SchemaBuilder.struct().field("id", PropertyType.schema).optional().build())
+                        SchemaBuilder.struct().field("id", PropertyType.schema).optional().build()
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -966,20 +1127,23 @@ class ChangeEventExtensionsTest {
                         SchemaBuilder.struct()
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -1002,8 +1166,13 @@ class ChangeEventExtensionsTest {
                                     Struct(
                                             schema
                                                 .nestedSchema("event.start.keys.Person")
-                                                .valueSchema())
-                                        .put("name", PropertyType.toConnectValue("john"))))))
+                                                .valueSchema()
+                                        )
+                                        .put("name", PropertyType.toConnectValue("john"))
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "end",
                 Struct(schema.nestedSchema("event.end"))
@@ -1018,13 +1187,20 @@ class ChangeEventExtensionsTest {
                                     Struct(
                                             schema
                                                 .nestedSchema("event.end.keys.Company")
-                                                .valueSchema())
-                                        .put("name", PropertyType.toConnectValue("acme corp"))))))
+                                                .valueSchema()
+                                        )
+                                        .put("name", PropertyType.toConnectValue("acme corp"))
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "keys",
                 listOf(
                     Struct(schema.nestedSchema("event.keys").valueSchema())
-                        .put("id", PropertyType.toConnectValue(5L))))
+                        .put("id", PropertyType.toConnectValue(5L))
+                ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -1036,7 +1212,11 @@ class ChangeEventExtensionsTest {
                                 mapOf(
                                     "id" to PropertyType.toConnectValue(5L),
                                     "since" to
-                                        PropertyType.toConnectValue(LocalDate.of(1999, 12, 31))))))
+                                        PropertyType.toConnectValue(LocalDate.of(1999, 12, 31)),
+                                ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -1051,15 +1231,21 @@ class ChangeEventExtensionsTest {
                 "rel-0",
                 "WORKS_FOR",
                 Node(
-                    "node-0", listOf("Person"), mapOf("Person" to listOf(mapOf("name" to "john")))),
+                    "node-0",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
                 Node(
                     "node-1",
                     listOf("Company"),
-                    mapOf("Company" to listOf(mapOf("name" to "acme corp")))),
+                    mapOf("Company" to listOf(mapOf("name" to "acme corp"))),
+                ),
                 listOf(mapOf("id" to 5L)),
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(1999, 12, 31)))))
+                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(1999, 12, 31))),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -1081,12 +1267,16 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "end",
                 SchemaBuilder.struct()
@@ -1101,21 +1291,27 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "keys",
                 SchemaBuilder.array(
                         SchemaBuilder.struct()
                             .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                             .optional()
-                            .build())
+                            .build()
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -1127,9 +1323,11 @@ class ChangeEventExtensionsTest {
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("since", SimpleTypes.LOCALDATE.schema(true))
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
@@ -1138,10 +1336,13 @@ class ChangeEventExtensionsTest {
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("since", SimpleTypes.LOCALDATE.schema(true))
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -1162,7 +1363,11 @@ class ChangeEventExtensionsTest {
                                 "Person",
                                 listOf(
                                     Struct(schema.nestedValueSchema("event.start.keys.Person"))
-                                        .put("name", "john")))))
+                                        .put("name", "john")
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "end",
                 Struct(schema.nestedSchema("event.end"))
@@ -1175,7 +1380,11 @@ class ChangeEventExtensionsTest {
                                 "Company",
                                 listOf(
                                     Struct(schema.nestedValueSchema("event.end.keys.Company"))
-                                        .put("name", "acme corp")))))
+                                        .put("name", "acme corp")
+                                ),
+                            ),
+                    ),
+            )
             .put("keys", listOf(Struct(schema.nestedValueSchema("event.keys")).put("id", 5L)))
             .put(
                 "state",
@@ -1190,7 +1399,12 @@ class ChangeEventExtensionsTest {
                                     .put(
                                         "since",
                                         DateTimeFormatter.ISO_DATE.format(
-                                            LocalDate.of(1999, 12, 31))))))
+                                            LocalDate.of(1999, 12, 31)
+                                        ),
+                                    ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -1205,15 +1419,21 @@ class ChangeEventExtensionsTest {
                 "rel-0",
                 "WORKS_FOR",
                 Node(
-                    "node-0", listOf("Person"), mapOf("Person" to listOf(mapOf("name" to "john")))),
+                    "node-0",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
                 Node(
                     "node-1",
                     listOf("Company"),
-                    mapOf("Company" to listOf(mapOf("name" to "acme corp")))),
+                    mapOf("Company" to listOf(mapOf("name" to "acme corp"))),
+                ),
                 listOf(mapOf("id" to 5L)),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(1999, 12, 31))),
-                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(2000, 1, 1)))))
+                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(2000, 1, 1))),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -1235,12 +1455,16 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", PropertyType.schema)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "end",
                 SchemaBuilder.struct()
@@ -1255,18 +1479,24 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", PropertyType.schema)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "keys",
                 SchemaBuilder.array(
-                        SchemaBuilder.struct().field("id", PropertyType.schema).optional().build())
+                        SchemaBuilder.struct().field("id", PropertyType.schema).optional().build()
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -1275,20 +1505,23 @@ class ChangeEventExtensionsTest {
                         SchemaBuilder.struct()
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -1311,8 +1544,13 @@ class ChangeEventExtensionsTest {
                                     Struct(
                                             schema
                                                 .nestedSchema("event.start.keys.Person")
-                                                .valueSchema())
-                                        .put("name", PropertyType.toConnectValue("john"))))))
+                                                .valueSchema()
+                                        )
+                                        .put("name", PropertyType.toConnectValue("john"))
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "end",
                 Struct(schema.nestedSchema("event.end"))
@@ -1327,13 +1565,20 @@ class ChangeEventExtensionsTest {
                                     Struct(
                                             schema
                                                 .nestedSchema("event.end.keys.Company")
-                                                .valueSchema())
-                                        .put("name", PropertyType.toConnectValue("acme corp"))))))
+                                                .valueSchema()
+                                        )
+                                        .put("name", PropertyType.toConnectValue("acme corp"))
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "keys",
                 listOf(
                     Struct(schema.nestedSchema("event.keys").valueSchema())
-                        .put("id", PropertyType.toConnectValue(5L))))
+                        .put("id", PropertyType.toConnectValue(5L))
+                ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -1345,7 +1590,10 @@ class ChangeEventExtensionsTest {
                                 mapOf(
                                     "id" to PropertyType.toConnectValue(5L),
                                     "since" to
-                                        PropertyType.toConnectValue(LocalDate.of(1999, 12, 31)))))
+                                        PropertyType.toConnectValue(LocalDate.of(1999, 12, 31)),
+                                ),
+                            ),
+                    )
                     .put(
                         "after",
                         Struct(schema.nestedSchema("event.state.after"))
@@ -1353,8 +1601,11 @@ class ChangeEventExtensionsTest {
                                 "properties",
                                 mapOf(
                                     "id" to PropertyType.toConnectValue(5L),
-                                    "since" to
-                                        PropertyType.toConnectValue(LocalDate.of(2000, 1, 1))))))
+                                    "since" to PropertyType.toConnectValue(LocalDate.of(2000, 1, 1)),
+                                ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -1369,15 +1620,21 @@ class ChangeEventExtensionsTest {
                 "rel-0",
                 "WORKS_FOR",
                 Node(
-                    "node-0", listOf("Person"), mapOf("Person" to listOf(mapOf("name" to "john")))),
+                    "node-0",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
                 Node(
                     "node-1",
                     listOf("Company"),
-                    mapOf("Company" to listOf(mapOf("name" to "acme corp")))),
+                    mapOf("Company" to listOf(mapOf("name" to "acme corp"))),
+                ),
                 listOf(mapOf("id" to 5L)),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(1999, 12, 31))),
-                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(2000, 1, 1)))))
+                RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(2000, 1, 1))),
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -1399,12 +1656,16 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "end",
                 SchemaBuilder.struct()
@@ -1419,21 +1680,27 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "keys",
                 SchemaBuilder.array(
                         SchemaBuilder.struct()
                             .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                             .optional()
-                            .build())
+                            .build()
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -1445,9 +1712,11 @@ class ChangeEventExtensionsTest {
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("since", SimpleTypes.LOCALDATE.schema(true))
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
@@ -1456,10 +1725,13 @@ class ChangeEventExtensionsTest {
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("since", SimpleTypes.LOCALDATE.schema(true))
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -1480,7 +1752,11 @@ class ChangeEventExtensionsTest {
                                 "Person",
                                 listOf(
                                     Struct(schema.nestedValueSchema("event.start.keys.Person"))
-                                        .put("name", "john")))))
+                                        .put("name", "john")
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "end",
                 Struct(schema.nestedSchema("event.end"))
@@ -1493,7 +1769,11 @@ class ChangeEventExtensionsTest {
                                 "Company",
                                 listOf(
                                     Struct(schema.nestedValueSchema("event.end.keys.Company"))
-                                        .put("name", "acme corp")))))
+                                        .put("name", "acme corp")
+                                ),
+                            ),
+                    ),
+            )
             .put("keys", listOf(Struct(schema.nestedValueSchema("event.keys")).put("id", 5L)))
             .put(
                 "state",
@@ -1508,7 +1788,11 @@ class ChangeEventExtensionsTest {
                                     .put(
                                         "since",
                                         DateTimeFormatter.ISO_DATE.format(
-                                            LocalDate.of(1999, 12, 31)))))
+                                            LocalDate.of(1999, 12, 31)
+                                        ),
+                                    ),
+                            ),
+                    )
                     .put(
                         "after",
                         Struct(schema.nestedSchema("event.state.after"))
@@ -1518,8 +1802,11 @@ class ChangeEventExtensionsTest {
                                     .put("id", 5L)
                                     .put(
                                         "since",
-                                        DateTimeFormatter.ISO_DATE.format(
-                                            LocalDate.of(2000, 1, 1))))))
+                                        DateTimeFormatter.ISO_DATE.format(LocalDate.of(2000, 1, 1)),
+                                    ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -1534,15 +1821,21 @@ class ChangeEventExtensionsTest {
                 "rel-0",
                 "WORKS_FOR",
                 Node(
-                    "node-0", listOf("Person"), mapOf("Person" to listOf(mapOf("name" to "john")))),
+                    "node-0",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
                 Node(
                     "node-1",
                     listOf("Company"),
-                    mapOf("Company" to listOf(mapOf("name" to "acme corp")))),
+                    mapOf("Company" to listOf(mapOf("name" to "acme corp"))),
+                ),
                 listOf(mapOf("id" to 5L)),
                 EntityOperation.DELETE,
                 RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(2000, 1, 1))),
-                null))
+                null,
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -1564,12 +1857,16 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", PropertyType.schema)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "end",
                 SchemaBuilder.struct()
@@ -1584,18 +1881,24 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", PropertyType.schema)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "keys",
                 SchemaBuilder.array(
-                        SchemaBuilder.struct().field("id", PropertyType.schema).optional().build())
+                        SchemaBuilder.struct().field("id", PropertyType.schema).optional().build()
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -1604,20 +1907,23 @@ class ChangeEventExtensionsTest {
                         SchemaBuilder.struct()
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
                             .field(
                                 "properties",
-                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
-                                    .build())
+                                SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -1640,8 +1946,13 @@ class ChangeEventExtensionsTest {
                                     Struct(
                                             schema
                                                 .nestedSchema("event.start.keys.Person")
-                                                .valueSchema())
-                                        .put("name", PropertyType.toConnectValue("john"))))))
+                                                .valueSchema()
+                                        )
+                                        .put("name", PropertyType.toConnectValue("john"))
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "end",
                 Struct(schema.nestedSchema("event.end"))
@@ -1656,13 +1967,20 @@ class ChangeEventExtensionsTest {
                                     Struct(
                                             schema
                                                 .nestedSchema("event.end.keys.Company")
-                                                .valueSchema())
-                                        .put("name", PropertyType.toConnectValue("acme corp"))))))
+                                                .valueSchema()
+                                        )
+                                        .put("name", PropertyType.toConnectValue("acme corp"))
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "keys",
                 listOf(
                     Struct(schema.nestedSchema("event.keys").valueSchema())
-                        .put("id", PropertyType.toConnectValue(5L))))
+                        .put("id", PropertyType.toConnectValue(5L))
+                ),
+            )
             .put(
                 "state",
                 Struct(schema.nestedSchema("event.state"))
@@ -1673,8 +1991,11 @@ class ChangeEventExtensionsTest {
                                 "properties",
                                 mapOf(
                                     "id" to PropertyType.toConnectValue(5L),
-                                    "since" to
-                                        PropertyType.toConnectValue(LocalDate.of(2000, 1, 1))))))
+                                    "since" to PropertyType.toConnectValue(LocalDate.of(2000, 1, 1)),
+                                ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -1689,15 +2010,21 @@ class ChangeEventExtensionsTest {
                 "rel-0",
                 "WORKS_FOR",
                 Node(
-                    "node-0", listOf("Person"), mapOf("Person" to listOf(mapOf("name" to "john")))),
+                    "node-0",
+                    listOf("Person"),
+                    mapOf("Person" to listOf(mapOf("name" to "john"))),
+                ),
                 Node(
                     "node-1",
                     listOf("Company"),
-                    mapOf("Company" to listOf(mapOf("name" to "acme corp")))),
+                    mapOf("Company" to listOf(mapOf("name" to "acme corp"))),
+                ),
                 listOf(mapOf("id" to 5L)),
                 EntityOperation.DELETE,
                 RelationshipState(mapOf("id" to 5L, "since" to LocalDate.of(2000, 1, 1))),
-                null))
+                null,
+            ),
+        )
 
     schema.nestedSchema("event") shouldBe
         SchemaBuilder.struct()
@@ -1719,12 +2046,16 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "end",
                 SchemaBuilder.struct()
@@ -1739,21 +2070,27 @@ class ChangeEventExtensionsTest {
                                         SchemaBuilder.struct()
                                             .field("name", Schema.OPTIONAL_STRING_SCHEMA)
                                             .optional()
-                                            .build())
+                                            .build()
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .field(
                 "keys",
                 SchemaBuilder.array(
                         SchemaBuilder.struct()
                             .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                             .optional()
-                            .build())
+                            .build()
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .field(
                 "state",
                 SchemaBuilder.struct()
@@ -1765,9 +2102,11 @@ class ChangeEventExtensionsTest {
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("since", SimpleTypes.LOCALDATE.schema(true))
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "after",
                         SchemaBuilder.struct()
@@ -1776,10 +2115,13 @@ class ChangeEventExtensionsTest {
                                 SchemaBuilder.struct()
                                     .field("id", Schema.OPTIONAL_INT64_SCHEMA)
                                     .field("since", SimpleTypes.LOCALDATE.schema(true))
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
-                    .build())
+                            .build(),
+                    )
+                    .build(),
+            )
             .build()
 
     value.get("event") shouldBe
@@ -1800,7 +2142,11 @@ class ChangeEventExtensionsTest {
                                 "Person",
                                 listOf(
                                     Struct(schema.nestedValueSchema("event.start.keys.Person"))
-                                        .put("name", "john")))))
+                                        .put("name", "john")
+                                ),
+                            ),
+                    ),
+            )
             .put(
                 "end",
                 Struct(schema.nestedSchema("event.end"))
@@ -1813,7 +2159,11 @@ class ChangeEventExtensionsTest {
                                 "Company",
                                 listOf(
                                     Struct(schema.nestedValueSchema("event.end.keys.Company"))
-                                        .put("name", "acme corp")))))
+                                        .put("name", "acme corp")
+                                ),
+                            ),
+                    ),
+            )
             .put("keys", listOf(Struct(schema.nestedValueSchema("event.keys")).put("id", 5L)))
             .put(
                 "state",
@@ -1827,8 +2177,11 @@ class ChangeEventExtensionsTest {
                                     .put("id", 5L)
                                     .put(
                                         "since",
-                                        DateTimeFormatter.ISO_DATE.format(
-                                            LocalDate.of(2000, 1, 1))))))
+                                        DateTimeFormatter.ISO_DATE.format(LocalDate.of(2000, 1, 1)),
+                                    ),
+                            ),
+                    ),
+            )
 
     val reverted = value.toChangeEvent()
     reverted shouldBe change
@@ -1838,7 +2191,7 @@ class ChangeEventExtensionsTest {
   @ArgumentsSource(PayloadModeValues::class)
   fun `node event keys should be nullified when node keys are not defined`(
       name: String,
-      payloadMode: PayloadMode
+      payloadMode: PayloadMode,
   ) {
     val (_, _, schema, value) =
         newChangeEvent(
@@ -1849,7 +2202,9 @@ class ChangeEventExtensionsTest {
                 listOf("Label1", "Label2"),
                 mapOf(),
                 null,
-                NodeState(listOf("Label1"), mapOf("id" to 5L))))
+                NodeState(listOf("Label1"), mapOf("id" to 5L)),
+            ),
+        )
 
     val expectedKeySchema = SchemaBuilder.struct().optional().build()
     schema.nestedSchema("event.keys") shouldBe expectedKeySchema
@@ -1860,7 +2215,7 @@ class ChangeEventExtensionsTest {
   @ArgumentsSource(PayloadModeValues::class)
   fun `relationship event keys should be nullified when rel keys are not defined`(
       name: String,
-      payloadMode: PayloadMode
+      payloadMode: PayloadMode,
   ) {
     val (_, _, schema, value) =
         newChangeEvent(
@@ -1873,7 +2228,9 @@ class ChangeEventExtensionsTest {
                 listOf(),
                 EntityOperation.DELETE,
                 RelationshipState(mapOf("id" to 5L)),
-                null))
+                null,
+            ),
+        )
 
     val expectedKeySchema =
         SchemaBuilder.array(SchemaBuilder.struct().optional().build()).optional().build()
@@ -1899,7 +2256,8 @@ class ChangeEventExtensionsTest {
             startTime,
             commitTime,
             mapOf("user" to "app_user", "app" to "hr", "xyz" to mapOf("a" to 1L, "b" to 2L)),
-            mapOf("new_field" to "abc", "another_field" to 1L))
+            mapOf("new_field" to "abc", "another_field" to 1L),
+        )
 
     val changeEventConverter = ChangeEventConverter(PayloadMode.EXTENDED)
     val schema = changeEventConverter.metadataToConnectSchema(metadata)
@@ -1925,7 +2283,9 @@ class ChangeEventExtensionsTest {
                         "xyz",
                         Struct(schema.nestedSchema("txMetadata.xyz"))
                             .put("a", PropertyType.toConnectValue(1L))
-                            .put("b", PropertyType.toConnectValue(2L))))
+                            .put("b", PropertyType.toConnectValue(2L)),
+                    ),
+            )
             .put("new_field", PropertyType.toConnectValue("abc"))
             .put("another_field", PropertyType.toConnectValue(1L))
 
@@ -1950,7 +2310,8 @@ class ChangeEventExtensionsTest {
             startTime,
             commitTime,
             mapOf("user" to "app_user", "app" to "hr", "xyz" to mapOf("a" to 1L, "b" to 2L)),
-            mapOf("new_field" to "abc", "another_field" to 1L))
+            mapOf("new_field" to "abc", "another_field" to 1L),
+        )
 
     val changeEventConverter = ChangeEventConverter(PayloadMode.COMPACT)
     val schema = changeEventConverter.metadataToConnectSchema(metadata)
@@ -1974,7 +2335,9 @@ class ChangeEventExtensionsTest {
                     .put("app", "hr")
                     .put(
                         "xyz",
-                        Struct(schema.nestedSchema("txMetadata.xyz")).put("a", 1L).put("b", 2L)))
+                        Struct(schema.nestedSchema("txMetadata.xyz")).put("a", 1L).put("b", 2L),
+                    ),
+            )
             .put("new_field", "abc")
             .put("another_field", 1L)
 
@@ -1986,7 +2349,7 @@ class ChangeEventExtensionsTest {
   @ArgumentsSource(PayloadModeValues::class)
   fun `node events should be converted to struct and back with extended payload`(
       name: String,
-      payloadMode: PayloadMode
+      payloadMode: PayloadMode,
   ) {
     val changeEventConverter = ChangeEventConverter(payloadMode)
 
@@ -2003,7 +2366,10 @@ class ChangeEventExtensionsTest {
                         "id" to 1L,
                         "name" to "john",
                         "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1)))),
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             NodeEvent(
                 "rel-1",
                 EntityOperation.CREATE,
@@ -2016,7 +2382,10 @@ class ChangeEventExtensionsTest {
                         "id" to 1L,
                         "name" to "john",
                         "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1)))),
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             NodeEvent(
                 "rel-1",
                 EntityOperation.CREATE,
@@ -2024,7 +2393,8 @@ class ChangeEventExtensionsTest {
                 mapOf(
                     "Person" to
                         listOf(mapOf("id" to 1L), mapOf("name" to "john", "surname" to "doe")),
-                    "Employee" to listOf(mapOf("id" to 1L))),
+                    "Employee" to listOf(mapOf("id" to 1L)),
+                ),
                 null,
                 NodeState(
                     listOf("Person", "Employee"),
@@ -2032,7 +2402,10 @@ class ChangeEventExtensionsTest {
                         "id" to 1L,
                         "name" to "john",
                         "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1)))),
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             NodeEvent(
                 "rel-1",
                 EntityOperation.UPDATE,
@@ -2040,7 +2413,8 @@ class ChangeEventExtensionsTest {
                 mapOf(
                     "Person" to
                         listOf(mapOf("id" to 1L), mapOf("name" to "john", "surname" to "doe")),
-                    "Employee" to listOf(mapOf("id" to 1L))),
+                    "Employee" to listOf(mapOf("id" to 1L)),
+                ),
                 NodeState(
                     listOf("Person"),
                     mapOf(
@@ -2048,14 +2422,19 @@ class ChangeEventExtensionsTest {
                         "name" to "john",
                         "surname" to "doe",
                         "dob" to LocalDate.of(1990, 1, 1),
-                        "pob" to "London")),
+                        "pob" to "London",
+                    ),
+                ),
                 NodeState(
                     listOf("Person", "Employee"),
                     mapOf(
                         "id" to 1L,
                         "name" to "john",
                         "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1)))),
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+            ),
             NodeEvent(
                 "rel-1",
                 EntityOperation.DELETE,
@@ -2063,15 +2442,20 @@ class ChangeEventExtensionsTest {
                 mapOf(
                     "Person" to
                         listOf(mapOf("id" to 1L), mapOf("name" to "john", "surname" to "doe")),
-                    "Employee" to listOf(mapOf("id" to 1L))),
+                    "Employee" to listOf(mapOf("id" to 1L)),
+                ),
                 NodeState(
                     listOf("Person", "Employee"),
                     mapOf(
                         "id" to 1L,
                         "name" to "john",
                         "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1))),
-                null))
+                        "dob" to LocalDate.of(1990, 1, 1),
+                    ),
+                ),
+                null,
+            ),
+        )
         .forEach { event ->
           val schema = changeEventConverter.nodeEventToConnectSchema(event)
           val converted = changeEventConverter.nodeEventToConnectValue(event, schema)
@@ -2091,7 +2475,9 @@ class ChangeEventExtensionsTest {
             listOf("Person", "Employee"),
             mapOf(
                 "Person" to listOf(mapOf("id" to 1L), mapOf("name" to "john", "surname" to "doe")),
-                "Employee" to listOf(mapOf("id" to 5L, "company_id" to 7L))))
+                "Employee" to listOf(mapOf("id" to 5L, "company_id" to 7L)),
+            ),
+        )
     val schema = changeEventConverter.nodeToConnectSchema(node)
     val converted = changeEventConverter.nodeToConnectValue(node, schema)
 
@@ -2109,13 +2495,18 @@ class ChangeEventExtensionsTest {
                                 .put("id", PropertyType.toConnectValue(1L)),
                             Struct(schema.nestedSchema("keys.Person").valueSchema())
                                 .put("name", PropertyType.toConnectValue("john"))
-                                .put("surname", PropertyType.toConnectValue("doe"))))
+                                .put("surname", PropertyType.toConnectValue("doe")),
+                        ),
+                    )
                     .put(
                         "Employee",
                         listOf(
                             Struct(schema.nestedSchema("keys.Employee").valueSchema())
                                 .put("id", PropertyType.toConnectValue(5L))
-                                .put("company_id", PropertyType.toConnectValue(7L)))))
+                                .put("company_id", PropertyType.toConnectValue(7L))
+                        ),
+                    ),
+            )
 
     val reverted = converted.toNode()
     reverted shouldBe node
@@ -2131,7 +2522,9 @@ class ChangeEventExtensionsTest {
             listOf("Person", "Employee"),
             mapOf(
                 "Person" to listOf(mapOf("id" to 1L), mapOf("name" to "john", "surname" to "doe")),
-                "Employee" to listOf(mapOf("id" to 5L, "company_id" to 7L))))
+                "Employee" to listOf(mapOf("id" to 5L, "company_id" to 7L)),
+            ),
+        )
     val schema = changeEventConverter.nodeToConnectSchema(node)
     val converted = changeEventConverter.nodeToConnectValue(node, schema)
 
@@ -2148,13 +2541,18 @@ class ChangeEventExtensionsTest {
                             Struct(schema.nestedSchema("keys.Person").valueSchema()).put("id", 1L),
                             Struct(schema.nestedSchema("keys.Person").valueSchema())
                                 .put("name", "john")
-                                .put("surname", "doe")))
+                                .put("surname", "doe"),
+                        ),
+                    )
                     .put(
                         "Employee",
                         listOf(
                             Struct(schema.nestedSchema("keys.Employee").valueSchema())
                                 .put("id", 5L)
-                                .put("company_id", 7L))))
+                                .put("company_id", 7L)
+                        ),
+                    ),
+            )
 
     val reverted = converted.toNode()
     reverted shouldBe node
@@ -2164,7 +2562,7 @@ class ChangeEventExtensionsTest {
   @ArgumentsSource(PayloadModeValues::class)
   fun `relationship events should be converted to struct and back`(
       name: String,
-      payloadMode: PayloadMode
+      payloadMode: PayloadMode,
   ) {
     val changeEventConverter = ChangeEventConverter(payloadMode)
 
@@ -2177,20 +2575,22 @@ class ChangeEventExtensionsTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe")))),
+                            listOf(mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe"))
+                    ),
+                ),
                 Node(
                     "node-2",
                     listOf("Person"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe")))),
+                            listOf(mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe"))
+                    ),
+                ),
                 null,
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(
-                    mapOf("since" to LocalDate.of(2012, 10, 1), "met_at" to "London"))),
+                RelationshipState(mapOf("since" to LocalDate.of(2012, 10, 1), "met_at" to "London")),
+            ),
             RelationshipEvent(
                 "rel-1",
                 "KNOWS",
@@ -2199,20 +2599,22 @@ class ChangeEventExtensionsTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe")))),
+                            listOf(mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe"))
+                    ),
+                ),
                 Node(
                     "node-2",
                     listOf("Person"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe")))),
+                            listOf(mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe"))
+                    ),
+                ),
                 listOf(),
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(
-                    mapOf("since" to LocalDate.of(2012, 10, 1), "met_at" to "London"))),
+                RelationshipState(mapOf("since" to LocalDate.of(2012, 10, 1), "met_at" to "London")),
+            ),
             RelationshipEvent(
                 "rel-1",
                 "KNOWS",
@@ -2221,15 +2623,17 @@ class ChangeEventExtensionsTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe")))),
+                            listOf(mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe"))
+                    ),
+                ),
                 Node(
                     "node-2",
                     listOf("Person"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe")))),
+                            listOf(mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe"))
+                    ),
+                ),
                 listOf(mapOf("a" to 1L), mapOf("b" to "another")),
                 EntityOperation.CREATE,
                 null,
@@ -2238,7 +2642,10 @@ class ChangeEventExtensionsTest {
                         "since" to LocalDate.of(2012, 10, 1),
                         "met_at" to "London",
                         "a" to 1L,
-                        "b" to "another"))),
+                        "b" to "another",
+                    )
+                ),
+            ),
             RelationshipEvent(
                 "rel-1",
                 "KNOWS",
@@ -2247,15 +2654,17 @@ class ChangeEventExtensionsTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe")))),
+                            listOf(mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe"))
+                    ),
+                ),
                 Node(
                     "node-2",
                     listOf("Person"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe")))),
+                            listOf(mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe"))
+                    ),
+                ),
                 listOf(mapOf("a" to 1L), mapOf("b" to "another")),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("a" to 1L, "b" to "another", "c" to 5L)),
@@ -2264,7 +2673,10 @@ class ChangeEventExtensionsTest {
                         "since" to LocalDate.of(2012, 10, 1),
                         "met_at" to "London",
                         "a" to 1L,
-                        "b" to "another"))),
+                        "b" to "another",
+                    )
+                ),
+            ),
             RelationshipEvent(
                 "rel-1",
                 "KNOWS",
@@ -2273,15 +2685,17 @@ class ChangeEventExtensionsTest {
                     listOf("Person", "Employee"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe")))),
+                            listOf(mapOf("id" to 5L), mapOf("name" to "john", "surname" to "doe"))
+                    ),
+                ),
                 Node(
                     "node-2",
                     listOf("Person"),
                     mapOf(
                         "Person" to
-                            listOf(
-                                mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe")))),
+                            listOf(mapOf("id" to 4L), mapOf("name" to "mary", "surname" to "doe"))
+                    ),
+                ),
                 listOf(mapOf("a" to 1L), mapOf("b" to "another")),
                 EntityOperation.DELETE,
                 RelationshipState(
@@ -2289,8 +2703,12 @@ class ChangeEventExtensionsTest {
                         "since" to LocalDate.of(2012, 10, 1),
                         "met_at" to "London",
                         "a" to 1L,
-                        "b" to "another")),
-                null))
+                        "b" to "another",
+                    )
+                ),
+                null,
+            ),
+        )
         .forEach { event ->
           val schema = changeEventConverter.relationshipEventToConnectSchema(event)
           val converted = changeEventConverter.relationshipEventToConnectValue(event, schema)
@@ -2303,11 +2721,12 @@ class ChangeEventExtensionsTest {
   object PayloadModeValues : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of("extended", PayloadMode.EXTENDED),
-          Arguments.of("compact", PayloadMode.COMPACT))
+          Arguments.of("compact", PayloadMode.COMPACT),
+      )
     }
   }
 
@@ -2315,7 +2734,7 @@ class ChangeEventExtensionsTest {
       val event: T,
       val change: ChangeEvent,
       val schema: Schema,
-      val converted: Struct
+      val converted: Struct,
   )
 
   private fun <T : Event> newChangeEvent(payloadMode: PayloadMode, event: T): ChangeEventResult<T> {
@@ -2337,12 +2756,18 @@ class ChangeEventExtensionsTest {
                 ZonedDateTime.now().minusSeconds(1),
                 ZonedDateTime.now(),
                 mapOf("user" to "app_user", "app" to "hr"),
-                emptyMap()),
-            event)
+                emptyMap(),
+            ),
+            event,
+        )
     val schemaAndValue = changeEventConverter.toConnectValue(change)
 
     return ChangeEventResult(
-        event, change, schemaAndValue.schema(), schemaAndValue.value() as Struct)
+        event,
+        change,
+        schemaAndValue.schema(),
+        schemaAndValue.value() as Struct,
+    )
   }
 
   private fun Schema.nestedSchema(path: String): Schema {

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCommon.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCommon.kt
@@ -56,7 +56,7 @@ class TestRelationship(
     val startId: Long,
     val endId: Long,
     val type: String,
-    props: Map<String, Value>
+    props: Map<String, Value>,
 ) : Entity(props), Relationship {
   override fun id(): Long = id
 

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCompactTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesCompactTest.kt
@@ -83,7 +83,8 @@ class DynamicTypesCompactTest {
 
               override fun subSequence(startIndex: Int, endIndex: Int): CharSequence =
                   value.subSequence(startIndex, endIndex)
-            })
+            },
+        )
         .forEach { string ->
           withClue(string) {
             DynamicTypes.toConnectSchema(payloadMode, string, false) shouldBe
@@ -181,42 +182,59 @@ class DynamicTypesCompactTest {
         SimpleTypes.LOCALTIME.schema(true)
 
     DynamicTypes.toConnectSchema(
-        payloadMode, LocalDateTime.of(1999, 12, 31, 23, 59, 59), optional = false) shouldBe
-        SimpleTypes.LOCALDATETIME.schema()
+        payloadMode,
+        LocalDateTime.of(1999, 12, 31, 23, 59, 59),
+        optional = false,
+    ) shouldBe SimpleTypes.LOCALDATETIME.schema()
     DynamicTypes.toConnectSchema(
-        payloadMode, LocalDateTime.of(1999, 12, 31, 23, 59, 59), optional = true) shouldBe
-        SimpleTypes.LOCALDATETIME.schema(true)
+        payloadMode,
+        LocalDateTime.of(1999, 12, 31, 23, 59, 59),
+        optional = true,
+    ) shouldBe SimpleTypes.LOCALDATETIME.schema(true)
 
     DynamicTypes.toConnectSchema(
-        payloadMode, OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC), optional = false) shouldBe
-        SimpleTypes.OFFSETTIME.schema()
+        payloadMode,
+        OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC),
+        optional = false,
+    ) shouldBe SimpleTypes.OFFSETTIME.schema()
     DynamicTypes.toConnectSchema(
-        payloadMode, OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC), optional = true) shouldBe
-        SimpleTypes.OFFSETTIME.schema(true)
+        payloadMode,
+        OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC),
+        optional = true,
+    ) shouldBe SimpleTypes.OFFSETTIME.schema(true)
 
     DynamicTypes.toConnectSchema(
         payloadMode,
         OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC),
-        optional = false) shouldBe SimpleTypes.ZONEDDATETIME.schema()
+        optional = false,
+    ) shouldBe SimpleTypes.ZONEDDATETIME.schema()
     DynamicTypes.toConnectSchema(
-        payloadMode, OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC), true) shouldBe
-        SimpleTypes.ZONEDDATETIME.schema(true)
+        payloadMode,
+        OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC),
+        true,
+    ) shouldBe SimpleTypes.ZONEDDATETIME.schema(true)
 
     DynamicTypes.toConnectSchema(
         payloadMode,
         ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneId.of("Europe/London")),
-        optional = false) shouldBe SimpleTypes.ZONEDDATETIME.schema()
+        optional = false,
+    ) shouldBe SimpleTypes.ZONEDDATETIME.schema()
     DynamicTypes.toConnectSchema(
         payloadMode,
         ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneId.of("Europe/London")),
-        optional = true) shouldBe SimpleTypes.ZONEDDATETIME.schema(true)
+        optional = true,
+    ) shouldBe SimpleTypes.ZONEDDATETIME.schema(true)
 
     DynamicTypes.toConnectSchema(
-        payloadMode, Values.isoDuration(12, 12, 59, 1230).asIsoDuration(), false) shouldBe
-        SimpleTypes.DURATION.schema()
+        payloadMode,
+        Values.isoDuration(12, 12, 59, 1230).asIsoDuration(),
+        false,
+    ) shouldBe SimpleTypes.DURATION.schema()
     DynamicTypes.toConnectSchema(
-        payloadMode, Values.isoDuration(12, 12, 59, 1230).asIsoDuration(), true) shouldBe
-        SimpleTypes.DURATION.schema(true)
+        payloadMode,
+        Values.isoDuration(12, 12, 59, 1230).asIsoDuration(),
+        true,
+    ) shouldBe SimpleTypes.DURATION.schema(true)
 
     // Point
     listOf(Values.point(4326, 1.0, 2.0).asPoint(), Values.point(4326, 1.0, 2.0, 3.0).asPoint())
@@ -241,8 +259,10 @@ class DynamicTypesCompactTest {
         TestNode(
             0,
             listOf("Person"),
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe"))),
-        false) shouldBe
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        ),
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<labels>", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
@@ -252,7 +272,10 @@ class DynamicTypesCompactTest {
 
     // Relationship
     DynamicTypes.toConnectSchema(
-        payloadMode, TestRelationship(0, 1, 2, "KNOWS", emptyMap()), false) shouldBe
+        payloadMode,
+        TestRelationship(0, 1, 2, "KNOWS", emptyMap()),
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<type>", SchemaBuilder.STRING_SCHEMA)
@@ -266,8 +289,10 @@ class DynamicTypesCompactTest {
             1,
             2,
             "KNOWS",
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe"))),
-        false) shouldBe
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        ),
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<type>", SchemaBuilder.STRING_SCHEMA)
@@ -347,7 +372,8 @@ class DynamicTypesCompactTest {
     listOf(
             mapOf("a" to 1, "b" to 2, "c" to 3) to Schema.INT64_SCHEMA,
             mapOf("a" to "a", "b" to "b", "c" to "c") to Schema.STRING_SCHEMA,
-            mapOf("a" to 1, "b" to 2.toShort(), "c" to 3.toLong()) to Schema.INT64_SCHEMA)
+            mapOf("a" to 1, "b" to 2.toShort(), "c" to 3.toLong()) to Schema.INT64_SCHEMA,
+        )
         .forEach { (map, valueSchema) ->
           withClue("not optional: $map") {
             DynamicTypes.toConnectSchema(payloadMode, map, false) shouldBe
@@ -358,7 +384,8 @@ class DynamicTypesCompactTest {
     listOf(
             mapOf("a" to 1, "b" to 2, "c" to 3) to Schema.OPTIONAL_INT64_SCHEMA,
             mapOf("a" to "a", "b" to "b", "c" to "c") to Schema.OPTIONAL_STRING_SCHEMA,
-            mapOf("a" to 1, "b" to 2.toShort(), "c" to 3.toLong()) to Schema.OPTIONAL_INT64_SCHEMA)
+            mapOf("a" to 1, "b" to 2.toShort(), "c" to 3.toLong()) to Schema.OPTIONAL_INT64_SCHEMA,
+        )
         .forEach { (map, valueSchema) ->
           withClue("optional: $map") {
             DynamicTypes.toConnectSchema(payloadMode, map, true) shouldBe
@@ -372,7 +399,8 @@ class DynamicTypesCompactTest {
     DynamicTypes.toConnectSchema(
         payloadMode,
         mapOf("a" to 1, "b" to true, "c" to "string", "d" to 5.toFloat()),
-        false) shouldBe
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("a", Schema.INT64_SCHEMA)
             .field("b", Schema.BOOLEAN_SCHEMA)
@@ -383,7 +411,8 @@ class DynamicTypesCompactTest {
     DynamicTypes.toConnectSchema(
         payloadMode,
         mapOf("a" to 1, "b" to true, "c" to "string", "d" to 5.toFloat()),
-        true) shouldBe
+        true,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("a", Schema.OPTIONAL_INT64_SCHEMA)
             .field("b", Schema.OPTIONAL_BOOLEAN_SCHEMA)
@@ -418,7 +447,8 @@ class DynamicTypesCompactTest {
             'c' to "c",
             "string" to "string",
             "string".toCharArray() to "string",
-            "string".toByteArray() to "string".toByteArray())
+            "string".toByteArray() to "string".toByteArray(),
+        )
         .forEach { (value, expected) ->
           withClue(value) {
             val schema = DynamicTypes.toConnectSchema(payloadMode, value, false)
@@ -439,7 +469,8 @@ class DynamicTypesCompactTest {
                     .put("months", 5L)
                     .put("days", 2L)
                     .put("seconds", 0L)
-                    .put("nanoseconds", 9999))
+                    .put("nanoseconds", 9999)
+        )
         .forEach { (value, expected) ->
           withClue(value) {
             val schema = DynamicTypes.toConnectSchema(payloadMode, value, false)
@@ -480,7 +511,8 @@ class DynamicTypesCompactTest {
             Array(1) { "string" } to Array(1) { "string" },
             listOf(1, 2, 3) to arrayOf(1L, 2L, 3L),
             listOf("a", "b", "c") to arrayOf("a", "b", "c"),
-            setOf(true, false) to arrayOf(true, false))
+            setOf(true, false) to arrayOf(true, false),
+        )
         .forEach { (value, expected) ->
           withClue(value) {
             val schema = DynamicTypes.toConnectSchema(payloadMode, value, false)
@@ -498,7 +530,8 @@ class DynamicTypesCompactTest {
   fun `maps should be returned as maps and should be converted back`() {
     listOf(
             mapOf("a" to "x", "b" to "y", "c" to "z") to mapOf("a" to "x", "b" to "y", "c" to "z"),
-            mapOf("a" to 1, "b" to 2, "c" to 3) to mapOf("a" to 1L, "b" to 2L, "c" to 3L))
+            mapOf("a" to 1, "b" to 2, "c" to 3) to mapOf("a" to 1L, "b" to 2L, "c" to 3L),
+        )
         .forEach { (value, expected) ->
           withClue(value) {
             val schema = DynamicTypes.toConnectSchema(payloadMode, value, false)
@@ -555,7 +588,8 @@ class DynamicTypesCompactTest {
         TestNode(
             0,
             listOf("Person", "Employee"),
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")))
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        )
     val schema = DynamicTypes.toConnectSchema(payloadMode, node, false)
     val converted = DynamicTypes.toConnectValue(schema, node)
 
@@ -572,7 +606,8 @@ class DynamicTypesCompactTest {
             "<id>" to 0L,
             "<labels>" to listOf("Person", "Employee"),
             "name" to "john",
-            "surname" to "doe")
+            "surname" to "doe",
+        )
   }
 
   @Test
@@ -583,7 +618,8 @@ class DynamicTypesCompactTest {
             1,
             2,
             "KNOWS",
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")))
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        )
     val schema = DynamicTypes.toConnectSchema(payloadMode, rel, false)
     val converted = DynamicTypes.toConnectValue(schema, rel)
 
@@ -604,7 +640,8 @@ class DynamicTypesCompactTest {
             "<end.id>" to 2L,
             "<type>" to "KNOWS",
             "name" to "john",
-            "surname" to "doe")
+            "surname" to "doe",
+        )
   }
 
   @Test
@@ -615,7 +652,8 @@ class DynamicTypesCompactTest {
             "age" to 21,
             "dob" to LocalDate.of(1999, 12, 31),
             "employed" to true,
-            "nullable" to null)
+            "nullable" to null,
+        )
     val schema = DynamicTypes.toConnectSchema(payloadMode, map, false)
     val converted = DynamicTypes.toConnectValue(schema, map)
 
@@ -667,7 +705,8 @@ class DynamicTypesCompactTest {
             .put("last_name", "doe")
             .put(
                 "dob",
-                DynamicTypes.toConnectValue(SimpleTypes.LOCALDATE.schema, LocalDate.of(2000, 1, 1)))
+                DynamicTypes.toConnectValue(SimpleTypes.LOCALDATE.schema, LocalDate.of(2000, 1, 1)),
+            )
 
     DynamicTypes.fromConnectValue(schema, struct) shouldBe
         mapOf("id" to 1, "name" to "john", "last_name" to "doe", "dob" to LocalDate.of(2000, 1, 1))
@@ -689,7 +728,9 @@ class DynamicTypesCompactTest {
             .field("address", addressSchema)
             .field("years_of_interest", SchemaBuilder.array(Schema.INT32_SCHEMA))
             .field(
-                "events_of_interest", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA))
+                "events_of_interest",
+                SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA),
+            )
             .build()
     val struct =
         Struct(schema)
@@ -698,12 +739,14 @@ class DynamicTypesCompactTest {
             .put("last_name", "doe")
             .put(
                 "dob",
-                DynamicTypes.toConnectValue(SimpleTypes.LOCALDATE.schema, LocalDate.of(2000, 1, 1)))
+                DynamicTypes.toConnectValue(SimpleTypes.LOCALDATE.schema, LocalDate.of(2000, 1, 1)),
+            )
             .put("address", Struct(addressSchema).put("city", "london").put("country", "uk"))
             .put("years_of_interest", listOf(2000, 2005, 2017))
             .put(
                 "events_of_interest",
-                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"))
+                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"),
+            )
 
     DynamicTypes.fromConnectValue(schema, struct) shouldBe
         mapOf(
@@ -714,6 +757,7 @@ class DynamicTypesCompactTest {
             "address" to mapOf("city" to "london", "country" to "uk"),
             "years_of_interest" to listOf(2000, 2005, 2017),
             "events_of_interest" to
-                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"))
+                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"),
+        )
   }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesExtendedTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesExtendedTest.kt
@@ -58,7 +58,7 @@ class DynamicTypesExtendedTest {
   fun `should derive schema for property typed values and convert them back and forth`(
       name: String,
       value: Any?,
-      expectedIfDifferent: Any?
+      expectedIfDifferent: Any?,
   ) {
     DynamicTypes.toConnectSchema(payloadMode, value, false) shouldBe PropertyType.schema
     DynamicTypes.toConnectSchema(payloadMode, value, true) shouldBe PropertyType.schema
@@ -73,7 +73,7 @@ class DynamicTypesExtendedTest {
   object PropertyTypedValueProvider : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of("null", null, null),
@@ -99,7 +99,8 @@ class DynamicTypesExtendedTest {
                 override fun subSequence(startIndex: Int, endIndex: Int): CharSequence =
                     value.subSequence(startIndex, endIndex)
               },
-              "a char sequence"),
+              "a char sequence",
+          ),
           Arguments.of("local date", LocalDate.of(1999, 12, 31), null),
           Arguments.of("local time", LocalTime.of(23, 59, 59), null),
           Arguments.of("local date time", LocalDateTime.of(1999, 12, 31, 23, 59, 59), null),
@@ -107,11 +108,13 @@ class DynamicTypesExtendedTest {
           Arguments.of(
               "offset date time",
               OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC),
-              null),
+              null,
+          ),
           Arguments.of(
               "zoned date time",
               ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneId.of("Europe/London")),
-              null),
+              null,
+          ),
           Arguments.of("duration", Values.isoDuration(12, 12, 59, 1230).asIsoDuration(), null),
           Arguments.of("point (2d)", Values.point(4326, 1.0, 2.0).asPoint(), null),
           Arguments.of("point (3d)", Values.point(4326, 1.0, 2.0, 3.0).asPoint(), null),
@@ -160,53 +163,76 @@ class DynamicTypesExtendedTest {
           Arguments.of(
               "array (local date time)",
               Array(1) { LocalDateTime.of(1999, 12, 31, 23, 59, 59) },
-              null),
+              null,
+          ),
           Arguments.of(
-              "list (local date time)", listOf(LocalDateTime.of(1999, 12, 31, 23, 59, 59)), null),
+              "list (local date time)",
+              listOf(LocalDateTime.of(1999, 12, 31, 23, 59, 59)),
+              null,
+          ),
           Arguments.of("empty list (local date time)", emptyList<LocalDateTime>(), null),
           Arguments.of(
               "array (offset time)",
               Array(1) { OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC) },
-              null),
+              null,
+          ),
           Arguments.of(
-              "list (offset time)", listOf(OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC)), null),
+              "list (offset time)",
+              listOf(OffsetTime.of(23, 59, 59, 0, ZoneOffset.UTC)),
+              null,
+          ),
           Arguments.of("empty list (offset time)", emptyList<OffsetTime>(), null),
           Arguments.of(
               "array (offset date time)",
               Array(1) { OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC) },
-              null),
+              null,
+          ),
           Arguments.of(
               "list (offset date time)",
               listOf(OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC)),
-              null),
+              null,
+          ),
           Arguments.of("empty list (offset date time)", emptyList<OffsetDateTime>(), null),
           Arguments.of(
               "array (zoned date time)",
               Array(1) {
                 ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneId.of("Europe/London"))
               },
-              null),
+              null,
+          ),
           Arguments.of(
               "list (zoned date time)",
               listOf(ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 0, ZoneId.of("Europe/London"))),
-              null),
+              null,
+          ),
           Arguments.of("empty list (zoned date time)", emptyList<ZonedDateTime>(), null),
           Arguments.of(
               "array (duration)",
               Array(1) { Values.isoDuration(12, 12, 59, 1230).asIsoDuration() },
-              null),
+              null,
+          ),
           Arguments.of(
               "list (duration)",
               listOf(Values.isoDuration(12, 12, 59, 1230).asIsoDuration()),
-              null),
+              null,
+          ),
           Arguments.of("empty list (duration)", emptyList<Duration>(), null),
           Arguments.of(
-              "array (point (2d))", Array(1) { Values.point(4326, 1.0, 2.0).asPoint() }, null),
+              "array (point (2d))",
+              Array(1) { Values.point(4326, 1.0, 2.0).asPoint() },
+              null,
+          ),
           Arguments.of("list (point (2d))", listOf(Values.point(4326, 1.0, 2.0).asPoint()), null),
           Arguments.of(
-              "array (point (3d))", Array(1) { Values.point(4326, 1.0, 2.0, 3.0).asPoint() }, null),
+              "array (point (3d))",
+              Array(1) { Values.point(4326, 1.0, 2.0, 3.0).asPoint() },
+              null,
+          ),
           Arguments.of(
-              "list (point (3d))", listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint()), null),
+              "list (point (3d))",
+              listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint()),
+              null,
+          ),
           Arguments.of("empty list (point)", emptyList<Point>(), null),
       )
     }
@@ -226,8 +252,10 @@ class DynamicTypesExtendedTest {
         TestNode(
             0,
             listOf("Person"),
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe"))),
-        false) shouldBe
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        ),
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<labels>", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
@@ -237,7 +265,10 @@ class DynamicTypesExtendedTest {
 
     // Relationship
     DynamicTypes.toConnectSchema(
-        payloadMode, TestRelationship(0, 1, 2, "KNOWS", emptyMap()), false) shouldBe
+        payloadMode,
+        TestRelationship(0, 1, 2, "KNOWS", emptyMap()),
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<type>", Schema.STRING_SCHEMA)
@@ -251,8 +282,10 @@ class DynamicTypesExtendedTest {
             1,
             2,
             "KNOWS",
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe"))),
-        false) shouldBe
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        ),
+        false,
+    ) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<type>", Schema.STRING_SCHEMA)
@@ -288,7 +321,8 @@ class DynamicTypesExtendedTest {
             arrayOf<String>(),
             arrayOf<LocalDate>(),
             arrayOf<Boolean>(),
-            arrayOf<Point>())
+            arrayOf<Point>(),
+        )
         .forEach { array ->
           withClue(array) {
             DynamicTypes.toConnectSchema(payloadMode, array, false) shouldBe PropertyType.schema
@@ -301,7 +335,7 @@ class DynamicTypesExtendedTest {
   @ArgumentsSource(PropertyTypedCollectionProvider::class)
   fun `collections with elements of property types should map to an array schema`(
       name: String,
-      value: Any?
+      value: Any?,
   ) {
     DynamicTypes.toConnectSchema(payloadMode, value, false) shouldBe
         SchemaBuilder.array(PropertyType.schema).build()
@@ -312,12 +346,13 @@ class DynamicTypesExtendedTest {
   object PropertyTypedCollectionProvider : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(
               "list of mixed simple types",
-              listOf(1, true, "a", 5.toFloat(), LocalDate.of(1999, 1, 1))),
+              listOf(1, true, "a", 5.toFloat(), LocalDate.of(1999, 1, 1)),
+          ),
           Arguments.of(
               "list of mixed types",
               listOf(
@@ -327,7 +362,10 @@ class DynamicTypesExtendedTest {
                   5.toFloat(),
                   LocalDate.of(1999, 1, 1),
                   IntArray(1) { 1 },
-                  Array(1) { LocalTime.of(23, 59, 59) })))
+                  Array(1) { LocalTime.of(23, 59, 59) },
+              ),
+          ),
+      )
     }
   }
 
@@ -358,17 +396,19 @@ class DynamicTypesExtendedTest {
   object PropertyTypedMapProvider : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of("string to int", mapOf("a" to 1, "b" to 2, "c" to 3)),
           Arguments.of("string to string", mapOf("a" to "a", "b" to "b", "c" to "c")),
           Arguments.of(
               "string to numeric",
-              mapOf("a" to 1, "b" to 2.toShort(), "c" to 3.toLong(), "d" to 4.toFloat())),
+              mapOf("a" to 1, "b" to 2.toShort(), "c" to 3.toLong(), "d" to 4.toFloat()),
+          ),
           Arguments.of(
               "string to mixed simple type",
-              mapOf("a" to 1, "b" to true, "c" to "string", "d" to 4.toFloat())),
+              mapOf("a" to 1, "b" to true, "c" to "string", "d" to 4.toFloat()),
+          ),
           Arguments.of(
               "string to mixed",
               mapOf(
@@ -376,7 +416,9 @@ class DynamicTypesExtendedTest {
                   "b" to true,
                   "c" to "string",
                   "d" to 4.toFloat(),
-                  "e" to Array(1) { LocalDate.of(1999, 1, 1) })),
+                  "e" to Array(1) { LocalDate.of(1999, 1, 1) },
+              ),
+          ),
       )
     }
   }
@@ -397,12 +439,15 @@ class DynamicTypesExtendedTest {
                 mapOf(
                     "a" to PropertyType.toConnectValue("x"),
                     "b" to PropertyType.toConnectValue("y"),
-                    "c" to PropertyType.toConnectValue("z")),
+                    "c" to PropertyType.toConnectValue("z"),
+                ),
             mapOf("a" to 1, "b" to 2, "c" to 3) to
                 mapOf(
                     "a" to PropertyType.toConnectValue(1L),
                     "b" to PropertyType.toConnectValue(2L),
-                    "c" to PropertyType.toConnectValue(3L)))
+                    "c" to PropertyType.toConnectValue(3L),
+                ),
+        )
         .forEach { (value, expected) ->
           withClue(value) {
             val schema = DynamicTypes.toConnectSchema(payloadMode, value, false)
@@ -422,7 +467,8 @@ class DynamicTypesExtendedTest {
         TestNode(
             0,
             listOf("Person", "Employee"),
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")))
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        )
     val schema = DynamicTypes.toConnectSchema(payloadMode, node, false)
     val converted = DynamicTypes.toConnectValue(schema, node)
 
@@ -439,7 +485,8 @@ class DynamicTypesExtendedTest {
             "<id>" to 0L,
             "<labels>" to listOf("Person", "Employee"),
             "name" to "john",
-            "surname" to "doe")
+            "surname" to "doe",
+        )
   }
 
   @Test
@@ -450,7 +497,8 @@ class DynamicTypesExtendedTest {
             1,
             2,
             "KNOWS",
-            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")))
+            mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
+        )
     val schema = DynamicTypes.toConnectSchema(payloadMode, rel, false)
     val converted = DynamicTypes.toConnectValue(schema, rel)
 
@@ -471,7 +519,8 @@ class DynamicTypesExtendedTest {
             "<end.id>" to 2L,
             "<type>" to "KNOWS",
             "name" to "john",
-            "surname" to "doe")
+            "surname" to "doe",
+        )
   }
 
   @Test
@@ -482,7 +531,8 @@ class DynamicTypesExtendedTest {
             "age" to 21,
             "dob" to LocalDate.of(1999, 12, 31),
             "employed" to true,
-            "nullable" to null)
+            "nullable" to null,
+        )
     val schema = DynamicTypes.toConnectSchema(payloadMode, map, false)
     val converted = DynamicTypes.toConnectValue(schema, map)
 
@@ -492,9 +542,12 @@ class DynamicTypesExtendedTest {
             "age" to PropertyType.toConnectValue(21L),
             "dob" to
                 PropertyType.getPropertyStruct(
-                    LOCAL_DATE, DateTimeFormatter.ISO_DATE.format(LocalDate.of(1999, 12, 31))),
+                    LOCAL_DATE,
+                    DateTimeFormatter.ISO_DATE.format(LocalDate.of(1999, 12, 31)),
+                ),
             "employed" to PropertyType.toConnectValue(true),
-            "nullable" to null)
+            "nullable" to null,
+        )
 
     val reverted = DynamicTypes.fromConnectValue(schema, converted)
     reverted shouldBe map
@@ -511,9 +564,12 @@ class DynamicTypesExtendedTest {
             PropertyType.toConnectValue("john"),
             PropertyType.toConnectValue(21L),
             PropertyType.getPropertyStruct(
-                LOCAL_DATE, DateTimeFormatter.ISO_DATE.format(LocalDate.of(1999, 12, 31))),
+                LOCAL_DATE,
+                DateTimeFormatter.ISO_DATE.format(LocalDate.of(1999, 12, 31)),
+            ),
             PropertyType.toConnectValue(true),
-            null)
+            null,
+        )
 
     val reverted = DynamicTypes.fromConnectValue(schema, converted)
     reverted shouldBe coll
@@ -555,7 +611,9 @@ class DynamicTypesExtendedTest {
             .field("address", addressSchema)
             .field("years_of_interest", PropertyType.schema)
             .field(
-                "events_of_interest", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA))
+                "events_of_interest",
+                SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA),
+            )
             .build()
     val struct =
         Struct(schema)
@@ -567,11 +625,13 @@ class DynamicTypesExtendedTest {
                 "address",
                 Struct(addressSchema)
                     .put("city", PropertyType.toConnectValue("london"))
-                    .put("country", PropertyType.toConnectValue("uk")))
+                    .put("country", PropertyType.toConnectValue("uk")),
+            )
             .put("years_of_interest", PropertyType.toConnectValue(listOf(2000L, 2005L, 2017L)))
             .put(
                 "events_of_interest",
-                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"))
+                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"),
+            )
 
     DynamicTypes.fromConnectValue(schema, struct) shouldBe
         mapOf(
@@ -582,6 +642,7 @@ class DynamicTypesExtendedTest {
             "address" to mapOf("city" to "london", "country" to "uk"),
             "years_of_interest" to listOf(2000, 2005, 2017),
             "events_of_interest" to
-                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"))
+                mapOf("2000" to "birth", "2005" to "school", "2017" to "college"),
+        )
   }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/DynamicTypesTest.kt
@@ -36,8 +36,8 @@ class DynamicTypesTest {
   fun `kafka connect date values should be returned as local date`() {
     DynamicTypes.fromConnectValue(
         Date.SCHEMA,
-        java.util.Date(LocalDate.of(2000, 1, 1).toEpochDay() * MILLIS_PER_DAY)) shouldBe
-        LocalDate.of(2000, 1, 1)
+        java.util.Date(LocalDate.of(2000, 1, 1).toEpochDay() * MILLIS_PER_DAY),
+    ) shouldBe LocalDate.of(2000, 1, 1)
   }
 
   @Test
@@ -46,9 +46,14 @@ class DynamicTypesTest {
         Time.SCHEMA,
         java.util.Date(
             OffsetDateTime.of(
-                    LocalDate.EPOCH, LocalTime.of(23, 59, 59, 999_000_000), ZoneOffset.UTC)
+                    LocalDate.EPOCH,
+                    LocalTime.of(23, 59, 59, 999_000_000),
+                    ZoneOffset.UTC,
+                )
                 .toInstant()
-                .toEpochMilli())) shouldBe LocalTime.of(23, 59, 59, 999_000_000)
+                .toEpochMilli()
+        ),
+    ) shouldBe LocalTime.of(23, 59, 59, 999_000_000)
   }
 
   @Test
@@ -57,20 +62,29 @@ class DynamicTypesTest {
         Timestamp.SCHEMA,
         java.util.Date(
             OffsetDateTime.of(
-                    LocalDate.of(2000, 1, 1), LocalTime.of(23, 59, 59, 999_000_000), ZoneOffset.UTC)
+                    LocalDate.of(2000, 1, 1),
+                    LocalTime.of(23, 59, 59, 999_000_000),
+                    ZoneOffset.UTC,
+                )
                 .toInstant()
-                .toEpochMilli())) shouldBe LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999_000_000)
+                .toEpochMilli()
+        ),
+    ) shouldBe LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999_000_000)
   }
 
   @Test
   fun `kafka connect decimal values should be returned as string`() {
     DynamicTypes.fromConnectValue(
-        Decimal.schema(4), BigDecimal(BigInteger("12345678901234567890"), 4)) shouldBe
-        "1234567890123456.7890"
+        Decimal.schema(4),
+        BigDecimal(BigInteger("12345678901234567890"), 4),
+    ) shouldBe "1234567890123456.7890"
     DynamicTypes.fromConnectValue(
-        Decimal.schema(6), BigDecimal(BigInteger("12345678901234567890"), 6)) shouldBe
-        "12345678901234.567890"
+        Decimal.schema(6),
+        BigDecimal(BigInteger("12345678901234567890"), 6),
+    ) shouldBe "12345678901234.567890"
     DynamicTypes.fromConnectValue(
-        Decimal.schema(6), BigDecimal(BigInteger("123456000000"), 6)) shouldBe "123456.000000"
+        Decimal.schema(6),
+        BigDecimal(BigInteger("123456000000"), 6),
+    ) shouldBe "123456.000000"
   }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/PropertyTypeTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/PropertyTypeTest.kt
@@ -70,7 +70,7 @@ class PropertyTypeTest {
       name: String,
       value: Any?,
       expectedConverted: Any?,
-      expectedReverted: Any?
+      expectedReverted: Any?,
   ) {
     val converted = PropertyType.toConnectValue(value)
     converted shouldBe expectedConverted
@@ -82,7 +82,7 @@ class PropertyTypeTest {
   object PropertyTypedValues : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of("null", null, null, null),
@@ -93,47 +93,64 @@ class PropertyTypeTest {
           Arguments.of("long", 1L, getPropertyStruct(LONG, 1L), 1L),
           Arguments.of("float", 1.toFloat(), getPropertyStruct(FLOAT, 1.toDouble()), 1.toDouble()),
           Arguments.of(
-              "double", 1.toDouble(), getPropertyStruct(FLOAT, 1.toDouble()), 1.toDouble()),
+              "double",
+              1.toDouble(),
+              getPropertyStruct(FLOAT, 1.toDouble()),
+              1.toDouble(),
+          ),
           Arguments.of("char", 'c', getPropertyStruct(STRING, "c"), "c"),
           Arguments.of("string", "string", getPropertyStruct(STRING, "string"), "string"),
           Arguments.of(
-              "char array", "string".toCharArray(), getPropertyStruct(STRING, "string"), "string"),
+              "char array",
+              "string".toCharArray(),
+              getPropertyStruct(STRING, "string"),
+              "string",
+          ),
           Arguments.of(
               "string builder",
               StringBuilder().append("string"),
               getPropertyStruct(STRING, "string"),
-              "string"),
+              "string",
+          ),
           Arguments.of(
               "string buffer",
               StringBuffer().append("string"),
               getPropertyStruct(STRING, "string"),
-              "string"),
+              "string",
+          ),
           Arguments.of(
               "local date",
               LocalDate.of(1999, 1, 1),
               getPropertyStruct(LOCAL_DATE, "1999-01-01"),
-              LocalDate.of(1999, 1, 1)),
+              LocalDate.of(1999, 1, 1),
+          ),
           Arguments.of(
               "local time",
               LocalTime.of(23, 59, 59, 999999999),
               getPropertyStruct(LOCAL_TIME, "23:59:59.999999999"),
-              LocalTime.of(23, 59, 59, 999999999)),
+              LocalTime.of(23, 59, 59, 999999999),
+          ),
           Arguments.of(
               "local date time",
               LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999),
               getPropertyStruct(LOCAL_DATE_TIME, "1999-01-01T23:59:59.999999999"),
-              LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999)),
+              LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999),
+          ),
           Arguments.of(
               "offset date time",
               OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(1)),
               getPropertyStruct(ZONED_DATE_TIME, "1999-01-01T23:59:59.999999999+01:00"),
-              OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(1))),
+              OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(1)),
+          ),
           Arguments.of(
               "zoned date time",
               ZonedDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul")),
               getPropertyStruct(
-                  ZONED_DATE_TIME, "1999-01-01T23:59:59.999999999+02:00[Europe/Istanbul]"),
-              ZonedDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))),
+                  ZONED_DATE_TIME,
+                  "1999-01-01T23:59:59.999999999+02:00[Europe/Istanbul]",
+              ),
+              ZonedDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul")),
+          ),
           Arguments.of(
               "duration",
               Values.isoDuration(5, 20, 10000, 999999999).asIsoDuration(),
@@ -143,8 +160,10 @@ class PropertyTypeTest {
                       .put(MONTHS, 5L)
                       .put(DAYS, 20L)
                       .put(SECONDS, 10000L)
-                      .put(NANOS, 999999999)),
-              Values.isoDuration(5, 20, 10000, 999999999).asIsoDuration()),
+                      .put(NANOS, 999999999),
+              ),
+              Values.isoDuration(5, 20, 10000, 999999999).asIsoDuration(),
+          ),
           Arguments.of(
               "point (2d)",
               Values.point(4326, 1.0, 2.0).asPoint(),
@@ -154,8 +173,10 @@ class PropertyTypeTest {
                       .put(SR_ID, 4326)
                       .put(X, 1.0)
                       .put(Y, 2.0)
-                      .put(DIMENSION, TWO_D)),
-              Values.point(4326, 1.0, 2.0).asPoint()),
+                      .put(DIMENSION, TWO_D),
+              ),
+              Values.point(4326, 1.0, 2.0).asPoint(),
+          ),
           Arguments.of(
               "point (3d)",
               Values.point(4326, 1.0, 2.0, 3.0).asPoint(),
@@ -166,176 +187,222 @@ class PropertyTypeTest {
                       .put(X, 1.0)
                       .put(Y, 2.0)
                       .put(Z, 3.0)
-                      .put(DIMENSION, THREE_D)),
-              Values.point(4326, 1.0, 2.0, 3.0).asPoint()),
+                      .put(DIMENSION, THREE_D),
+              ),
+              Values.point(4326, 1.0, 2.0, 3.0).asPoint(),
+          ),
           Arguments.of(
               "byte array",
               "a string".toByteArray(),
               getPropertyStruct(BYTES, "a string".toByteArray()),
-              "a string".toByteArray()),
+              "a string".toByteArray(),
+          ),
           Arguments.of(
               "byte buffer",
               ByteBuffer.allocate(1).put(1),
               getPropertyStruct(BYTES, ByteArray(1) { 1 }),
-              ByteArray(1) { 1 }),
+              ByteArray(1) { 1 },
+          ),
           Arguments.of(
               "array (byte)",
               Array(1) { 1.toByte() },
               getPropertyStruct(BYTES, ByteArray(1) { 1 }),
-              ByteArray(1) { 1 }),
+              ByteArray(1) { 1 },
+          ),
           Arguments.of(
               "list (byte)",
               listOf(1.toByte(), 1.toByte()),
               getPropertyStruct(BYTES, ByteArray(2) { 1 }),
-              ByteArray(2) { 1.toByte() }),
+              ByteArray(2) { 1.toByte() },
+          ),
           Arguments.of(
               "short array (empty)",
               ShortArray(0),
               getPropertyStruct(LONG_LIST, emptyList<Long>()),
-              emptyList<Long>()),
+              emptyList<Long>(),
+          ),
           Arguments.of(
               "short array",
               ShortArray(1) { 1.toShort() },
               getPropertyStruct(LONG_LIST, listOf(1L)),
-              listOf(1L)),
+              listOf(1L),
+          ),
           Arguments.of(
               "array (short)",
               Array(1) { 1.toShort() },
               getPropertyStruct(LONG_LIST, listOf(1L)),
-              listOf(1L)),
+              listOf(1L),
+          ),
           Arguments.of(
               "list (short)",
               listOf(1.toShort(), 2.toShort()),
               getPropertyStruct(LONG_LIST, listOf(1L, 2L)),
-              listOf(1L, 2L)),
+              listOf(1L, 2L),
+          ),
           Arguments.of(
               "int array (empty)",
               IntArray(0),
               getPropertyStruct(LONG_LIST, emptyList<Long>()),
-              emptyList<Long>()),
+              emptyList<Long>(),
+          ),
           Arguments.of(
-              "int array", IntArray(1) { 1 }, getPropertyStruct(LONG_LIST, listOf(1L)), listOf(1L)),
+              "int array",
+              IntArray(1) { 1 },
+              getPropertyStruct(LONG_LIST, listOf(1L)),
+              listOf(1L),
+          ),
           Arguments.of(
-              "array (int)", Array(1) { 1 }, getPropertyStruct(LONG_LIST, listOf(1L)), listOf(1L)),
+              "array (int)",
+              Array(1) { 1 },
+              getPropertyStruct(LONG_LIST, listOf(1L)),
+              listOf(1L),
+          ),
           Arguments.of(
               "list (int)",
               listOf(1, 2),
               getPropertyStruct(LONG_LIST, listOf(1L, 2L)),
-              listOf(1L, 2L)),
+              listOf(1L, 2L),
+          ),
           Arguments.of(
               "long array (empty)",
               LongArray(0),
               getPropertyStruct(LONG_LIST, emptyList<Long>()),
-              emptyList<Long>()),
+              emptyList<Long>(),
+          ),
           Arguments.of(
               "long array",
               LongArray(1) { 1.toLong() },
               getPropertyStruct(LONG_LIST, listOf(1L)),
-              listOf(1L)),
+              listOf(1L),
+          ),
           Arguments.of(
               "array (long)",
               Array(1) { 1.toLong() },
               getPropertyStruct(LONG_LIST, listOf(1L)),
-              listOf(1L)),
+              listOf(1L),
+          ),
           Arguments.of(
               "list (long)",
               listOf(1.toLong(), 2.toLong()),
               getPropertyStruct(LONG_LIST, listOf(1L, 2L)),
-              listOf(1L, 2L)),
+              listOf(1L, 2L),
+          ),
           Arguments.of(
               "float array (empty)",
               FloatArray(0),
               getPropertyStruct(FLOAT_LIST, emptyList<Double>()),
-              emptyList<Float>()),
+              emptyList<Float>(),
+          ),
           Arguments.of(
               "float array",
               FloatArray(1) { 1.toFloat() },
               getPropertyStruct(FLOAT_LIST, listOf(1.toDouble())),
-              listOf(1.toDouble())),
+              listOf(1.toDouble()),
+          ),
           Arguments.of(
               "array (float)",
               Array(1) { 1.toFloat() },
               getPropertyStruct(FLOAT_LIST, listOf(1.toDouble())),
-              listOf(1.toDouble())),
+              listOf(1.toDouble()),
+          ),
           Arguments.of(
               "list (float)",
               listOf(1.toFloat(), 2.toFloat()),
               getPropertyStruct(FLOAT_LIST, listOf(1.toDouble(), 2.toDouble())),
-              listOf(1.toDouble(), 2.toDouble())),
+              listOf(1.toDouble(), 2.toDouble()),
+          ),
           Arguments.of(
               "double array (empty)",
               DoubleArray(0),
               getPropertyStruct(FLOAT_LIST, emptyList<Double>()),
-              emptyList<Double>()),
+              emptyList<Double>(),
+          ),
           Arguments.of(
               "double array",
               DoubleArray(1) { 1.toDouble() },
               getPropertyStruct(FLOAT_LIST, listOf(1.toDouble())),
-              listOf(1.toDouble())),
+              listOf(1.toDouble()),
+          ),
           Arguments.of(
               "array (double)",
               Array(1) { 1.toDouble() },
               getPropertyStruct(FLOAT_LIST, listOf(1.toDouble())),
-              listOf(1.toDouble())),
+              listOf(1.toDouble()),
+          ),
           Arguments.of(
               "list (double)",
               listOf(1.toDouble(), 2.toDouble()),
               getPropertyStruct(FLOAT_LIST, listOf(1.toDouble(), 2.toDouble())),
-              listOf(1.toDouble(), 2.toDouble())),
+              listOf(1.toDouble(), 2.toDouble()),
+          ),
           Arguments.of(
               "array (string)",
               Array(1) { "a" },
               getPropertyStruct(STRING_LIST, listOf("a")),
-              listOf("a")),
+              listOf("a"),
+          ),
           Arguments.of(
               "list (string)",
               listOf("a", "b"),
               getPropertyStruct(STRING_LIST, listOf("a", "b")),
-              listOf("a", "b")),
+              listOf("a", "b"),
+          ),
           Arguments.of(
               "array (local date)",
               Array(1) { LocalDate.of(1999, 1, 1) },
               getPropertyStruct(LOCAL_DATE_LIST, listOf("1999-01-01")),
-              listOf(LocalDate.of(1999, 1, 1))),
+              listOf(LocalDate.of(1999, 1, 1)),
+          ),
           Arguments.of(
               "list (local date)",
               listOf(LocalDate.of(1999, 1, 1)),
               getPropertyStruct(LOCAL_DATE_LIST, listOf("1999-01-01")),
-              listOf(LocalDate.of(1999, 1, 1))),
+              listOf(LocalDate.of(1999, 1, 1)),
+          ),
           Arguments.of(
               "array (local time)",
               Array(1) { LocalTime.of(23, 59, 59, 999999999) },
               getPropertyStruct(LOCAL_TIME_LIST, listOf("23:59:59.999999999")),
-              listOf(LocalTime.of(23, 59, 59, 999999999))),
+              listOf(LocalTime.of(23, 59, 59, 999999999)),
+          ),
           Arguments.of(
               "list (local time)",
               listOf(LocalTime.of(23, 59, 59, 999999999)),
               getPropertyStruct(LOCAL_TIME_LIST, listOf("23:59:59.999999999")),
-              listOf(LocalTime.of(23, 59, 59, 999999999))),
+              listOf(LocalTime.of(23, 59, 59, 999999999)),
+          ),
           Arguments.of(
               "array (local date time)",
               Array(1) { LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999) },
               getPropertyStruct(LOCAL_DATE_TIME_LIST, listOf("1999-01-01T23:59:59.999999999")),
-              listOf(LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999))),
+              listOf(LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999)),
+          ),
           Arguments.of(
               "list (local date time)",
               listOf(LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999)),
               getPropertyStruct(LOCAL_DATE_TIME_LIST, listOf("1999-01-01T23:59:59.999999999")),
-              listOf(LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999))),
+              listOf(LocalDateTime.of(1999, 1, 1, 23, 59, 59, 999999999)),
+          ),
           Arguments.of(
               "array (offset date time)",
               Array(1) {
                 OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(2))
               },
               getPropertyStruct(
-                  ZONED_DATE_TIME_LIST, listOf("1999-01-01T23:59:59.999999999+02:00")),
-              listOf(OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(2)))),
+                  ZONED_DATE_TIME_LIST,
+                  listOf("1999-01-01T23:59:59.999999999+02:00"),
+              ),
+              listOf(OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
+          ),
           Arguments.of(
               "list (offset date time)",
               listOf(OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
               getPropertyStruct(
-                  ZONED_DATE_TIME_LIST, listOf("1999-01-01T23:59:59.999999999+02:00")),
-              listOf(OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(2)))),
+                  ZONED_DATE_TIME_LIST,
+                  listOf("1999-01-01T23:59:59.999999999+02:00"),
+              ),
+              listOf(OffsetDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
+          ),
           Arguments.of(
               "array (zoned date time)",
               Array(1) {
@@ -343,31 +410,37 @@ class PropertyTypeTest {
               },
               getPropertyStruct(
                   ZONED_DATE_TIME_LIST,
-                  listOf("1999-01-01T23:59:59.999999999+02:00[Europe/Istanbul]")),
+                  listOf("1999-01-01T23:59:59.999999999+02:00[Europe/Istanbul]"),
+              ),
               listOf(
-                  ZonedDateTime.of(
-                      1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul")))),
+                  ZonedDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))
+              ),
+          ),
           Arguments.of(
               "list (zoned date time)",
               listOf(
-                  ZonedDateTime.of(
-                      1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))),
+                  ZonedDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))
+              ),
               getPropertyStruct(
                   ZONED_DATE_TIME_LIST,
-                  listOf("1999-01-01T23:59:59.999999999+02:00[Europe/Istanbul]")),
+                  listOf("1999-01-01T23:59:59.999999999+02:00[Europe/Istanbul]"),
+              ),
               listOf(
-                  ZonedDateTime.of(
-                      1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul")))),
+                  ZonedDateTime.of(1999, 1, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))
+              ),
+          ),
           Arguments.of(
               "array (offset time)",
               Array(1) { OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2)) },
               getPropertyStruct(OFFSET_TIME_LIST, listOf("23:59:59.999999999+02:00")),
-              listOf(OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2)))),
+              listOf(OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
+          ),
           Arguments.of(
               "list (offset time)",
               listOf(OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
               getPropertyStruct(OFFSET_TIME_LIST, listOf("23:59:59.999999999+02:00")),
-              listOf(OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2)))),
+              listOf(OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
+          ),
           Arguments.of(
               "array (duration)",
               Array(1) { Values.isoDuration(12, 12, 59, 1230).asIsoDuration() },
@@ -378,8 +451,11 @@ class PropertyTypeTest {
                           .put(MONTHS, 12L)
                           .put(DAYS, 12L)
                           .put(SECONDS, 59L)
-                          .put(NANOS, 1230))),
-              listOf(Values.isoDuration(12, 12, 59, 1230).asIsoDuration())),
+                          .put(NANOS, 1230)
+                  ),
+              ),
+              listOf(Values.isoDuration(12, 12, 59, 1230).asIsoDuration()),
+          ),
           Arguments.of(
               "list (duration)",
               listOf(Values.isoDuration(12, 12, 59, 1230).asIsoDuration()),
@@ -390,8 +466,11 @@ class PropertyTypeTest {
                           .put(MONTHS, 12L)
                           .put(DAYS, 12L)
                           .put(SECONDS, 59L)
-                          .put(NANOS, 1230))),
-              listOf(Values.isoDuration(12, 12, 59, 1230).asIsoDuration())),
+                          .put(NANOS, 1230)
+                  ),
+              ),
+              listOf(Values.isoDuration(12, 12, 59, 1230).asIsoDuration()),
+          ),
           Arguments.of(
               "array (point (2d))",
               Array(1) { Values.point(4326, 1.0, 2.0).asPoint() },
@@ -402,8 +481,11 @@ class PropertyTypeTest {
                           .put(SR_ID, 4326)
                           .put(X, 1.0)
                           .put(Y, 2.0)
-                          .put(DIMENSION, TWO_D))),
-              listOf(Values.point(4326, 1.0, 2.0).asPoint())),
+                          .put(DIMENSION, TWO_D)
+                  ),
+              ),
+              listOf(Values.point(4326, 1.0, 2.0).asPoint()),
+          ),
           Arguments.of(
               "list (point (2d))",
               listOf(Values.point(4326, 1.0, 2.0).asPoint()),
@@ -414,8 +496,11 @@ class PropertyTypeTest {
                           .put(SR_ID, 4326)
                           .put(X, 1.0)
                           .put(Y, 2.0)
-                          .put(DIMENSION, TWO_D))),
-              listOf(Values.point(4326, 1.0, 2.0).asPoint())),
+                          .put(DIMENSION, TWO_D)
+                  ),
+              ),
+              listOf(Values.point(4326, 1.0, 2.0).asPoint()),
+          ),
           Arguments.of(
               "array (point (3d))",
               Array(1) { Values.point(4326, 1.0, 2.0, 3.0).asPoint() },
@@ -427,8 +512,11 @@ class PropertyTypeTest {
                           .put(X, 1.0)
                           .put(Y, 2.0)
                           .put(Z, 3.0)
-                          .put(DIMENSION, THREE_D))),
-              listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint())),
+                          .put(DIMENSION, THREE_D)
+                  ),
+              ),
+              listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint()),
+          ),
           Arguments.of(
               "list (point (3d))",
               listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint()),
@@ -440,18 +528,24 @@ class PropertyTypeTest {
                           .put(X, 1.0)
                           .put(Y, 2.0)
                           .put(Z, 3.0)
-                          .put(DIMENSION, THREE_D))),
-              listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint())),
+                          .put(DIMENSION, THREE_D)
+                  ),
+              ),
+              listOf(Values.point(4326, 1.0, 2.0, 3.0).asPoint()),
+          ),
           Arguments.of(
               "empty list (any)",
               emptyList<Any>(),
               getPropertyStruct(LONG_LIST, emptyList<Long>()),
-              emptyList<Any>()),
+              emptyList<Any>(),
+          ),
           Arguments.of(
               "empty list (typed)",
               emptyList<Int>(),
               getPropertyStruct(LONG_LIST, emptyList<Long>()),
-              emptyList<Any>()))
+              emptyList<Any>(),
+          ),
+      )
     }
   }
 

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/StreamsTransactionEventExtensionsTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/StreamsTransactionEventExtensionsTest.kt
@@ -61,7 +61,10 @@ class StreamsTransactionEventExtensionsTest {
                 after =
                     NodeChange(
                         properties = mapOf("name" to "john", "surname" to "doe"),
-                        labels = listOf("User"))))
+                        labels = listOf("User"),
+                    ),
+            ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -75,7 +78,9 @@ class StreamsTransactionEventExtensionsTest {
                 listOf("User"),
                 emptyMap(),
                 null,
-                NodeState(listOf("User"), mapOf("name" to "john", "surname" to "doe"))))
+                NodeState(listOf("User"), mapOf("name" to "john", "surname" to "doe")),
+            ),
+        )
   }
 
   @Test
@@ -94,14 +99,23 @@ class StreamsTransactionEventExtensionsTest {
                             mapOf(
                                 "name" to "john",
                                 "surname" to "doe",
-                                "dob" to LocalDate.of(2000, 1, 1)),
-                        labels = listOf("User"))),
+                                "dob" to LocalDate.of(2000, 1, 1),
+                            ),
+                        labels = listOf("User"),
+                    ),
+            ),
             schema =
                 Schema(
                     constraints =
                         listOf(
                             Constraint(
-                                "User", setOf("name", "surname"), StreamsConstraintType.UNIQUE))))
+                                "User",
+                                setOf("name", "surname"),
+                                StreamsConstraintType.UNIQUE,
+                            )
+                        )
+                ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -117,8 +131,10 @@ class StreamsTransactionEventExtensionsTest {
                 null,
                 NodeState(
                     listOf("User"),
-                    mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1)))))
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1)),
+                ),
+            ),
+        )
   }
 
   @Test
@@ -137,14 +153,23 @@ class StreamsTransactionEventExtensionsTest {
                             mapOf(
                                 "name" to "john",
                                 "surname" to "doe",
-                                "dob" to LocalDate.of(2000, 1, 1)),
-                        labels = listOf("User"))),
+                                "dob" to LocalDate.of(2000, 1, 1),
+                            ),
+                        labels = listOf("User"),
+                    ),
+            ),
             schema =
                 Schema(
                     constraints =
                         listOf(
                             Constraint(
-                                "User", setOf("name", "surname"), StreamsConstraintType.UNIQUE))))
+                                "User",
+                                setOf("name", "surname"),
+                                StreamsConstraintType.UNIQUE,
+                            )
+                        )
+                ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -160,8 +185,10 @@ class StreamsTransactionEventExtensionsTest {
                 NodeState(listOf("User"), mapOf("name" to "joe", "surname" to "doe")),
                 NodeState(
                     listOf("User"),
-                    mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1)))))
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1)),
+                ),
+            ),
+        )
   }
 
   @Test
@@ -179,15 +206,24 @@ class StreamsTransactionEventExtensionsTest {
                             mapOf(
                                 "name" to "john",
                                 "surname" to "doe",
-                                "dob" to LocalDate.of(2000, 1, 1)),
-                        labels = listOf("User")),
-                after = null),
+                                "dob" to LocalDate.of(2000, 1, 1),
+                            ),
+                        labels = listOf("User"),
+                    ),
+                after = null,
+            ),
             schema =
                 Schema(
                     constraints =
                         listOf(
                             Constraint(
-                                "User", setOf("name", "surname"), StreamsConstraintType.UNIQUE))))
+                                "User",
+                                setOf("name", "surname"),
+                                StreamsConstraintType.UNIQUE,
+                            )
+                        )
+                ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -202,8 +238,11 @@ class StreamsTransactionEventExtensionsTest {
                 mapOf("User" to listOf(mapOf("name" to "john", "surname" to "doe"))),
                 NodeState(
                     listOf("User"),
-                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1))),
-                null))
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(2000, 1, 1)),
+                ),
+                null,
+            ),
+        )
   }
 
   @Test
@@ -218,13 +257,20 @@ class StreamsTransactionEventExtensionsTest {
                 label = "KNOWS",
                 start =
                     RelationshipNodeChange(
-                        "1", listOf("Person"), mapOf("name" to "joe", "surname" to "doe")),
+                        "1",
+                        listOf("Person"),
+                        mapOf("name" to "joe", "surname" to "doe"),
+                    ),
                 end =
                     RelationshipNodeChange(
-                        "2", listOf("Person"), mapOf("name" to "mary", "surname" to "doe")),
+                        "2",
+                        listOf("Person"),
+                        mapOf("name" to "mary", "surname" to "doe"),
+                    ),
                 before = null,
                 after = RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1))),
-            ))
+            ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -238,15 +284,19 @@ class StreamsTransactionEventExtensionsTest {
                 Node(
                     "1",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe")))),
+                    mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe"))),
+                ),
                 Node(
                     "2",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("name" to "mary", "surname" to "doe")))),
+                    mapOf("Person" to listOf(mapOf("name" to "mary", "surname" to "doe"))),
+                ),
                 emptyList(),
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1)))))
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+        )
   }
 
   @Test
@@ -263,15 +313,18 @@ class StreamsTransactionEventExtensionsTest {
                     RelationshipNodeChange(
                         "1",
                         listOf("Person", "Employee"),
-                        mapOf("name" to "joe", "surname" to "doe")),
+                        mapOf("name" to "joe", "surname" to "doe"),
+                    ),
                 end =
                     RelationshipNodeChange(
                         "2",
                         listOf("Person", "Employee"),
-                        mapOf("name" to "mary", "surname" to "doe")),
+                        mapOf("name" to "mary", "surname" to "doe"),
+                    ),
                 before = RelationshipChange(emptyMap()),
                 after = RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1))),
-            ))
+            ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -285,15 +338,19 @@ class StreamsTransactionEventExtensionsTest {
                 Node(
                     "1",
                     listOf("Person", "Employee"),
-                    mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe")))),
+                    mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe"))),
+                ),
                 Node(
                     "2",
                     listOf("Person", "Employee"),
-                    mapOf("Person" to listOf(mapOf("name" to "mary", "surname" to "doe")))),
+                    mapOf("Person" to listOf(mapOf("name" to "mary", "surname" to "doe"))),
+                ),
                 emptyList(),
                 EntityOperation.UPDATE,
                 RelationshipState(emptyMap()),
-                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1)))))
+                RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
+            ),
+        )
   }
 
   @Test
@@ -308,12 +365,20 @@ class StreamsTransactionEventExtensionsTest {
                 label = "KNOWS",
                 start =
                     RelationshipNodeChange(
-                        "1", listOf("Person"), mapOf("name" to "joe", "surname" to "doe")),
+                        "1",
+                        listOf("Person"),
+                        mapOf("name" to "joe", "surname" to "doe"),
+                    ),
                 end =
                     RelationshipNodeChange(
-                        "2", listOf("Person"), mapOf("name" to "mary", "surname" to "doe")),
+                        "2",
+                        listOf("Person"),
+                        mapOf("name" to "mary", "surname" to "doe"),
+                    ),
                 before = RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1))),
-                after = null))
+                after = null,
+            ),
+        )
 
     event.toChangeEvent() shouldBe
         ChangeEvent(
@@ -327,15 +392,19 @@ class StreamsTransactionEventExtensionsTest {
                 Node(
                     "1",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe")))),
+                    mapOf("Person" to listOf(mapOf("name" to "joe", "surname" to "doe"))),
+                ),
                 Node(
                     "2",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("name" to "mary", "surname" to "doe")))),
+                    mapOf("Person" to listOf(mapOf("name" to "mary", "surname" to "doe"))),
+                ),
                 emptyList(),
                 EntityOperation.DELETE,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
-                null))
+                null,
+            ),
+        )
   }
 
   private fun newStreamsEvent(
@@ -343,10 +412,13 @@ class StreamsTransactionEventExtensionsTest {
       operationType: OperationType,
       payload: Payload,
       meta: Meta? = null,
-      schema: Schema? = null
+      schema: Schema? = null,
   ): StreamsTransactionEvent =
       StreamsTransactionEvent(
-          meta ?: defaultMetadata(time, operationType), payload, schema ?: Schema())
+          meta ?: defaultMetadata(time, operationType),
+          payload,
+          schema ?: Schema(),
+      )
 
   private fun defaultExpectedMetadata(time: Long) =
       Metadata(
@@ -371,5 +443,6 @@ class StreamsTransactionEventExtensionsTest {
           txId = 1,
           txEventId = 0,
           txEventsCount = 3,
-          operation = operationType)
+          operation = operationType,
+      )
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/TypesTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/TypesTest.kt
@@ -121,8 +121,8 @@ class TypesTest {
   ) {
     driver.session().use {
       val returned = it.run("RETURN \$value", mapOf("value" to input)).single().get(0).asObject()
-      val schema = DynamicTypes.toConnectSchema(payloadMode, returned)
-      val converted = DynamicTypes.toConnectValue(schema, returned)
+      val schema = payloadMode.schema(returned)
+      val converted = payloadMode.value(schema, returned)
       val reverted = DynamicTypes.fromConnectValue(schema, converted)
 
       schema shouldBe expectedSchema
@@ -181,7 +181,7 @@ class TypesTest {
               PropertyType.getPropertyStruct(FLOAT, 1.0),
           ),
           Arguments.of(
-              Named.of("float-extended", 1.0),
+              Named.of("float-compact", 1.0),
               PayloadMode.COMPACT,
               SimpleTypes.FLOAT.schema,
               1.0,
@@ -772,7 +772,7 @@ class TypesTest {
 
       val changes = cdc.query(changeId).collectList().block()
 
-      val changeEventConverter = ChangeEventConverter(payloadMode = payloadMode)
+      val changeEventConverter = ChangeEventConverter(payloadMode)
       changes!!.take(2).forEach { change ->
         val converted = changeEventConverter.toConnectValue(change)
         val schema = converted.schema()
@@ -849,7 +849,7 @@ class TypesTest {
 
       val changes = cdc.query(changeId).collectList().block()
 
-      val changeEventConverter = ChangeEventConverter(payloadMode = payloadMode)
+      val changeEventConverter = ChangeEventConverter(payloadMode)
       changes!!.take(2).forEach { change ->
         val converted = changeEventConverter.toConnectValue(change)
         val schema = converted.schema()
@@ -967,10 +967,10 @@ class TypesTest {
             )
             .optional()
             .build()
-    val schema = DynamicTypes.toConnectSchema(payloadMode, returned, optional = true)
+    val schema = payloadMode.schema(returned, optional = true)
     schema shouldBe expectedSchema
 
-    val converted = DynamicTypes.toConnectValue(schema, returned)
+    val converted = payloadMode.value(schema, returned)
     converted shouldBe
         Struct(schema)
             .put("id", PropertyType.toConnectValue("ROOT_ID"))
@@ -1104,10 +1104,10 @@ class TypesTest {
             )
             .optional()
             .build()
-    val schema = DynamicTypes.toConnectSchema(payloadMode, returned, optional = true)
+    val schema = payloadMode.schema(returned, optional = true)
     schema shouldBe expectedSchema
 
-    val converted = DynamicTypes.toConnectValue(schema, returned)
+    val converted = payloadMode.value(schema, returned)
     converted shouldBe
         Struct(schema)
             .put("id", "ROOT_ID")
@@ -1137,8 +1137,8 @@ class TypesTest {
   }
 
   private fun schemaAndValue(payloadMode: PayloadMode, value: Any): Triple<Schema, Any?, Any?> {
-    val schema = DynamicTypes.toConnectSchema(payloadMode, value)
-    val converted = DynamicTypes.toConnectValue(schema, value)
+    val schema = payloadMode.schema(value)
+    val converted = payloadMode.value(schema, value)
     val reverted = DynamicTypes.fromConnectValue(schema, converted)
     return Triple(schema, converted, reverted)
   }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/TypesTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/TypesTest.kt
@@ -98,7 +98,8 @@ class TypesTest {
         System.getenv("NEO4J_TEST_IMAGE")
             .ifBlank {
               throw IllegalArgumentException(
-                  "NEO4J_TEST_IMAGE environment variable is not defined!")
+                  "NEO4J_TEST_IMAGE environment variable is not defined!"
+              )
             }
             .run { DockerImageName.parse(this).asCompatibleSubstituteFor("neo4j") }
   }
@@ -116,7 +117,7 @@ class TypesTest {
       input: Any?,
       payloadMode: PayloadMode,
       expectedSchema: Schema,
-      expectedValue: Any?
+      expectedValue: Any?,
   ) {
     driver.session().use {
       val returned = it.run("RETURN \$value", mapOf("value" to input)).single().get(0).asObject()
@@ -134,74 +135,100 @@ class TypesTest {
 
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(
-              Named.of("null-extended", null), PayloadMode.EXTENDED, PropertyType.schema, null),
+              Named.of("null-extended", null),
+              PayloadMode.EXTENDED,
+              PropertyType.schema,
+              null,
+          ),
           Arguments.of(
-              Named.of("null-compact", null), PayloadMode.COMPACT, SimpleTypes.NULL.schema, null),
+              Named.of("null-compact", null),
+              PayloadMode.COMPACT,
+              SimpleTypes.NULL.schema,
+              null,
+          ),
           Arguments.of(
               Named.of("boolean-extended", true),
               PayloadMode.EXTENDED,
               PropertyType.schema,
-              PropertyType.getPropertyStruct(BOOLEAN, true)),
+              PropertyType.getPropertyStruct(BOOLEAN, true),
+          ),
           Arguments.of(
               Named.of("boolean-compact", true),
               PayloadMode.COMPACT,
               SimpleTypes.BOOLEAN.schema,
-              true),
+              true,
+          ),
           Arguments.of(
               Named.of("long-extended", 1),
               PayloadMode.EXTENDED,
               PropertyType.schema,
-              PropertyType.toConnectValue(1L)),
+              PropertyType.toConnectValue(1L),
+          ),
           Arguments.of(
-              Named.of("long-compact", 1), PayloadMode.COMPACT, SimpleTypes.LONG.schema, 1L),
+              Named.of("long-compact", 1),
+              PayloadMode.COMPACT,
+              SimpleTypes.LONG.schema,
+              1L,
+          ),
           Arguments.of(
               Named.of("float-extended", 1.0),
               PayloadMode.EXTENDED,
               PropertyType.schema,
-              PropertyType.getPropertyStruct(FLOAT, 1.0)),
+              PropertyType.getPropertyStruct(FLOAT, 1.0),
+          ),
           Arguments.of(
-              Named.of("float-extended", 1.0), PayloadMode.COMPACT, SimpleTypes.FLOAT.schema, 1.0),
+              Named.of("float-extended", 1.0),
+              PayloadMode.COMPACT,
+              SimpleTypes.FLOAT.schema,
+              1.0,
+          ),
           Arguments.of(
               Named.of("string-extended", "a string"),
               PayloadMode.EXTENDED,
               PropertyType.schema,
-              PropertyType.toConnectValue("a string")),
+              PropertyType.toConnectValue("a string"),
+          ),
           Arguments.of(
               Named.of("string-compact", "a string"),
               PayloadMode.COMPACT,
               SimpleTypes.STRING.schema,
-              "a string"),
+              "a string",
+          ),
           LocalDate.of(1999, 12, 31).let {
             Arguments.of(
                 Named.of("local date-extended", it),
                 PayloadMode.EXTENDED,
                 PropertyType.schema,
-                PropertyType.getPropertyStruct(LOCAL_DATE, DateTimeFormatter.ISO_DATE.format(it)))
+                PropertyType.getPropertyStruct(LOCAL_DATE, DateTimeFormatter.ISO_DATE.format(it)),
+            )
           },
           LocalDate.of(1999, 12, 31).let {
             Arguments.of(
                 Named.of("local date-compact", it),
                 PayloadMode.COMPACT,
                 SimpleTypes.LOCALDATE.schema,
-                DateTimeFormatter.ISO_DATE.format(it))
+                DateTimeFormatter.ISO_DATE.format(it),
+            )
           },
           LocalTime.of(23, 59, 59, 5).let {
             Arguments.of(
                 Named.of("local time-extended", it),
                 PayloadMode.EXTENDED,
                 PropertyType.schema,
-                PropertyType.getPropertyStruct(LOCAL_TIME, DateTimeFormatter.ISO_TIME.format(it)))
+                PropertyType.getPropertyStruct(LOCAL_TIME, DateTimeFormatter.ISO_TIME.format(it)),
+            )
           },
           LocalTime.of(23, 59, 59, 5).let {
             Arguments.of(
                 Named.of("local time-compact", it),
                 PayloadMode.COMPACT,
                 SimpleTypes.LOCALTIME.schema,
-                DateTimeFormatter.ISO_TIME.format(it))
+                DateTimeFormatter.ISO_TIME.format(it),
+            )
           },
           LocalDateTime.of(1999, 12, 31, 23, 59, 59, 5).let {
             Arguments.of(
@@ -209,28 +236,34 @@ class TypesTest {
                 PayloadMode.EXTENDED,
                 PropertyType.schema,
                 PropertyType.getPropertyStruct(
-                    LOCAL_DATE_TIME, DateTimeFormatter.ISO_DATE_TIME.format(it)))
+                    LOCAL_DATE_TIME,
+                    DateTimeFormatter.ISO_DATE_TIME.format(it),
+                ),
+            )
           },
           LocalDateTime.of(1999, 12, 31, 23, 59, 59, 5).let {
             Arguments.of(
                 Named.of("local date time-compact", it),
                 PayloadMode.COMPACT,
                 SimpleTypes.LOCALDATETIME.schema,
-                DateTimeFormatter.ISO_DATE_TIME.format(it))
+                DateTimeFormatter.ISO_DATE_TIME.format(it),
+            )
           },
           OffsetTime.of(23, 59, 59, 5, ZoneOffset.ofHours(1)).let {
             Arguments.of(
                 Named.of("offset time-extended", it),
                 PayloadMode.EXTENDED,
                 PropertyType.schema,
-                PropertyType.getPropertyStruct(OFFSET_TIME, DateTimeFormatter.ISO_TIME.format(it)))
+                PropertyType.getPropertyStruct(OFFSET_TIME, DateTimeFormatter.ISO_TIME.format(it)),
+            )
           },
           OffsetTime.of(23, 59, 59, 5, ZoneOffset.ofHours(1)).let {
             Arguments.of(
                 Named.of("offset time-compact", it),
                 PayloadMode.COMPACT,
                 SimpleTypes.OFFSETTIME.schema,
-                DateTimeFormatter.ISO_TIME.format(it))
+                DateTimeFormatter.ISO_TIME.format(it),
+            )
           },
           OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 5, ZoneOffset.ofHours(1)).let {
             Arguments.of(
@@ -238,14 +271,18 @@ class TypesTest {
                 PayloadMode.EXTENDED,
                 PropertyType.schema,
                 PropertyType.getPropertyStruct(
-                    ZONED_DATE_TIME, DateTimeFormatter.ISO_DATE_TIME.format(it)))
+                    ZONED_DATE_TIME,
+                    DateTimeFormatter.ISO_DATE_TIME.format(it),
+                ),
+            )
           },
           OffsetDateTime.of(1999, 12, 31, 23, 59, 59, 5, ZoneOffset.ofHours(1)).let {
             Arguments.of(
                 Named.of("offset date time-compact", it),
                 PayloadMode.COMPACT,
                 SimpleTypes.ZONEDDATETIME.schema,
-                DateTimeFormatter.ISO_DATE_TIME.format(it))
+                DateTimeFormatter.ISO_DATE_TIME.format(it),
+            )
           },
           ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 5, ZoneId.of("Europe/Istanbul")).let {
             Arguments.of(
@@ -253,14 +290,18 @@ class TypesTest {
                 PayloadMode.EXTENDED,
                 PropertyType.schema,
                 PropertyType.getPropertyStruct(
-                    ZONED_DATE_TIME, DateTimeFormatter.ISO_DATE_TIME.format(it)))
+                    ZONED_DATE_TIME,
+                    DateTimeFormatter.ISO_DATE_TIME.format(it),
+                ),
+            )
           },
           ZonedDateTime.of(1999, 12, 31, 23, 59, 59, 5, ZoneId.of("Europe/Istanbul")).let {
             Arguments.of(
                 Named.of("zoned date time-compact", it),
                 PayloadMode.COMPACT,
                 SimpleTypes.ZONEDDATETIME.schema,
-                DateTimeFormatter.ISO_DATE_TIME.format(it))
+                DateTimeFormatter.ISO_DATE_TIME.format(it),
+            )
           },
           Arguments.of(
               Named.of("duration-extended", Values.isoDuration(5, 2, 23, 5).asIsoDuration()),
@@ -272,7 +313,9 @@ class TypesTest {
                       .put("months", 5L)
                       .put("days", 2L)
                       .put("seconds", 23L)
-                      .put("nanoseconds", 5))),
+                      .put("nanoseconds", 5),
+              ),
+          ),
           Arguments.of(
               Named.of("duration-compact", Values.isoDuration(5, 2, 23, 5).asIsoDuration()),
               PayloadMode.COMPACT,
@@ -281,7 +324,8 @@ class TypesTest {
                   .put("months", 5L)
                   .put("days", 2L)
                   .put("seconds", 23L)
-                  .put("nanoseconds", 5)),
+                  .put("nanoseconds", 5),
+          ),
           Arguments.of(
               Named.of("point - 2d-extended", Values.point(7203, 2.3, 4.5).asPoint()),
               PayloadMode.EXTENDED,
@@ -293,7 +337,9 @@ class TypesTest {
                       .put("srid", 7203)
                       .put("x", 2.3)
                       .put("y", 4.5)
-                      .put("z", null))),
+                      .put("z", null),
+              ),
+          ),
           Arguments.of(
               Named.of("point - 2d-compact", Values.point(7203, 2.3, 4.5).asPoint()),
               PayloadMode.COMPACT,
@@ -303,7 +349,8 @@ class TypesTest {
                   .put("srid", 7203)
                   .put("x", 2.3)
                   .put("y", 4.5)
-                  .put("z", null)),
+                  .put("z", null),
+          ),
           Arguments.of(
               Named.of("point - 3d-extended", Values.point(4979, 12.78, 56.7, 100.0).asPoint()),
               PayloadMode.EXTENDED,
@@ -315,7 +362,9 @@ class TypesTest {
                       .put("srid", 4979)
                       .put("x", 12.78)
                       .put("y", 56.7)
-                      .put("z", 100.0))),
+                      .put("z", 100.0),
+              ),
+          ),
           Arguments.of(
               Named.of("point - 3d-compact", Values.point(4979, 12.78, 56.7, 100.0).asPoint()),
               PayloadMode.COMPACT,
@@ -325,40 +374,51 @@ class TypesTest {
                   .put("srid", 4979)
                   .put("x", 12.78)
                   .put("y", 56.7)
-                  .put("z", 100.0)),
+                  .put("z", 100.0),
+          ),
           Arguments.of(
               Named.of("list - empty-extended", emptyList<Any>()),
               PayloadMode.EXTENDED,
               PropertyType.schema,
-              PropertyType.getPropertyStruct(LONG_LIST, emptyList<Long>())),
+              PropertyType.getPropertyStruct(LONG_LIST, emptyList<Long>()),
+          ),
           Arguments.of(
               Named.of("list - empty-compact", emptyList<Any>()),
               PayloadMode.COMPACT,
               SchemaBuilder.array(SimpleTypes.NULL.schema(true)).build(),
-              emptyList<Any>()),
+              emptyList<Any>(),
+          ),
           Arguments.of(
               Named.of("list - long-extended", (1L..50L).toList()),
               PayloadMode.EXTENDED,
               PropertyType.schema,
-              PropertyType.getPropertyStruct(LONG_LIST, (1L..50L).toList())),
+              PropertyType.getPropertyStruct(LONG_LIST, (1L..50L).toList()),
+          ),
           Arguments.of(
               Named.of("list - long-compact", (1L..50L).toList()),
               PayloadMode.COMPACT,
               SchemaBuilder.array(SimpleTypes.LONG.schema()).build(),
-              (1L..50L).toList()),
+              (1L..50L).toList(),
+          ),
           Arguments.of(
               Named.of(
-                  "list - non-uniformly typed elements-extended", listOf(1, true, 2.0, "a string")),
+                  "list - non-uniformly typed elements-extended",
+                  listOf(1, true, 2.0, "a string"),
+              ),
               PayloadMode.EXTENDED,
               SchemaBuilder.array(PropertyType.schema).build(),
               listOf(
                   PropertyType.toConnectValue(1L),
                   PropertyType.getPropertyStruct(BOOLEAN, true),
                   PropertyType.getPropertyStruct(FLOAT, 2.0),
-                  PropertyType.toConnectValue("a string"))),
+                  PropertyType.toConnectValue("a string"),
+              ),
+          ),
           Arguments.of(
               Named.of(
-                  "list - non-uniformly typed elements-compact", listOf(1, true, 2.0, "a string")),
+                  "list - non-uniformly typed elements-compact",
+                  listOf(1, true, 2.0, "a string"),
+              ),
               PayloadMode.COMPACT,
               SchemaBuilder.struct()
                   .field("e0", SimpleTypes.LONG.schema())
@@ -372,39 +432,50 @@ class TypesTest {
                           .field("e1", SimpleTypes.BOOLEAN.schema())
                           .field("e2", SimpleTypes.FLOAT.schema())
                           .field("e3", SimpleTypes.STRING.schema())
-                          .build())
+                          .build()
+                  )
                   .put("e0", 1L)
                   .put("e1", true)
                   .put("e2", 2.0)
-                  .put("e3", "a string")),
+                  .put("e3", "a string"),
+          ),
           Arguments.of(
               Named.of(
-                  "map - uniformly typed values-extended", mapOf("a" to 1, "b" to 2, "c" to 3)),
+                  "map - uniformly typed values-extended",
+                  mapOf("a" to 1, "b" to 2, "c" to 3),
+              ),
               PayloadMode.EXTENDED,
               SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
               mapOf(
                   "a" to PropertyType.toConnectValue(1L),
                   "b" to PropertyType.toConnectValue(2L),
-                  "c" to PropertyType.toConnectValue(3L))),
+                  "c" to PropertyType.toConnectValue(3L),
+              ),
+          ),
           Arguments.of(
               Named.of("map - uniformly typed values-compact", mapOf("a" to 1, "b" to 2, "c" to 3)),
               PayloadMode.COMPACT,
               SchemaBuilder.map(SimpleTypes.STRING.schema(), SimpleTypes.LONG.schema()).build(),
-              mapOf("a" to 1L, "b" to 2L, "c" to 3L)),
+              mapOf("a" to 1L, "b" to 2L, "c" to 3L),
+          ),
           Arguments.of(
               Named.of(
                   "map - non-uniformly typed values-extended",
-                  mapOf("a" to 1, "b" to true, "c" to 3.0)),
+                  mapOf("a" to 1, "b" to true, "c" to 3.0),
+              ),
               PayloadMode.EXTENDED,
               SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build(),
               mapOf(
                   "a" to PropertyType.toConnectValue(1L),
                   "b" to PropertyType.getPropertyStruct(BOOLEAN, true),
-                  "c" to PropertyType.getPropertyStruct(FLOAT, 3.0))),
+                  "c" to PropertyType.getPropertyStruct(FLOAT, 3.0),
+              ),
+          ),
           Arguments.of(
               Named.of(
                   "map - non-uniformly typed values-compact",
-                  mapOf("a" to 1, "b" to true, "c" to 3.0)),
+                  mapOf("a" to 1, "b" to true, "c" to 3.0),
+              ),
               PayloadMode.COMPACT,
               SchemaBuilder.struct()
                   .field("a", SimpleTypes.LONG.schema())
@@ -416,10 +487,13 @@ class TypesTest {
                           .field("a", SimpleTypes.LONG.schema())
                           .field("b", SimpleTypes.BOOLEAN.schema())
                           .field("c", SimpleTypes.FLOAT.schema())
-                          .build())
+                          .build()
+                  )
                   .put("a", 1L)
                   .put("b", true)
-                  .put("c", 3.0)))
+                  .put("c", 3.0),
+          ),
+      )
     }
   }
 
@@ -442,10 +516,13 @@ class TypesTest {
                           mapOf(
                               "name" to "john",
                               "surname" to "doe",
-                              "dob" to LocalDate.of(1999, 12, 31)),
+                              "dob" to LocalDate.of(1999, 12, 31),
+                          ),
                       "company" to mapOf("name" to "acme corp", "est" to LocalDate.of(1980, 1, 1)),
                       "works_for" to
-                          mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5))))
+                          mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5)),
+                  ),
+              )
               .single()
 
       val person = record.get("p").asNode()
@@ -473,7 +550,8 @@ class TypesTest {
                 "<labels>" to person.labels().toList(),
                 "name" to "john",
                 "surname" to "doe",
-                "dob" to LocalDate.of(1999, 12, 31))
+                "dob" to LocalDate.of(1999, 12, 31),
+            )
       }
 
       val company = record.get("c").asNode()
@@ -498,7 +576,8 @@ class TypesTest {
                 "<id>" to company.id(),
                 "<labels>" to company.labels().toList(),
                 "name" to "acme corp",
-                "est" to LocalDate.of(1980, 1, 1))
+                "est" to LocalDate.of(1980, 1, 1),
+            )
       }
 
       val worksFor = record.get("r").asRelationship()
@@ -529,7 +608,8 @@ class TypesTest {
                 "<start.id>" to worksFor.startNodeId(),
                 "<end.id>" to worksFor.endNodeId(),
                 "contractId" to 5916L,
-                "since" to LocalDate.of(2000, 1, 5))
+                "since" to LocalDate.of(2000, 1, 5),
+            )
       }
     }
   }
@@ -552,10 +632,13 @@ class TypesTest {
                           mapOf(
                               "name" to "john",
                               "surname" to "doe",
-                              "dob" to LocalDate.of(1999, 12, 31)),
+                              "dob" to LocalDate.of(1999, 12, 31),
+                          ),
                       "company" to mapOf("name" to "acme corp", "est" to LocalDate.of(1980, 1, 1)),
                       "works_for" to
-                          mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5))))
+                          mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5)),
+                  ),
+              )
               .single()
 
       val person = record.get("p").asNode()
@@ -583,7 +666,8 @@ class TypesTest {
                 "<labels>" to person.labels().toList(),
                 "name" to "john",
                 "surname" to "doe",
-                "dob" to LocalDate.of(1999, 12, 31))
+                "dob" to LocalDate.of(1999, 12, 31),
+            )
       }
 
       val company = record.get("c").asNode()
@@ -608,7 +692,8 @@ class TypesTest {
                 "<id>" to company.id(),
                 "<labels>" to company.labels().toList(),
                 "name" to "acme corp",
-                "est" to LocalDate.of(1980, 1, 1))
+                "est" to LocalDate.of(1980, 1, 1),
+            )
       }
 
       val worksFor = record.get("r").asRelationship()
@@ -639,7 +724,8 @@ class TypesTest {
                 "<start.id>" to worksFor.startNodeId(),
                 "<end.id>" to worksFor.endNodeId(),
                 "contractId" to 5916L,
-                "since" to LocalDate.of(2000, 1, 5))
+                "since" to LocalDate.of(2000, 1, 5),
+            )
       }
     }
   }
@@ -647,7 +733,8 @@ class TypesTest {
   @Test
   fun `should build schema and value for change events and convert back with extended payload`() {
     Assumptions.assumeTrue(
-        canIUse(Dbms.changeDataCapture()).withNeo4j(Neo4jDetector.detect(driver)))
+        canIUse(Dbms.changeDataCapture()).withNeo4j(Neo4jDetector.detect(driver))
+    )
 
     val payloadMode = PayloadMode.EXTENDED
     // set-up cdc
@@ -675,9 +762,12 @@ class TypesTest {
                       mapOf(
                           "name" to "john",
                           "surname" to "doe",
-                          "dob" to LocalDate.of(1999, 12, 31)),
+                          "dob" to LocalDate.of(1999, 12, 31),
+                      ),
                   "company" to mapOf("name" to "acme corp", "est" to LocalDate.of(1980, 1, 1)),
-                  "works_for" to mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5))))
+                  "works_for" to mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5)),
+              ),
+          )
           .consume()
 
       val changes = cdc.query(changeId).collectList().block()
@@ -720,7 +810,8 @@ class TypesTest {
   @Test
   fun `should build schema and value for change events and convert back with compact payload`() {
     Assumptions.assumeTrue(
-        canIUse(Dbms.changeDataCapture()).withNeo4j(Neo4jDetector.detect(driver)))
+        canIUse(Dbms.changeDataCapture()).withNeo4j(Neo4jDetector.detect(driver))
+    )
 
     val payloadMode = PayloadMode.COMPACT
     // set-up cdc
@@ -748,9 +839,12 @@ class TypesTest {
                       mapOf(
                           "name" to "john",
                           "surname" to "doe",
-                          "dob" to LocalDate.of(1999, 12, 31)),
+                          "dob" to LocalDate.of(1999, 12, 31),
+                      ),
                   "company" to mapOf("name" to "acme corp", "est" to LocalDate.of(1980, 1, 1)),
-                  "works_for" to mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5))))
+                  "works_for" to mapOf("contractId" to 5916, "since" to LocalDate.of(2000, 1, 5)),
+              ),
+          )
           .consume()
 
       val changes = cdc.query(changeId).collectList().block()
@@ -809,7 +903,8 @@ class TypesTest {
                          arr_mixed: [{foo: "bar"}, null, {foo: 1}]
                       } AS data
                       RETURN data, data.id AS id
-                    """)
+                    """
+                  )
                   .single()
 
           buildMap {
@@ -829,17 +924,21 @@ class TypesTest {
                         SchemaBuilder.array(
                                 SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "arr_mixed",
                         SchemaBuilder.array(
                                 SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema)
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field("id", PropertyType.schema)
                     .field(
                         "root",
@@ -848,17 +947,24 @@ class TypesTest {
                                         Schema.STRING_SCHEMA,
                                         SchemaBuilder.array(
                                                 SchemaBuilder.map(
-                                                        Schema.STRING_SCHEMA, PropertyType.schema)
+                                                        Schema.STRING_SCHEMA,
+                                                        PropertyType.schema,
+                                                    )
                                                     .optional()
-                                                    .build())
+                                                    .build()
+                                            )
                                             .optional()
-                                            .build())
+                                            .build(),
+                                    )
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .optional()
             .build()
     val schema = DynamicTypes.toConnectSchema(payloadMode, returned, optional = true)
@@ -877,7 +983,9 @@ class TypesTest {
                         listOf(
                             mapOf("foo" to PropertyType.toConnectValue("bar")),
                             null,
-                            mapOf("foo" to PropertyType.toConnectValue(1L))))
+                            mapOf("foo" to PropertyType.toConnectValue(1L)),
+                        ),
+                    )
                     .put("id", PropertyType.toConnectValue("ROOT_ID"))
                     .put(
                         "root",
@@ -885,8 +993,11 @@ class TypesTest {
                             mapOf("children" to listOf<Any>()),
                             mapOf(
                                 "children" to
-                                    listOf(
-                                        mapOf("name" to PropertyType.toConnectValue("child")))))))
+                                    listOf(mapOf("name" to PropertyType.toConnectValue("child")))
+                            ),
+                        ),
+                    ),
+            )
 
     val reverted = DynamicTypes.fromConnectValue(schema, converted)
     reverted shouldBe returned
@@ -911,7 +1022,8 @@ class TypesTest {
                          arr_mixed: [{foo: "bar"}, null, {foo: 1}]
                       } AS data
                       RETURN data, data.id AS id
-                    """)
+                    """
+                  )
                   .single()
 
           buildMap {
@@ -930,29 +1042,40 @@ class TypesTest {
                         "arr",
                         SchemaBuilder.array(
                                 SchemaBuilder.map(
-                                        Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+                                        Schema.STRING_SCHEMA,
+                                        Schema.OPTIONAL_STRING_SCHEMA,
+                                    )
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field(
                         "arr_mixed",
                         SchemaBuilder.struct()
                             .field(
                                 "e0",
                                 SchemaBuilder.map(
-                                        Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+                                        Schema.STRING_SCHEMA,
+                                        Schema.OPTIONAL_STRING_SCHEMA,
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .field("e1", SimpleTypes.NULL.schema())
                             .field(
                                 "e2",
                                 SchemaBuilder.map(
-                                        Schema.STRING_SCHEMA, Schema.OPTIONAL_INT64_SCHEMA)
+                                        Schema.STRING_SCHEMA,
+                                        Schema.OPTIONAL_INT64_SCHEMA,
+                                    )
                                     .optional()
-                                    .build())
+                                    .build(),
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .field("id", Schema.OPTIONAL_STRING_SCHEMA)
                     .field(
                         "root",
@@ -962,17 +1085,23 @@ class TypesTest {
                                         SchemaBuilder.array(
                                                 SchemaBuilder.map(
                                                         Schema.STRING_SCHEMA,
-                                                        Schema.OPTIONAL_STRING_SCHEMA)
+                                                        Schema.OPTIONAL_STRING_SCHEMA,
+                                                    )
                                                     .optional()
-                                                    .build())
+                                                    .build()
+                                            )
                                             .optional()
-                                            .build())
+                                            .build(),
+                                    )
                                     .optional()
-                                    .build())
+                                    .build()
+                            )
                             .optional()
-                            .build())
+                            .build(),
+                    )
                     .optional()
-                    .build())
+                    .build(),
+            )
             .optional()
             .build()
     val schema = DynamicTypes.toConnectSchema(payloadMode, returned, optional = true)
@@ -991,13 +1120,17 @@ class TypesTest {
                         Struct(schema.field("data").schema().field("arr_mixed").schema())
                             .put("e0", mapOf("foo" to "bar"))
                             .put("e1", null)
-                            .put("e2", mapOf("foo" to 1L)))
+                            .put("e2", mapOf("foo" to 1L)),
+                    )
                     .put("id", "ROOT_ID")
                     .put(
                         "root",
                         listOf(
                             mapOf("children" to listOf<Any>()),
-                            mapOf("children" to listOf(mapOf("name" to "child"))))))
+                            mapOf("children" to listOf(mapOf("name" to "child"))),
+                        ),
+                    ),
+            )
 
     val reverted = DynamicTypes.fromConnectValue(schema, converted)
     reverted shouldBe returned

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/ExtendedValueConverterTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/ExtendedValueConverterTest.kt
@@ -14,13 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.connectors.kafka.data
+package org.neo4j.connectors.kafka.data.converter
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
 import java.nio.ByteBuffer
+import java.sql.Date
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -42,15 +43,15 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.ArgumentsProvider
 import org.junit.jupiter.params.provider.ArgumentsSource
 import org.junit.jupiter.params.support.ParameterDeclarations
-import org.neo4j.connectors.kafka.configuration.PayloadMode
-import org.neo4j.connectors.kafka.data.PropertyType.LOCAL_DATE
+import org.neo4j.connectors.kafka.data.DynamicTypes
+import org.neo4j.connectors.kafka.data.PropertyType
 import org.neo4j.driver.Values
 import org.neo4j.driver.types.Point
 
-class DynamicTypesExtendedTest {
+class ExtendedValueConverterTest {
 
   companion object {
-    val payloadMode = PayloadMode.EXTENDED
+    val converter = ExtendedValueConverter()
   }
 
   @ParameterizedTest(name = "{0}")
@@ -60,10 +61,10 @@ class DynamicTypesExtendedTest {
       value: Any?,
       expectedIfDifferent: Any?,
   ) {
-    DynamicTypes.toConnectSchema(payloadMode, value, false) shouldBe PropertyType.schema
-    DynamicTypes.toConnectSchema(payloadMode, value, true) shouldBe PropertyType.schema
+    converter.schema(value, false) shouldBe PropertyType.schema
+    converter.schema(value, true) shouldBe PropertyType.schema
 
-    val converted = DynamicTypes.toConnectValue(PropertyType.schema, value)
+    val converted = converter.value(PropertyType.schema, value)
     converted shouldBe PropertyType.toConnectValue(value)
 
     val reverted = DynamicTypes.fromConnectValue(PropertyType.schema, converted)
@@ -241,14 +242,13 @@ class DynamicTypesExtendedTest {
   @Test
   fun `should derive schema for entity types correctly`() {
     // Node
-    DynamicTypes.toConnectSchema(payloadMode, TestNode(0, emptyList(), emptyMap()), false) shouldBe
+    converter.schema(TestNode(0, emptyList(), emptyMap()), false) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<labels>", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
             .build()
 
-    DynamicTypes.toConnectSchema(
-        payloadMode,
+    converter.schema(
         TestNode(
             0,
             listOf("Person"),
@@ -264,19 +264,14 @@ class DynamicTypesExtendedTest {
             .build()
 
     // Relationship
-    DynamicTypes.toConnectSchema(
-        payloadMode,
-        TestRelationship(0, 1, 2, "KNOWS", emptyMap()),
-        false,
-    ) shouldBe
+    converter.schema(TestRelationship(0, 1, 2, "KNOWS", emptyMap()), false) shouldBe
         SchemaBuilder.struct()
             .field("<id>", Schema.INT64_SCHEMA)
             .field("<type>", Schema.STRING_SCHEMA)
             .field("<start.id>", Schema.INT64_SCHEMA)
             .field("<end.id>", Schema.INT64_SCHEMA)
             .build()
-    DynamicTypes.toConnectSchema(
-        payloadMode,
+    converter.schema(
         TestRelationship(
             0,
             1,
@@ -300,17 +295,17 @@ class DynamicTypesExtendedTest {
   fun `empty collections should map to property type`() {
     listOf(listOf<Any>(), setOf<Any>()).forEach { collection ->
       withClue(collection) {
-        DynamicTypes.toConnectSchema(payloadMode, collection, false) shouldBe PropertyType.schema
-        DynamicTypes.toConnectSchema(payloadMode, collection, true) shouldBe PropertyType.schema
+        converter.schema(collection, false) shouldBe PropertyType.schema
+        converter.schema(collection, true) shouldBe PropertyType.schema
       }
     }
   }
 
   @Test
   fun `empty arrays should map to an array of property type`() {
-    DynamicTypes.toConnectSchema(payloadMode, arrayOf<Any>(), false) shouldBe
+    converter.schema(arrayOf<Any>(), false) shouldBe
         SchemaBuilder.array(PropertyType.schema).build()
-    DynamicTypes.toConnectSchema(payloadMode, arrayOf<Any>(), true) shouldBe
+    converter.schema(arrayOf<Any>(), true) shouldBe
         SchemaBuilder.array(PropertyType.schema).optional().build()
   }
 
@@ -325,8 +320,8 @@ class DynamicTypesExtendedTest {
         )
         .forEach { array ->
           withClue(array) {
-            DynamicTypes.toConnectSchema(payloadMode, array, false) shouldBe PropertyType.schema
-            DynamicTypes.toConnectSchema(payloadMode, array, true) shouldBe PropertyType.schema
+            converter.schema(array, false) shouldBe PropertyType.schema
+            converter.schema(array, true) shouldBe PropertyType.schema
           }
         }
   }
@@ -337,9 +332,8 @@ class DynamicTypesExtendedTest {
       name: String,
       value: Any?,
   ) {
-    DynamicTypes.toConnectSchema(payloadMode, value, false) shouldBe
-        SchemaBuilder.array(PropertyType.schema).build()
-    DynamicTypes.toConnectSchema(payloadMode, value, true) shouldBe
+    converter.schema(value, false) shouldBe SchemaBuilder.array(PropertyType.schema).build()
+    converter.schema(value, true) shouldBe
         SchemaBuilder.array(PropertyType.schema).optional().build()
   }
 
@@ -371,25 +365,23 @@ class DynamicTypesExtendedTest {
 
   @Test
   fun `empty maps should map to an empty struct schema`() {
-    DynamicTypes.toConnectSchema(payloadMode, mapOf<String, Any>(), false) shouldBe
-        SchemaBuilder.struct().build()
-    DynamicTypes.toConnectSchema(payloadMode, mapOf<String, Any>(), true) shouldBe
-        SchemaBuilder.struct().optional().build()
+    converter.schema(mapOf<String, Any>(), false) shouldBe SchemaBuilder.struct().build()
+    converter.schema(mapOf<String, Any>(), true) shouldBe SchemaBuilder.struct().optional().build()
   }
 
   @Test
   fun `map keys should be enforced to be a string`() {
     shouldThrow<IllegalArgumentException> {
-      DynamicTypes.toConnectSchema(payloadMode, mapOf(1 to 5, "a" to "b"), false)
+      converter.schema(mapOf(1 to 5, "a" to "b"), false)
     } shouldHaveMessage ("unsupported map key type java.lang.Integer")
   }
 
   @ParameterizedTest(name = "{0}")
   @ArgumentsSource(PropertyTypedMapProvider::class)
   fun `maps with property typed values should map to a map schema`(name: String, value: Any?) {
-    DynamicTypes.toConnectSchema(payloadMode, value, false) shouldBe
+    converter.schema(value, false) shouldBe
         SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).build()
-    DynamicTypes.toConnectSchema(payloadMode, value, true) shouldBe
+    converter.schema(value, true) shouldBe
         SchemaBuilder.map(Schema.STRING_SCHEMA, PropertyType.schema).optional().build()
   }
 
@@ -427,8 +419,8 @@ class DynamicTypesExtendedTest {
   fun `unsupported types should throw`() {
     data class Test(val a: String)
 
-    listOf(object {}, java.sql.Date(0), object : Entity(emptyMap()) {}, Test("a string")).forEach {
-      shouldThrow<IllegalArgumentException> { DynamicTypes.toConnectSchema(payloadMode, it, false) }
+    listOf(object {}, Date(0), object : Entity(emptyMap()) {}, Test("a string")).forEach {
+      shouldThrow<IllegalArgumentException> { converter.schema(it, false) }
     }
   }
 
@@ -450,8 +442,8 @@ class DynamicTypesExtendedTest {
         )
         .forEach { (value, expected) ->
           withClue(value) {
-            val schema = DynamicTypes.toConnectSchema(payloadMode, value, false)
-            val converted = DynamicTypes.toConnectValue(schema, value)
+            val schema = converter.schema(value, false)
+            val converted = converter.value(schema, value)
 
             converted shouldBe expected
 
@@ -469,8 +461,8 @@ class DynamicTypesExtendedTest {
             listOf("Person", "Employee"),
             mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
         )
-    val schema = DynamicTypes.toConnectSchema(payloadMode, node, false)
-    val converted = DynamicTypes.toConnectValue(schema, node)
+    val schema = converter.schema(node, false)
+    val converted = converter.value(schema, node)
 
     converted shouldBe
         Struct(schema)
@@ -499,8 +491,8 @@ class DynamicTypesExtendedTest {
             "KNOWS",
             mapOf("name" to Values.value("john"), "surname" to Values.value("doe")),
         )
-    val schema = DynamicTypes.toConnectSchema(payloadMode, rel, false)
-    val converted = DynamicTypes.toConnectValue(schema, rel)
+    val schema = converter.schema(rel, false)
+    val converted = converter.value(schema, rel)
 
     converted shouldBe
         Struct(schema)
@@ -533,8 +525,8 @@ class DynamicTypesExtendedTest {
             "employed" to true,
             "nullable" to null,
         )
-    val schema = DynamicTypes.toConnectSchema(payloadMode, map, false)
-    val converted = DynamicTypes.toConnectValue(schema, map)
+    val schema = converter.schema(map, false)
+    val converted = converter.value(schema, map)
 
     converted shouldBe
         mapOf(
@@ -542,7 +534,7 @@ class DynamicTypesExtendedTest {
             "age" to PropertyType.toConnectValue(21L),
             "dob" to
                 PropertyType.getPropertyStruct(
-                    LOCAL_DATE,
+                    PropertyType.LOCAL_DATE,
                     DateTimeFormatter.ISO_DATE.format(LocalDate.of(1999, 12, 31)),
                 ),
             "employed" to PropertyType.toConnectValue(true),
@@ -556,15 +548,15 @@ class DynamicTypesExtendedTest {
   @Test
   fun `collections with elements of different types should be returned as list of property types and should be converted back`() {
     val coll = listOf("john", 21, LocalDate.of(1999, 12, 31), true, null)
-    val schema = DynamicTypes.toConnectSchema(payloadMode, coll, false)
-    val converted = DynamicTypes.toConnectValue(schema, coll)
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
 
     converted shouldBe
         listOf(
             PropertyType.toConnectValue("john"),
             PropertyType.toConnectValue(21L),
             PropertyType.getPropertyStruct(
-                LOCAL_DATE,
+                PropertyType.LOCAL_DATE,
                 DateTimeFormatter.ISO_DATE.format(LocalDate.of(1999, 12, 31)),
             ),
             PropertyType.toConnectValue(true),

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/ValueConverterTestUtils.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/ValueConverterTestUtils.kt
@@ -14,9 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.connectors.kafka.data
+package org.neo4j.connectors.kafka.data.converter
 
 import java.util.function.Function
+import kotlin.collections.get
 import org.neo4j.driver.Value
 import org.neo4j.driver.types.Node
 import org.neo4j.driver.types.Relationship

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/utils/JSONUtilsTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/utils/JSONUtilsTest.kt
@@ -54,7 +54,8 @@ class JSONUtilsTest {
             "point2dWgs84" to Values.point(WGS84_Code, 1.0, 2.0),
             "point3dWgs84" to Values.point(WGS84_3D_Code, 1.0, 2.0, 3.0),
             "time" to Values.value(OffsetTime.of(14, 1, 1, 1, UTC)),
-            "dateTime" to Values.value(ZonedDateTime.of(2017, 12, 17, 17, 14, 35, 123456789, UTC)))
+            "dateTime" to Values.value(ZonedDateTime.of(2017, 12, 17, 17, 14, 35, 123456789, UTC)),
+        )
 
     // When
     val jsonString = JSONUtils.writeValueAsString(map)
@@ -76,7 +77,8 @@ class JSONUtilsTest {
                     txId = 1,
                     txEventId = 0,
                     txEventsCount = 1,
-                    operation = OperationType.created),
+                    operation = OperationType.created,
+                ),
             payload =
                 NodePayload(
                     id = "0",
@@ -84,9 +86,12 @@ class JSONUtilsTest {
                     after =
                         NodeChange(
                             properties = mapOf("prop1" to "foo", "bar" to 1),
-                            labels = listOf("LabelCDC")),
-                    type = EntityType.node),
-            schema = Schema())
+                            labels = listOf("LabelCDC"),
+                        ),
+                    type = EntityType.node,
+                ),
+            schema = Schema(),
+        )
     val cdcMap =
         mapOf<String, Any>(
             "meta" to
@@ -96,7 +101,8 @@ class JSONUtilsTest {
                     "txId" to 1,
                     "txEventId" to 0,
                     "txEventsCount" to 1,
-                    "operation" to OperationType.created),
+                    "operation" to OperationType.created,
+                ),
             "payload" to
                 mapOf(
                     "id" to "0",
@@ -104,9 +110,12 @@ class JSONUtilsTest {
                     "after" to
                         NodeChange(
                             properties = mapOf("prop1" to "foo", "bar" to 1),
-                            labels = listOf("LabelCDC")),
-                    "type" to EntityType.node),
-            "schema" to emptyMap<String, Any>())
+                            labels = listOf("LabelCDC"),
+                        ),
+                    "type" to EntityType.node,
+                ),
+            "schema" to emptyMap<String, Any>(),
+        )
     val cdcString =
         """{
             |"meta":{"timestamp":$timestamp,"username":"user","txId":1,"txEventId":0,"txEventsCount":1,"operation":"created"},

--- a/pom.xml
+++ b/pom.xml
@@ -637,12 +637,13 @@
                             <include>src/test/kotlin/**/*.kt</include>
                         </includes>
                         <ktfmt>
-                            <version>0.53</version>
+                            <version>0.56</version>
                             <style>META</style>
                             <blockIndent>2</blockIndent>
                             <continuationIndent>4</continuationIndent>
                             <removeUnusedImports>true</removeUnusedImports>
                             <maxWidth>100</maxWidth>
+                            <manageTrailingCommas>true</manageTrailingCommas>
                         </ktfmt>
                     </kotlin>
                     <java>

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaFromStreamsMessageIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaFromStreamsMessageIT.kt
@@ -58,7 +58,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should create node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(
         StreamsTransactionEvent(
@@ -74,7 +74,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         ),
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -93,7 +93,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should update node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -122,7 +122,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         ),
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -147,7 +147,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should delete node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -166,7 +166,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = null,
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -180,7 +180,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should create a node with a null unique constraint property value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
 
     // given a creation event
@@ -245,7 +245,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should update node with a null unique constraint property value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
 
     // given a database with a single node
@@ -258,7 +258,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    ),
+                    )
             ),
         )
         .consume()
@@ -303,7 +303,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                                 StreamsConstraintType.NODE_PROPERTY_EXISTS,
                             ),
                             Constraint("Person", setOf("invalid"), StreamsConstraintType.UNIQUE),
-                        ),
+                        )
                 ),
         )
 
@@ -338,7 +338,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should delete a node with a null unique constraint property value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
 
     // given a database containing 1 node
@@ -351,7 +351,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    ),
+                    )
             ),
         )
         .consume()
@@ -418,7 +418,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   fun `should fail to delete a node when no valid unique constraints are provided`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      sink: Neo4jSinkRegistration
+      sink: Neo4jSinkRegistration,
   ) = runTest {
 
     // given a database containing 1 node
@@ -431,7 +431,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    ),
+                    )
             ),
         )
         .consume()
@@ -448,20 +448,13 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = null,
                     before =
                         NodeChange(
-                            mapOf(
-                                "first_name" to "john",
-                                "last_name" to "smith",
-                            ),
+                            mapOf("first_name" to "john", "last_name" to "smith"),
                             listOf("Person"),
                         ),
                 ),
             schema =
                 Schema(
-                    properties =
-                        mapOf(
-                            "first_name" to "String",
-                            "last_name" to "String",
-                        ),
+                    properties = mapOf("first_name" to "String", "last_name" to "String"),
                     constraints =
                         listOf(
                             Constraint("Person", setOf("email"), StreamsConstraintType.UNIQUE),
@@ -515,7 +508,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         "first_name" to "john",
                         "last_name" to "smith",
                         "email" to "john@smith.org",
-                    ),
+                    )
             ),
         )
         .consume()
@@ -532,20 +525,13 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = null,
                     before =
                         NodeChange(
-                            mapOf(
-                                "first_name" to "john",
-                                "last_name" to "smith",
-                            ),
+                            mapOf("first_name" to "john", "last_name" to "smith"),
                             listOf("Person"),
                         ),
                 ),
             schema =
                 Schema(
-                    properties =
-                        mapOf(
-                            "first_name" to "String",
-                            "last_name" to "String",
-                        ),
+                    properties = mapOf("first_name" to "String", "last_name" to "String"),
                     constraints = emptyList(),
                 ),
         )
@@ -576,7 +562,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should create relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -602,12 +588,10 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
                     before = null,
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -661,12 +645,10 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
                     before = null,
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -712,12 +694,10 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     end = RelationshipNodeChange("person2", listOf("Person"), emptyMap()),
                     before = null,
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -736,7 +716,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should update relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -768,15 +748,13 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
                                 "type" to "friend",
-                            ),
+                            )
                         ),
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -836,15 +814,13 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
                                 "type" to "friend",
-                            ),
+                            )
                         ),
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -860,10 +836,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
     result.get("r").asRelationship() should
         {
           it.asMap() shouldBe
-              mapOf(
-                  "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
-                  "type" to "friend",
-              )
+              mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend")
         }
     result.get("start").asNode() should
         {
@@ -914,15 +887,13 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
                                 "type" to "friend",
-                            ),
+                            )
                         ),
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(1999, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -939,10 +910,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
       result.get("r").asRelationship() should
           {
             it.asMap() shouldBe
-                mapOf(
-                    "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
-                    "type" to "friend",
-                )
+                mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay(), "type" to "friend")
           }
       result.get("start").asNode() should
           {
@@ -961,7 +929,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should delete relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -993,12 +961,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
                                 "type" to "friend",
-                            ),
+                            )
                         ),
                     after = null,
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1045,12 +1013,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
                                 "type" to "friend",
-                            ),
+                            )
                         ),
                     after = null,
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -1102,12 +1070,12 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                             mapOf(
                                 "since" to LocalDate.of(2000, 1, 1).toEpochDay(),
                                 "type" to "friend",
-                            ),
+                            )
                         ),
                     after = null,
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -1130,7 +1098,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   @Test
   fun `should sync continuous changes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(
         StreamsTransactionEvent(
@@ -1152,7 +1120,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         ),
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     producer.publish(
@@ -1175,7 +1143,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                         ),
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     producer.publish(
@@ -1197,7 +1165,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = RelationshipChange(emptyMap()),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1244,12 +1212,10 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     end = RelationshipNodeChange("person2", listOf("Person"), mapOf("id" to 2L)),
                     before = RelationshipChange(emptyMap()),
                     after =
-                        RelationshipChange(
-                            mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay()),
-                        ),
+                        RelationshipChange(mapOf("since" to LocalDate.of(2000, 1, 1).toEpochDay())),
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1292,7 +1258,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = null,
                 ),
             schema = Schema(),
-        ),
+        )
     )
 
     producer.publish(
@@ -1315,7 +1281,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = null,
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     producer.publish(
@@ -1338,7 +1304,7 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
                     after = null,
                 ),
             schema = defaultSchema(),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1349,15 +1315,13 @@ class Neo4jCdcSchemaFromStreamsMessageIT {
   }
 
   private fun defaultSchema() =
-      Schema(
-          constraints = listOf(Constraint("Person", setOf("id"), StreamsConstraintType.UNIQUE)),
-      )
+      Schema(constraints = listOf(Constraint("Person", setOf("id"), StreamsConstraintType.UNIQUE)))
 
   private fun newMetadata(
       txId: Long = 1,
       txEventId: Int = 0,
       txEventsCount: Int = 1,
-      operation: OperationType
+      operation: OperationType,
   ) =
       Meta(
           timestamp = System.currentTimeMillis(),

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCdcSchemaIT.kt
@@ -59,7 +59,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should create node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(
         newEvent(
@@ -73,7 +73,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 NodeState(emptyList(), mapOf("id" to 5L, "name" to "john", "surname" to "doe")),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -92,7 +92,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should update node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -121,7 +121,7 @@ abstract class Neo4jCdcSchemaIT {
                     ),
                 ),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -146,7 +146,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should delete node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -167,7 +167,7 @@ abstract class Neo4jCdcSchemaIT {
                 NodeState(emptyList(), mapOf("id" to 1L, "name" to "john")),
                 null,
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -182,7 +182,7 @@ abstract class Neo4jCdcSchemaIT {
   fun `should fail to delete a node when keys is empty `(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      sink: Neo4jSinkRegistration
+      sink: Neo4jSinkRegistration,
   ) = runTest {
     session
         .run(
@@ -203,7 +203,7 @@ abstract class Neo4jCdcSchemaIT {
                 NodeState(emptyList(), mapOf("id" to 1L, "name" to "john")),
                 null,
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -224,7 +224,7 @@ abstract class Neo4jCdcSchemaIT {
   fun `should fail to delete a node when keys is effectively empty `(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      sink: Neo4jSinkRegistration
+      sink: Neo4jSinkRegistration,
   ) = runTest {
     session
         .run(
@@ -245,7 +245,7 @@ abstract class Neo4jCdcSchemaIT {
                 NodeState(emptyList(), mapOf("id" to 1L, "name" to "john")),
                 null,
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -265,7 +265,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should create relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -294,7 +294,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -351,7 +351,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -400,7 +400,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -449,7 +449,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -498,7 +498,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -546,14 +546,10 @@ abstract class Neo4jCdcSchemaIT {
                 EntityOperation.CREATE,
                 null,
                 RelationshipState(
-                    mapOf(
-                        "id" to 1L,
-                        "since" to LocalDate.of(2000, 1, 1),
-                        "type" to "friend",
-                    ),
+                    mapOf("id" to 1L, "since" to LocalDate.of(2000, 1, 1), "type" to "friend")
                 ),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -572,7 +568,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should update relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -603,7 +599,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -662,7 +658,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -727,7 +723,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -792,7 +788,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -856,7 +852,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1), "type" to "friend")),
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -877,7 +873,7 @@ abstract class Neo4jCdcSchemaIT {
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
       sink: Neo4jSinkRegistration,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createRelationshipKeyConstraint(neo4j, "KNOWS_KEY", "KNOWS", "id")
     session
@@ -891,11 +887,7 @@ abstract class Neo4jCdcSchemaIT {
                 "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
                 "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
                 "knows" to
-                    mapOf(
-                        "id" to 3L,
-                        "since" to LocalDate.of(2000, 1, 1),
-                        "type" to "friend",
-                    ),
+                    mapOf("id" to 3L, "since" to LocalDate.of(2000, 1, 1), "type" to "friend"),
             ),
         )
         .consume()
@@ -912,15 +904,11 @@ abstract class Neo4jCdcSchemaIT {
                 listOf(mapOf("id" to 3L)),
                 EntityOperation.UPDATE,
                 RelationshipState(
-                    mapOf(
-                        "id" to 3L,
-                        "since" to LocalDate.of(2000, 1, 1),
-                        "type" to "friend",
-                    ),
+                    mapOf("id" to 3L, "since" to LocalDate.of(2000, 1, 1), "type" to "friend")
                 ),
                 RelationshipState(mapOf("id" to 3L, "since" to LocalDate.of(1999, 1, 1))),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -947,7 +935,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should delete relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
@@ -978,7 +966,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1024,7 +1012,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -1075,7 +1063,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -1126,7 +1114,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -1177,7 +1165,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(1999, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
 
     // sink connector should transition into FAILED state
@@ -1198,7 +1186,7 @@ abstract class Neo4jCdcSchemaIT {
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
       sink: Neo4jSinkRegistration,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createRelationshipKeyConstraint(neo4j, "KNOWS_KEY", "KNOWS", "id")
     session
@@ -1212,11 +1200,7 @@ abstract class Neo4jCdcSchemaIT {
                 "person1" to mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
                 "person2" to mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
                 "knows" to
-                    mapOf(
-                        "id" to 3L,
-                        "since" to LocalDate.of(2000, 1, 1),
-                        "type" to "friend",
-                    ),
+                    mapOf("id" to 3L, "since" to LocalDate.of(2000, 1, 1), "type" to "friend"),
             ),
         )
         .consume()
@@ -1235,7 +1219,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("id" to 3L, "since" to LocalDate.of(1999, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1253,7 +1237,7 @@ abstract class Neo4jCdcSchemaIT {
   @Test
   fun `should sync continuous changes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(
         newEvent(
@@ -1265,12 +1249,9 @@ abstract class Neo4jCdcSchemaIT {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
-                NodeState(
-                    listOf("Person"),
-                    mapOf("id" to 1L, "name" to "john", "surname" to "doe"),
-                ),
+                NodeState(listOf("Person"), mapOf("id" to 1L, "name" to "john", "surname" to "doe")),
             ),
-        ),
+        )
     )
 
     producer.publish(
@@ -1283,12 +1264,9 @@ abstract class Neo4jCdcSchemaIT {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 2L))),
                 null,
-                NodeState(
-                    listOf("Person"),
-                    mapOf("id" to 2L, "name" to "mary", "surname" to "doe"),
-                ),
+                NodeState(listOf("Person"), mapOf("id" to 2L, "name" to "mary", "surname" to "doe")),
             ),
-        ),
+        )
     )
 
     producer.publish(
@@ -1305,7 +1283,7 @@ abstract class Neo4jCdcSchemaIT {
                 null,
                 RelationshipState(emptyMap()),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1349,7 +1327,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(emptyMap()),
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {
@@ -1386,7 +1364,7 @@ abstract class Neo4jCdcSchemaIT {
                 RelationshipState(mapOf("since" to LocalDate.of(2000, 1, 1))),
                 null,
             ),
-        ),
+        )
     )
     producer.publish(
         newEvent(
@@ -1403,7 +1381,7 @@ abstract class Neo4jCdcSchemaIT {
                 ),
                 null,
             ),
-        ),
+        )
     )
     producer.publish(
         newEvent(
@@ -1420,7 +1398,7 @@ abstract class Neo4jCdcSchemaIT {
                 ),
                 null,
             ),
-        ),
+        )
     )
 
     eventually(30.seconds) {

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jConnectorTest.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jConnectorTest.kt
@@ -110,7 +110,9 @@ class Neo4jConnectorTest {
                 SinkConfiguration.CYPHER_BIND_HEADER_AS to "",
                 SinkConfiguration.CYPHER_BIND_KEY_AS to "",
                 SinkConfiguration.CYPHER_BIND_VALUE_AS to "",
-                SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT to "false"))
+                SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT to "false",
+            )
+        )
 
     config
         .configValues()
@@ -121,7 +123,8 @@ class Neo4jConnectorTest {
                   SinkConfiguration.CYPHER_BIND_HEADER_AS,
                   SinkConfiguration.CYPHER_BIND_KEY_AS,
                   SinkConfiguration.CYPHER_BIND_VALUE_AS,
-                  SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT)
+                  SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT,
+              )
         }
         .forEach {
           it.errorMessages() shouldContain
@@ -139,7 +142,9 @@ class Neo4jConnectorTest {
                 SinkConfiguration.CYPHER_BIND_HEADER_AS to "",
                 SinkConfiguration.CYPHER_BIND_KEY_AS to "",
                 SinkConfiguration.CYPHER_BIND_VALUE_AS to "",
-                SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT to "true"))
+                SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT to "true",
+            )
+        )
 
     config
         .configValues()
@@ -149,7 +154,8 @@ class Neo4jConnectorTest {
                   SinkConfiguration.CYPHER_BIND_HEADER_AS,
                   SinkConfiguration.CYPHER_BIND_KEY_AS,
                   SinkConfiguration.CYPHER_BIND_VALUE_AS,
-                  SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT)
+                  SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT,
+              )
         }
         .forEach { it.errorMessages() should beEmpty<String>() }
   }
@@ -164,7 +170,9 @@ class Neo4jConnectorTest {
                 SinkConfiguration.CYPHER_BIND_HEADER_AS to "",
                 SinkConfiguration.CYPHER_BIND_KEY_AS to "",
                 SinkConfiguration.CYPHER_BIND_VALUE_AS to "__value",
-                SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT to "false"))
+                SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT to "false",
+            )
+        )
 
     config
         .configValues()
@@ -174,7 +182,8 @@ class Neo4jConnectorTest {
                   SinkConfiguration.CYPHER_BIND_HEADER_AS,
                   SinkConfiguration.CYPHER_BIND_KEY_AS,
                   SinkConfiguration.CYPHER_BIND_VALUE_AS,
-                  SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT)
+                  SinkConfiguration.CYPHER_BIND_VALUE_AS_EVENT,
+              )
         }
         .forEach { it.errorMessages() should beEmpty<String>() }
   }

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
@@ -66,7 +66,7 @@ abstract class Neo4jCudIT {
   fun `should create node from json string`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -82,7 +82,8 @@ abstract class Neo4jCudIT {
                     "id": 1,
                     "foo": "foo-value"
                   }
-                }""")
+                }""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n) RETURN n", emptyMap()).single() }
         .get("n")
@@ -98,7 +99,7 @@ abstract class Neo4jCudIT {
   fun `should create node from byte array`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -112,7 +113,10 @@ abstract class Neo4jCudIT {
                         "type" to "node",
                         "op" to "create",
                         "labels" to listOf("Foo", "Bar"),
-                        "properties" to mapOf("id" to 1L, "foo" to "foo-value"))))
+                        "properties" to mapOf("id" to 1L, "foo" to "foo-value"),
+                    )
+                ),
+    )
 
     eventually(30.seconds) { session.run("MATCH (n) RETURN n", emptyMap()).single() }
         .get("n")
@@ -128,7 +132,7 @@ abstract class Neo4jCudIT {
   fun `should create node from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -163,11 +167,18 @@ abstract class Neo4jCudIT {
                         .put(
                             "dob",
                             DynamicTypes.toConnectValue(
-                                PropertyType.schema, LocalDate.of(1995, 1, 1)))
+                                PropertyType.schema,
+                                LocalDate.of(1995, 1, 1),
+                            ),
+                        )
                         .put(
                             "place",
                             DynamicTypes.toConnectValue(
-                                PropertyType.schema, Values.point(7203, 1.0, 2.5).asPoint()))),
+                                PropertyType.schema,
+                                Values.point(7203, 1.0, 2.5).asPoint(),
+                            ),
+                        ),
+                ),
     )
 
     eventually(30.seconds) { session.run("MATCH (n) RETURN n", emptyMap()).single() }
@@ -180,7 +191,8 @@ abstract class Neo4jCudIT {
                   "id" to 1L,
                   "foo" to "foo-value",
                   "dob" to LocalDate.of(1995, 1, 1),
-                  "place" to Values.point(7203, 1.0, 2.5).asPoint())
+                  "place" to Values.point(7203, 1.0, 2.5).asPoint(),
+              )
         }
   }
 
@@ -189,7 +201,7 @@ abstract class Neo4jCudIT {
   fun `should update node from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -197,7 +209,8 @@ abstract class Neo4jCudIT {
     session
         .run(
             "CREATE (n:Foo:Bar) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 1L, "foo" to "foo-value")))
+            mapOf("props" to mapOf("id" to 1L, "foo" to "foo-value")),
+        )
         .consume()
 
     val idsSchema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build()
@@ -231,11 +244,18 @@ abstract class Neo4jCudIT {
                         .put(
                             "dob",
                             DynamicTypes.toConnectValue(
-                                PropertyType.schema, LocalDate.of(1995, 1, 1)))
+                                PropertyType.schema,
+                                LocalDate.of(1995, 1, 1),
+                            ),
+                        )
                         .put(
                             "place",
                             DynamicTypes.toConnectValue(
-                                PropertyType.schema, Values.point(7203, 1.0, 2.5).asPoint()))),
+                                PropertyType.schema,
+                                Values.point(7203, 1.0, 2.5).asPoint(),
+                            ),
+                        ),
+                ),
     )
 
     eventually(30.seconds) {
@@ -247,7 +267,8 @@ abstract class Neo4jCudIT {
                     "id" to 1L,
                     "foo" to "foo-value-updated",
                     "dob" to LocalDate.of(1995, 1, 1),
-                    "place" to Values.point(7203, 1.0, 2.5).asPoint())
+                    "place" to Values.point(7203, 1.0, 2.5).asPoint(),
+                )
           }
     }
   }
@@ -257,7 +278,7 @@ abstract class Neo4jCudIT {
   fun `should merge node from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -265,7 +286,8 @@ abstract class Neo4jCudIT {
     session
         .run(
             "CREATE (n:Foo:Bar) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 0L, "foo" to "foo-value")))
+            mapOf("props" to mapOf("id" to 0L, "foo" to "foo-value")),
+        )
         .consume()
 
     val idsSchema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build()
@@ -301,11 +323,18 @@ abstract class Neo4jCudIT {
                         .put(
                             "dob",
                             DynamicTypes.toConnectValue(
-                                PropertyType.schema, LocalDate.of(1995, 1, 1)))
+                                PropertyType.schema,
+                                LocalDate.of(1995, 1, 1),
+                            ),
+                        )
                         .put(
                             "place",
                             DynamicTypes.toConnectValue(
-                                PropertyType.schema, Values.point(7203, 1.0, 2.5).asPoint()))),
+                                PropertyType.schema,
+                                Values.point(7203, 1.0, 2.5).asPoint(),
+                            ),
+                        ),
+                ),
     )
 
     eventually(30.seconds) {
@@ -318,7 +347,8 @@ abstract class Neo4jCudIT {
                     "foo" to "foo-value",
                     "foo_new" to "foo-new-value-merged",
                     "dob" to LocalDate.of(1995, 1, 1),
-                    "place" to Values.point(7203, 1.0, 2.5).asPoint())
+                    "place" to Values.point(7203, 1.0, 2.5).asPoint(),
+                )
           }
     }
   }
@@ -328,7 +358,7 @@ abstract class Neo4jCudIT {
   fun `should delete node from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -336,7 +366,8 @@ abstract class Neo4jCudIT {
     session
         .run(
             "CREATE (n:Foo:Bar) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 0L, "foo" to "foo-value")))
+            mapOf("props" to mapOf("id" to 0L, "foo" to "foo-value")),
+        )
         .consume()
 
     val idsSchema = SchemaBuilder.struct().field("id", Schema.INT64_SCHEMA).build()
@@ -355,7 +386,8 @@ abstract class Neo4jCudIT {
                 .put("type", "node")
                 .put("op", "delete")
                 .put("labels", listOf("Foo", "Bar"))
-                .put("ids", Struct(idsSchema).put("id", 0L)))
+                .put("ids", Struct(idsSchema).put("id", 0L)),
+    )
 
     eventually(30.seconds) {
       session
@@ -371,7 +403,7 @@ abstract class Neo4jCudIT {
   fun `should detach delete node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.run(
@@ -384,7 +416,9 @@ abstract class Neo4jCudIT {
         mapOf(
             "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
             "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-            "r" to mapOf("by" to "incident")))
+            "r" to mapOf("by" to "incident"),
+        ),
+    )
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
@@ -397,7 +431,8 @@ abstract class Neo4jCudIT {
                     "id": 1
                   },
                   "detach": true
-                }""")
+                }""",
+    )
 
     eventually(30.seconds) {
       session
@@ -419,7 +454,7 @@ abstract class Neo4jCudIT {
   fun `should create and update node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
 
@@ -435,7 +470,8 @@ abstract class Neo4jCudIT {
                     "id": 0,
                     "foo": "foo-value"
                   }
-                }"""),
+                }""",
+        ),
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
             value =
@@ -450,7 +486,9 @@ abstract class Neo4jCudIT {
                     "id": 1,
                     "foo": "foo-value-updated"
                   }
-                }"""))
+                }""",
+        ),
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -466,7 +504,7 @@ abstract class Neo4jCudIT {
   fun `should not create node with update operation`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
 
@@ -485,7 +523,8 @@ abstract class Neo4jCudIT {
                     "id": 1,
                     "foo": "foo-value-updated"
                   }
-                }"""),
+                }""",
+        ),
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
             value =
@@ -497,7 +536,9 @@ abstract class Neo4jCudIT {
                     "id": 2,
                     "foo": "foo-value"
                   }
-                }"""))
+                }""",
+        ),
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n").single().get("n").asNode() should
@@ -514,7 +555,7 @@ abstract class Neo4jCudIT {
       @TopicProducer(TOPIC_1) producer1: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_2) producer2: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
 
@@ -529,7 +570,8 @@ abstract class Neo4jCudIT {
                     "id": 1,
                     "foo": "foo-value"
                   }
-                }""")
+                }""",
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -549,7 +591,8 @@ abstract class Neo4jCudIT {
                   "ids": {
                     "id": 1
                   }
-                }""")
+                }""",
+    )
 
     eventually(30.seconds) {
       session
@@ -565,7 +608,7 @@ abstract class Neo4jCudIT {
   fun `should create, delete and recreate node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -582,7 +625,8 @@ abstract class Neo4jCudIT {
                     "id": 0,
                     "foo": "foo-value"
                   }
-                }"""),
+                }""",
+        ),
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
             value =
@@ -594,7 +638,8 @@ abstract class Neo4jCudIT {
                     "id": 0
                   },
                   "detach": true
-                }"""),
+                }""",
+        ),
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
             value =
@@ -606,7 +651,9 @@ abstract class Neo4jCudIT {
                     "id": 1,
                     "foo": "foo-value-new"
                   }
-                }"""))
+                }""",
+        ),
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -622,7 +669,7 @@ abstract class Neo4jCudIT {
   fun `should create 1000 nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
 
@@ -640,9 +687,11 @@ abstract class Neo4jCudIT {
                     "id": ${it},
                     "foo": "foo-value-${it}"
                   }
-                }""")
+                }""",
+              )
             }
-            .toTypedArray())
+            .toTypedArray()
+    )
 
     eventually(30.seconds) {
       session
@@ -658,7 +707,7 @@ abstract class Neo4jCudIT {
   fun `should create node from struct with connect types`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -693,7 +742,9 @@ abstract class Neo4jCudIT {
                         .put("height", BigDecimal.valueOf(185, 2))
                         .put("dob", DateSupport.date(1978, 1, 15))
                         .put("tob", DateSupport.time(7, 45, 12, 999))
-                        .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999))))
+                        .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999)),
+                ),
+    )
 
     eventually(30.seconds) { session.run("MATCH (n) RETURN n", emptyMap()).single() }
         .get("n")
@@ -706,7 +757,8 @@ abstract class Neo4jCudIT {
                   "height" to "1.85",
                   "dob" to LocalDate.of(1978, 1, 15),
                   "tob" to LocalTime.of(7, 45, 12, 999000000),
-                  "tsob" to LocalDateTime.of(1978, 1, 15, 7, 45, 12, 999000000))
+                  "tsob" to LocalDateTime.of(1978, 1, 15, 7, 45, 12, 999000000),
+              )
         }
   }
 
@@ -715,7 +767,7 @@ abstract class Neo4jCudIT {
   fun `should create relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -729,7 +781,9 @@ abstract class Neo4jCudIT {
                 .trimIndent(),
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
-                "bar" to mapOf("id" to 1L, "bar" to "bar-value")))
+                "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -756,13 +810,15 @@ abstract class Neo4jCudIT {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r]->(:Bar {id: ${'$'}barId}) RETURN r",
-              mapOf("fooId" to 1L, "barId" to 1L))
+              mapOf("fooId" to 1L, "barId" to 1L),
+          )
           .single()
           .get("r")
           .asRelationship() should
@@ -778,7 +834,7 @@ abstract class Neo4jCudIT {
   fun `should create relationship by merging nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -809,14 +865,16 @@ abstract class Neo4jCudIT {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       val result =
           session
               .run(
                   "MATCH (f:Foo {id: ${'$'}fooId})-[r:RELATED_TO]->(b:Bar {id: ${'$'}barId}) RETURN f,b,r",
-                  mapOf("fooId" to 1L, "barId" to 1L))
+                  mapOf("fooId" to 1L, "barId" to 1L),
+              )
               .single()
 
       result.get("f").asNode() should
@@ -844,7 +902,7 @@ abstract class Neo4jCudIT {
   fun `should create relationship by merging one of the nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -877,14 +935,16 @@ abstract class Neo4jCudIT {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       val result =
           session
               .run(
                   "MATCH (f:Foo {id: ${'$'}fooId})-[r:RELATED_TO]->(b:Bar {id: ${'$'}barId}) RETURN f,b,r",
-                  mapOf("fooId" to 1L, "barId" to 1L))
+                  mapOf("fooId" to 1L, "barId" to 1L),
+              )
               .single()
 
       result.get("f").asNode() should
@@ -912,7 +972,7 @@ abstract class Neo4jCudIT {
   fun `should update relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -928,7 +988,9 @@ abstract class Neo4jCudIT {
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
                 "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-                "r" to mapOf("by" to "incident")))
+                "r" to mapOf("by" to "incident"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -955,13 +1017,15 @@ abstract class Neo4jCudIT {
                     "by": "incident-updated"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r]->(:Bar {id: ${'$'}barId}) RETURN r",
-              mapOf("fooId" to 1L, "barId" to 1L))
+              mapOf("fooId" to 1L, "barId" to 1L),
+          )
           .single()
           .get("r")
           .asRelationship() should
@@ -977,7 +1041,7 @@ abstract class Neo4jCudIT {
   fun `should update relationship with ids`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -994,7 +1058,9 @@ abstract class Neo4jCudIT {
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
                 "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-                "r" to mapOf("id" to 2L, "by" to "incident")))
+                "r" to mapOf("id" to 2L, "by" to "incident"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -1024,13 +1090,15 @@ abstract class Neo4jCudIT {
                     "by": "incident-updated"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r]->(:Bar {id: ${'$'}barId}) RETURN r",
-              mapOf("fooId" to 1L, "barId" to 1L))
+              mapOf("fooId" to 1L, "barId" to 1L),
+          )
           .single()
           .get("r")
           .asRelationship() should
@@ -1046,7 +1114,7 @@ abstract class Neo4jCudIT {
   fun `should merge relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1062,7 +1130,9 @@ abstract class Neo4jCudIT {
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
                 "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-                "r" to mapOf("by" to "incident")))
+                "r" to mapOf("by" to "incident"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -1090,13 +1160,15 @@ abstract class Neo4jCudIT {
                     "by-new": "incident-merged"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r]->(:Bar {id: ${'$'}barId}) RETURN r",
-              mapOf("fooId" to 1L, "barId" to 1L))
+              mapOf("fooId" to 1L, "barId" to 1L),
+          )
           .single()
           .get("r")
           .asRelationship() should
@@ -1112,7 +1184,7 @@ abstract class Neo4jCudIT {
   fun `should merge relationship with merging nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1143,14 +1215,16 @@ abstract class Neo4jCudIT {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       val result =
           session
               .run(
                   "MATCH (f:Foo {id: ${'$'}fooId})-[r]->(b:Bar {id: ${'$'}barId}) RETURN f,b,r",
-                  mapOf("fooId" to 1L, "barId" to 1L))
+                  mapOf("fooId" to 1L, "barId" to 1L),
+              )
               .single()
 
       result.get("f").asNode() should
@@ -1178,7 +1252,7 @@ abstract class Neo4jCudIT {
   fun `should merge relationship with merging one of the nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1211,14 +1285,16 @@ abstract class Neo4jCudIT {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       val result =
           session
               .run(
                   "MATCH (f:Foo {id: ${'$'}fooId})-[r]->(b:Bar {id: ${'$'}barId}) RETURN f,b,r",
-                  mapOf("fooId" to 1L, "barId" to 1L))
+                  mapOf("fooId" to 1L, "barId" to 1L),
+              )
               .single()
 
       result.get("f").asNode() should
@@ -1246,7 +1322,7 @@ abstract class Neo4jCudIT {
   fun `should merge relationship with ids`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1263,7 +1339,9 @@ abstract class Neo4jCudIT {
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
                 "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-                "r" to mapOf("id" to 2L, "by" to "incident")))
+                "r" to mapOf("id" to 2L, "by" to "incident"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -1294,13 +1372,15 @@ abstract class Neo4jCudIT {
                     "by-new": "incident-merged"
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r]->(:Bar {id: ${'$'}barId}) RETURN r",
-              mapOf("fooId" to 1L, "barId" to 1L))
+              mapOf("fooId" to 1L, "barId" to 1L),
+          )
           .single()
           .get("r")
           .asRelationship() should
@@ -1317,7 +1397,7 @@ abstract class Neo4jCudIT {
   fun `should delete relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1333,7 +1413,9 @@ abstract class Neo4jCudIT {
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
                 "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-                "r" to mapOf("by" to "incident")))
+                "r" to mapOf("by" to "incident"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -1357,13 +1439,15 @@ abstract class Neo4jCudIT {
                     }
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r:RELATED_TO]->(:Bar {id: ${'$'}barId}) RETURN count(r) as count",
-              mapOf("fooId" to 1L, "barId" to 1L))
+              mapOf("fooId" to 1L, "barId" to 1L),
+          )
           .single()
           .get("count")
           .asLong() shouldBe 0
@@ -1375,7 +1459,7 @@ abstract class Neo4jCudIT {
   fun `should delete relationship with ids`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1392,7 +1476,9 @@ abstract class Neo4jCudIT {
             mapOf(
                 "foo" to mapOf("id" to 1L, "foo" to "foo-value"),
                 "bar" to mapOf("id" to 1L, "bar" to "bar-value"),
-                "r" to mapOf("id" to 2L, "by" to "incident")))
+                "r" to mapOf("id" to 2L, "by" to "incident"),
+            ),
+        )
         .consume()
 
     producer.publish(
@@ -1419,13 +1505,15 @@ abstract class Neo4jCudIT {
                     "id": 2
                   }
                 }
-                """)
+                """,
+    )
 
     eventually(30.seconds) {
       session
           .run(
               "MATCH (:Foo {id: ${'$'}fooId})-[r:RELATED_TO {id: ${'$'}rId}]->(:Bar {id: ${'$'}barId}) RETURN count(r) as count",
-              mapOf("fooId" to 1L, "barId" to 1L, "rId" to 2L))
+              mapOf("fooId" to 1L, "barId" to 1L, "rId" to 2L),
+          )
           .single()
           .get("count")
           .asLong() shouldBe 0
@@ -1439,7 +1527,7 @@ abstract class Neo4jCudIT {
       @TopicProducer(TOPIC_2) producer2: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_3) producer3: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1457,7 +1545,8 @@ abstract class Neo4jCudIT {
                   "properties": {
                     "foo": "foo-value"
                   }
-                }""")
+                }""",
+    )
 
     producer2.publish(
         valueSchema = Schema.STRING_SCHEMA,
@@ -1472,7 +1561,8 @@ abstract class Neo4jCudIT {
                     "properties": {
                       "bar": "bar-value"
                     }
-                  }""")
+                  }""",
+    )
 
     producer3.publish(
         valueSchema = Schema.STRING_SCHEMA,
@@ -1500,7 +1590,8 @@ abstract class Neo4jCudIT {
                         "by": "incident"
                       }
                     }
-                    """)
+                    """,
+    )
 
     eventually(60.seconds) {
       val result =
@@ -1531,7 +1622,7 @@ abstract class Neo4jCudIT {
   fun `should handle mixed events`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "foo_id", "Foo", "id")
     session.createNodeKeyConstraint(neo4j, "bar_id", "Bar", "id")
@@ -1547,7 +1638,11 @@ abstract class Neo4jCudIT {
                           "type" to "node",
                           "op" to "create",
                           "labels" to listOf("Foo"),
-                          "properties" to mapOf("id" to i, "foo" to "${i}-foo-value")))))
+                          "properties" to mapOf("id" to i, "foo" to "${i}-foo-value"),
+                      )
+                  ),
+          )
+      )
 
       kafkaMessages.add(
           KafkaMessage(
@@ -1558,7 +1653,11 @@ abstract class Neo4jCudIT {
                           "type" to "node",
                           "op" to "create",
                           "labels" to listOf("Bar"),
-                          "properties" to mapOf("id" to i, "bar" to "${i}-bar-value")))))
+                          "properties" to mapOf("id" to i, "bar" to "${i}-bar-value"),
+                      )
+                  ),
+          )
+      )
 
       kafkaMessages.add(
           KafkaMessage(
@@ -1571,7 +1670,11 @@ abstract class Neo4jCudIT {
                           "rel_type" to "RELATED_TO",
                           "from" to mapOf("labels" to listOf("Foo"), "ids" to mapOf("id" to i)),
                           "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to i)),
-                          "properties" to mapOf("id" to i, "by" to "${i}-incident")))))
+                          "properties" to mapOf("id" to i, "by" to "${i}-incident"),
+                      )
+                  ),
+          )
+      )
     }
 
     val modulo = 4
@@ -1585,7 +1688,8 @@ abstract class Neo4jCudIT {
                         "op" to "update",
                         "labels" to listOf("Foo"),
                         "ids" to mapOf("id" to it),
-                        "properties" to mapOf("id" to it, "foo" to "$it-foo-value-updated"))
+                        "properties" to mapOf("id" to it, "foo" to "$it-foo-value-updated"),
+                    )
                 1 ->
                     mapOf(
                         "type" to "node",
@@ -1596,7 +1700,9 @@ abstract class Neo4jCudIT {
                             mapOf(
                                 "id" to it,
                                 "bar" to "$it-bar-value-updated",
-                                "bar-new" to "$it-new-bar-value-merged"))
+                                "bar-new" to "$it-new-bar-value-merged",
+                            ),
+                    )
                 2 ->
                     mapOf(
                         "type" to "relationship",
@@ -1604,7 +1710,8 @@ abstract class Neo4jCudIT {
                         "rel_type" to "RELATED_TO",
                         "from" to mapOf("labels" to listOf("Foo"), "ids" to mapOf("id" to it)),
                         "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to it)),
-                        "properties" to mapOf("id" to it, "by" to "$it-incident-updated"))
+                        "properties" to mapOf("id" to it, "by" to "$it-incident-updated"),
+                    )
                 3 ->
                     mapOf(
                         "type" to "relationship",
@@ -1616,15 +1723,19 @@ abstract class Neo4jCudIT {
                             mapOf(
                                 "id" to it,
                                 "by" to "$it-incident-updated",
-                                "by-new" to "$it-new-incident-merged"))
+                                "by-new" to "$it-new-incident-merged",
+                            ),
+                    )
                 else -> throw IllegalArgumentException("unexpected")
               }
             }
             .map { eventMap ->
               KafkaMessage(
                   valueSchema = Schema.STRING_SCHEMA,
-                  value = JSONUtils.writeValueAsString(eventMap))
-            })
+                  value = JSONUtils.writeValueAsString(eventMap),
+              )
+            }
+    )
 
     producer.publish(*kafkaMessages.toTypedArray())
 
@@ -1664,7 +1775,8 @@ abstract class Neo4jCudIT {
                           mapOf(
                               "id" to index,
                               "bar" to "$index-bar-value-updated",
-                              "bar-new" to "$index-new-bar-value-merged")
+                              "bar-new" to "$index-new-bar-value-merged",
+                          )
                     }
                 record.get("r").asRelationship() should
                     {
@@ -1707,7 +1819,8 @@ abstract class Neo4jCudIT {
                           mapOf(
                               "id" to index,
                               "by" to "$index-incident-updated",
-                              "by-new" to "$index-new-incident-merged")
+                              "by-new" to "$index-new-incident-merged",
+                          )
                     }
               }
             }

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCudIT.kt
@@ -35,8 +35,8 @@ import org.apache.kafka.connect.data.Time
 import org.apache.kafka.connect.data.Timestamp
 import org.junit.jupiter.api.Test
 import org.neo4j.caniuse.Neo4j
-import org.neo4j.connectors.kafka.data.DynamicTypes
 import org.neo4j.connectors.kafka.data.PropertyType
+import org.neo4j.connectors.kafka.data.converter.ExtendedValueConverter
 import org.neo4j.connectors.kafka.testing.DateSupport
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.createNodeKeyConstraint
@@ -59,6 +59,8 @@ abstract class Neo4jCudIT {
     const val TOPIC_1 = "test-1"
     const val TOPIC_2 = "test-2"
     const val TOPIC_3 = "test-3"
+
+    val converter = ExtendedValueConverter()
   }
 
   @Neo4jSink(cud = [CudStrategy(TOPIC)])
@@ -164,16 +166,10 @@ abstract class Neo4jCudIT {
                     Struct(propertiesSchema)
                         .put("id", 1L)
                         .put("foo", "foo-value")
-                        .put(
-                            "dob",
-                            DynamicTypes.toConnectValue(
-                                PropertyType.schema,
-                                LocalDate.of(1995, 1, 1),
-                            ),
-                        )
+                        .put("dob", converter.value(PropertyType.schema, LocalDate.of(1995, 1, 1)))
                         .put(
                             "place",
-                            DynamicTypes.toConnectValue(
+                            converter.value(
                                 PropertyType.schema,
                                 Values.point(7203, 1.0, 2.5).asPoint(),
                             ),
@@ -241,16 +237,10 @@ abstract class Neo4jCudIT {
                     "properties",
                     Struct(propertiesSchema)
                         .put("foo", "foo-value-updated")
-                        .put(
-                            "dob",
-                            DynamicTypes.toConnectValue(
-                                PropertyType.schema,
-                                LocalDate.of(1995, 1, 1),
-                            ),
-                        )
+                        .put("dob", converter.value(PropertyType.schema, LocalDate.of(1995, 1, 1)))
                         .put(
                             "place",
-                            DynamicTypes.toConnectValue(
+                            converter.value(
                                 PropertyType.schema,
                                 Values.point(7203, 1.0, 2.5).asPoint(),
                             ),
@@ -320,16 +310,10 @@ abstract class Neo4jCudIT {
                     Struct(propertiesSchema)
                         .put("id", 1L)
                         .put("foo_new", "foo-new-value-merged")
-                        .put(
-                            "dob",
-                            DynamicTypes.toConnectValue(
-                                PropertyType.schema,
-                                LocalDate.of(1995, 1, 1),
-                            ),
-                        )
+                        .put("dob", converter.value(PropertyType.schema, LocalDate.of(1995, 1, 1)))
                         .put(
                             "place",
-                            DynamicTypes.toConnectValue(
+                            converter.value(
                                 PropertyType.schema,
                                 Values.point(7203, 1.0, 2.5).asPoint(),
                             ),

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCypherIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jCypherIT.kt
@@ -76,11 +76,14 @@ abstract class Neo4jCypherIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName")])
+                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName",
+              )
+          ]
+  )
   @Test
   fun `should create node from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     SchemaBuilder.struct()
         .field("firstName", Schema.STRING_SCHEMA)
@@ -89,7 +92,8 @@ abstract class Neo4jCypherIT {
         .let { schema ->
           producer.publish(
               valueSchema = schema,
-              value = Struct(schema).put("firstName", "john").put("lastName", "doe"))
+              value = Struct(schema).put("firstName", "john").put("lastName", "doe"),
+          )
         }
 
     eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
@@ -106,39 +110,19 @@ abstract class Neo4jCypherIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName RETURN p")])
+                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName RETURN p",
+              )
+          ]
+  )
   @Test
   fun `should create node with a statement that returns a value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
-  ) = runTest {
-    producer.publish(
-        valueSchema = Schema.STRING_SCHEMA, value = """{"firstName": "john", "lastName": "doe"}""")
-
-    eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
-        .get("n")
-        .asNode() should
-        {
-          it.labels() shouldBe listOf("Person")
-          it.asMap() shouldBe mapOf("name" to "john", "surname" to "doe")
-        }
-  }
-
-  @Neo4jSink(
-      cypher =
-          [
-              CypherStrategy(
-                  TOPIC,
-                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName")])
-  @Test
-  fun `should create node from json string`(
-      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
-        value =
-            ObjectMapper().writeValueAsString(mapOf("firstName" to "john", "lastName" to "doe")))
+        value = """{"firstName": "john", "lastName": "doe"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
         .get("n")
@@ -154,15 +138,47 @@ abstract class Neo4jCypherIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName")])
+                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName",
+              )
+          ]
+  )
+  @Test
+  fun `should create node from json string`(
+      @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
+      session: Session,
+  ) = runTest {
+    producer.publish(
+        valueSchema = Schema.STRING_SCHEMA,
+        value = ObjectMapper().writeValueAsString(mapOf("firstName" to "john", "lastName" to "doe")),
+    )
+
+    eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
+        .get("n")
+        .asNode() should
+        {
+          it.labels() shouldBe listOf("Person")
+          it.asMap() shouldBe mapOf("name" to "john", "surname" to "doe")
+        }
+  }
+
+  @Neo4jSink(
+      cypher =
+          [
+              CypherStrategy(
+                  TOPIC,
+                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName",
+              )
+          ]
+  )
   @Test
   fun `should create node from json byte array`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(
         valueSchema = Schema.BYTES_SCHEMA,
-        value = ObjectMapper().writeValueAsBytes(mapOf("firstName" to "john", "lastName" to "doe")))
+        value = ObjectMapper().writeValueAsBytes(mapOf("firstName" to "john", "lastName" to "doe")),
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
         .get("n")
@@ -178,14 +194,19 @@ abstract class Neo4jCypherIT {
           [
               CypherStrategy(
                   TOPIC_1,
-                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName"),
+                  "CREATE (p:Person) SET p.name = event.firstName, p.surname = event.lastName",
+              ),
               CypherStrategy(
-                  TOPIC_2, "CREATE (p:Place) SET p.code = event.code, p.name = event.name")])
+                  TOPIC_2,
+                  "CREATE (p:Place) SET p.code = event.code, p.name = event.name",
+              ),
+          ]
+  )
   @Test
   fun `should create nodes from multiple topics`(
       @TopicProducer(TOPIC_1) producer1: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_2) producer2: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     SchemaBuilder.struct()
         .field("firstName", Schema.STRING_SCHEMA)
@@ -194,13 +215,16 @@ abstract class Neo4jCypherIT {
         .let { schema ->
           producer1.publish(
               valueSchema = schema,
-              value = Struct(schema).put("firstName", "john").put("lastName", "doe"))
+              value = Struct(schema).put("firstName", "john").put("lastName", "doe"),
+          )
           producer1.publish(
               valueSchema = schema,
-              value = Struct(schema).put("firstName", "mary").put("lastName", "doe"))
+              value = Struct(schema).put("firstName", "mary").put("lastName", "doe"),
+          )
           producer1.publish(
               valueSchema = schema,
-              value = Struct(schema).put("firstName", "joe").put("lastName", "brown"))
+              value = Struct(schema).put("firstName", "joe").put("lastName", "brown"),
+          )
         }
 
     SchemaBuilder.struct()
@@ -209,9 +233,13 @@ abstract class Neo4jCypherIT {
         .build()
         .let { schema ->
           producer2.publish(
-              valueSchema = schema, value = Struct(schema).put("code", 34).put("name", "istanbul"))
+              valueSchema = schema,
+              value = Struct(schema).put("code", 34).put("name", "istanbul"),
+          )
           producer2.publish(
-              valueSchema = schema, value = Struct(schema).put("code", 48).put("name", "mugla"))
+              valueSchema = schema,
+              value = Struct(schema).put("code", 48).put("name", "mugla"),
+          )
         }
 
     eventually(30.seconds) {
@@ -221,13 +249,16 @@ abstract class Neo4jCypherIT {
           listOf(
               mapOf(
                   "labels" to listOf("Person"),
-                  "properties" to mapOf("name" to "john", "surname" to "doe")),
+                  "properties" to mapOf("name" to "john", "surname" to "doe"),
+              ),
               mapOf(
                   "labels" to listOf("Person"),
-                  "properties" to mapOf("name" to "mary", "surname" to "doe")),
+                  "properties" to mapOf("name" to "mary", "surname" to "doe"),
+              ),
               mapOf(
                   "labels" to listOf("Person"),
-                  "properties" to mapOf("name" to "joe", "surname" to "brown")),
+                  "properties" to mapOf("name" to "joe", "surname" to "brown"),
+              ),
           )
 
       session.run("MATCH (n:Place) RETURN n", emptyMap()).list { r ->
@@ -236,17 +267,20 @@ abstract class Neo4jCypherIT {
           listOf(
               mapOf(
                   "labels" to listOf("Place"),
-                  "properties" to mapOf("code" to 34L, "name" to "istanbul")),
+                  "properties" to mapOf("code" to 34L, "name" to "istanbul"),
+              ),
               mapOf(
                   "labels" to listOf("Place"),
-                  "properties" to mapOf("code" to 48L, "name" to "mugla")),
+                  "properties" to mapOf("code" to 48L, "name" to "mugla"),
+              ),
           )
     }
   }
 
   @Neo4jSink(
       cypher = [CypherStrategy(TOPIC, "CREATE (p:Data) SET p.value = event")],
-      schemaControlValueCompatibility = SchemaCompatibilityMode.NONE)
+      schemaControlValueCompatibility = SchemaCompatibilityMode.NONE,
+  )
   @ParameterizedTest
   @ArgumentsSource(SimpleTypes::class)
   fun `should support connect simple types`(
@@ -254,7 +288,7 @@ abstract class Neo4jCypherIT {
       value: Any?,
       expected: Any?,
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(valueSchema = schema, value = value)
 
@@ -270,7 +304,7 @@ abstract class Neo4jCypherIT {
   object SimpleTypes : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(Schema.INT8_SCHEMA, Byte.MAX_VALUE, Byte.MAX_VALUE),
@@ -282,7 +316,10 @@ abstract class Neo4jCypherIT {
           Arguments.of(Schema.BOOLEAN_SCHEMA, true, true),
           Arguments.of(Schema.STRING_SCHEMA, "a string", "a string"),
           Arguments.of(
-              Schema.BYTES_SCHEMA, "a string".encodeToByteArray(), "a string".encodeToByteArray()),
+              Schema.BYTES_SCHEMA,
+              "a string".encodeToByteArray(),
+              "a string".encodeToByteArray(),
+          ),
           Arguments.of(Schema.OPTIONAL_INT8_SCHEMA, Byte.MAX_VALUE, Byte.MAX_VALUE),
           Arguments.of(Schema.OPTIONAL_INT16_SCHEMA, Short.MAX_VALUE, Short.MAX_VALUE),
           Arguments.of(Schema.OPTIONAL_INT32_SCHEMA, Int.MAX_VALUE, Int.MAX_VALUE),
@@ -294,14 +331,16 @@ abstract class Neo4jCypherIT {
           Arguments.of(
               Schema.OPTIONAL_BYTES_SCHEMA,
               "a string".encodeToByteArray(),
-              "a string".encodeToByteArray()),
+              "a string".encodeToByteArray(),
+          ),
       )
     }
   }
 
   @Neo4jSink(
       cypher = [CypherStrategy(TOPIC, "CREATE (p:Data) SET p.value = event")],
-      schemaControlValueCompatibility = SchemaCompatibilityMode.NONE)
+      schemaControlValueCompatibility = SchemaCompatibilityMode.NONE,
+  )
   @ParameterizedTest
   @ArgumentsSource(ConnectTypes::class)
   fun `should support connect types`(
@@ -309,7 +348,7 @@ abstract class Neo4jCypherIT {
       value: Any?,
       expected: Any?,
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(valueSchema = schema, value = value)
 
@@ -325,31 +364,40 @@ abstract class Neo4jCypherIT {
   object ConnectTypes : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(Date.SCHEMA, DateSupport.date(2000, 1, 1), LocalDate.of(2000, 1, 1)),
           Arguments.of(
-              Time.SCHEMA, DateSupport.time(23, 59, 59, 999), LocalTime.of(23, 59, 59, 999000000)),
+              Time.SCHEMA,
+              DateSupport.time(23, 59, 59, 999),
+              LocalTime.of(23, 59, 59, 999000000),
+          ),
           Arguments.of(
               Timestamp.SCHEMA,
               DateSupport.timestamp(2000, 1, 1, 23, 59, 59, 999),
-              LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999000000)),
+              LocalDateTime.of(2000, 1, 1, 23, 59, 59, 999000000),
+          ),
           Arguments.of(Decimal.schema(4), BigDecimal(BigInteger("1234567890"), 4), "123456.7890"),
           Arguments.of(
-              Decimal.schema(6), BigDecimal(BigInteger("1234567890000"), 6), "1234567.890000"))
+              Decimal.schema(6),
+              BigDecimal(BigInteger("1234567890000"), 6),
+              "1234567.890000",
+          ),
+      )
     }
   }
 
   @Neo4jSink(
       cypher = [CypherStrategy(TOPIC, "MATCH (n:Data) SET n.value = event")],
-      schemaControlValueCompatibility = SchemaCompatibilityMode.NONE)
+      schemaControlValueCompatibility = SchemaCompatibilityMode.NONE,
+  )
   @ParameterizedTest
   @ArgumentsSource(OptionalSchemas::class)
   fun `should support null values`(
       schema: Schema,
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     session.run("MERGE (n:Data) SET n.value = 1").consume()
 
@@ -367,7 +415,7 @@ abstract class Neo4jCypherIT {
   object OptionalSchemas : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(Schema.OPTIONAL_STRING_SCHEMA),
@@ -380,7 +428,8 @@ abstract class Neo4jCypherIT {
           Arguments.of(Schema.OPTIONAL_BOOLEAN_SCHEMA),
           Arguments.of(Schema.OPTIONAL_STRING_SCHEMA),
           Arguments.of(Schema.OPTIONAL_BYTES_SCHEMA),
-          Arguments.of(PropertyType.schema))
+          Arguments.of(PropertyType.schema),
+      )
     }
   }
 
@@ -391,7 +440,10 @@ abstract class Neo4jCypherIT {
                   TOPIC,
                   """
                   CREATE (n:Data) SET n.value = __value
-                  """)])
+                  """,
+              )
+          ]
+  )
   @ParameterizedTest
   @ArgumentsSource(KnownTypes::class)
   fun `should support cypher types`(
@@ -410,7 +462,7 @@ abstract class Neo4jCypherIT {
   object KnownTypes : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(PropertyType.schema, true),
@@ -431,15 +483,20 @@ abstract class Neo4jCypherIT {
           Arguments.of(PropertyType.schema, LocalTime.of(23, 59, 59, 999999999)),
           Arguments.of(
               PropertyType.schema,
-              ZonedDateTime.of(2019, 5, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))),
+              ZonedDateTime.of(2019, 5, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul")),
+          ),
           Arguments.of(
               PropertyType.schema,
-              ZonedDateTime.of(2019, 5, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul"))),
-          Arguments.of(
-              PropertyType.schema, OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2))),
+              ZonedDateTime.of(2019, 5, 1, 23, 59, 59, 999999999, ZoneId.of("Europe/Istanbul")),
+          ),
           Arguments.of(
               PropertyType.schema,
-              OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHoursMinutes(2, 30))),
+              OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHours(2)),
+          ),
+          Arguments.of(
+              PropertyType.schema,
+              OffsetTime.of(23, 59, 59, 999999999, ZoneOffset.ofHoursMinutes(2, 30)),
+          ),
           Arguments.of(PropertyType.schema, Values.isoDuration(5, 4, 3, 2).asIsoDuration()),
           Arguments.of(PropertyType.schema, Values.isoDuration(5, 4, 3, 2).asIsoDuration()),
           Arguments.of(PropertyType.schema, Values.point(7203, 2.3, 4.5).asPoint()),
@@ -458,7 +515,10 @@ abstract class Neo4jCypherIT {
                   """
                   UNWIND __value.array AS id
                   CREATE (n:Data) SET n.id = id
-                  """)])
+                  """,
+              )
+          ]
+  )
   @ParameterizedTest
   @ArgumentsSource(ArrayElementTypes::class)
   fun `should support arrays`(
@@ -485,26 +545,34 @@ abstract class Neo4jCypherIT {
   object ArrayElementTypes : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(
-              Schema.INT8_SCHEMA, listOf(1.toByte(), 2.toByte(), 3.toByte()), listOf(1L, 2L, 3L)),
+              Schema.INT8_SCHEMA,
+              listOf(1.toByte(), 2.toByte(), 3.toByte()),
+              listOf(1L, 2L, 3L),
+          ),
           Arguments.of(
               Schema.INT16_SCHEMA,
               listOf(1.toShort(), 2.toShort(), 3.toShort()),
-              listOf(1L, 2L, 3L)),
+              listOf(1L, 2L, 3L),
+          ),
           Arguments.of(Schema.INT32_SCHEMA, (1..10).toList(), (1L..10L).toList()),
           Arguments.of(Schema.INT64_SCHEMA, (1L..10L).toList(), (1L..10L).toList()),
           Arguments.of(
               Schema.FLOAT32_SCHEMA,
               listOf(1.0f, 1.1f, 1.2f),
-              listOf(1.0f.toDouble(), 1.1f.toDouble(), 1.2f.toDouble())),
+              listOf(1.0f.toDouble(), 1.1f.toDouble(), 1.2f.toDouble()),
+          ),
           Arguments.of(
-              Schema.FLOAT64_SCHEMA, listOf(1.0, 1.1, 1.2, 1.3), listOf(1.0, 1.1, 1.2, 1.3)),
+              Schema.FLOAT64_SCHEMA,
+              listOf(1.0, 1.1, 1.2, 1.3),
+              listOf(1.0, 1.1, 1.2, 1.3),
+          ),
           Arguments.of(Schema.BOOLEAN_SCHEMA, listOf(true, false, true), listOf(true, false, true)),
-          Arguments.of(
-              Schema.STRING_SCHEMA, listOf("a", "b", "c", "d"), listOf("a", "b", "c", "d")))
+          Arguments.of(Schema.STRING_SCHEMA, listOf("a", "b", "c", "d"), listOf("a", "b", "c", "d")),
+      )
     }
   }
 
@@ -515,7 +583,10 @@ abstract class Neo4jCypherIT {
                   TOPIC,
                   """
                   CREATE (n:Data) SET n = __value.map
-                  """)])
+                  """,
+              )
+          ]
+  )
   @Test
   fun `should support simple maps`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
@@ -526,7 +597,8 @@ abstract class Neo4jCypherIT {
       SchemaBuilder.struct().field("map", map).build().let { wrapper ->
         producer.publish(
             valueSchema = wrapper,
-            value = Struct(wrapper).put("map", mapOf("firstName" to "john", "lastName" to "doe")))
+            value = Struct(wrapper).put("map", mapOf("firstName" to "john", "lastName" to "doe")),
+        )
       }
     }
 
@@ -543,7 +615,10 @@ abstract class Neo4jCypherIT {
                   TOPIC,
                   """
                   CREATE (n:Data) SET n = __value.map
-                  """)])
+                  """,
+              )
+          ]
+  )
   @Test
   fun `should support complex maps`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
@@ -554,13 +629,15 @@ abstract class Neo4jCypherIT {
             "firstName" to "john",
             "lastName" to "doe",
             "dob" to LocalDate.of(1999, 1, 1),
-            "siblings" to 3)
+            "siblings" to 3,
+        )
     DynamicTypes.toConnectSchema(PayloadMode.EXTENDED, value).let { mapSchema ->
       // Protobuf does not support top level MAP values, so we are wrapping it inside a struct
       SchemaBuilder.struct().field("map", mapSchema).build().let { wrapper ->
         producer.publish(
             valueSchema = wrapper,
-            value = Struct(wrapper).put("map", DynamicTypes.toConnectValue(mapSchema, value)))
+            value = Struct(wrapper).put("map", DynamicTypes.toConnectValue(mapSchema, value)),
+        )
       }
     }
 
@@ -587,7 +664,10 @@ abstract class Neo4jCypherIT {
                     WITH ulElem, ul
                     UNWIND ulElem.value AS liElem
                     CREATE (ul)-[:HAS_LI]->(li:ListItem{value: liElem.value, class: liElem.class})
-                  """)])
+                  """,
+              )
+          ]
+  )
   @Test
   fun `should support complex tree struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
@@ -635,20 +715,25 @@ abstract class Neo4jCypherIT {
                       Struct(LI_SCHEMA).put("value", "First UL - First Element"),
                       Struct(LI_SCHEMA)
                           .put("value", "First UL - Second Element")
-                          .put("class", listOf("ClassA", "ClassB"))))
+                          .put("class", listOf("ClassA", "ClassB")),
+                  ),
+              )
       val secondUL =
           Struct(UL_SCHEMA)
               .put(
                   "value",
                   listOf(
                       Struct(LI_SCHEMA).put("value", "Second UL - First Element"),
-                      Struct(LI_SCHEMA).put("value", "Second UL - Second Element")))
+                      Struct(LI_SCHEMA).put("value", "Second UL - Second Element"),
+                  ),
+              )
       val ulList = listOf(firstUL, secondUL)
 
       val pList =
           listOf(
               Struct(P_SCHEMA).put("value", "First Paragraph"),
-              Struct(P_SCHEMA).put("value", "Second Paragraph"))
+              Struct(P_SCHEMA).put("value", "Second Paragraph"),
+          )
 
       return Struct(BODY_SCHEMA).put("ul", ulList).put("p", pList)
     }
@@ -691,11 +776,14 @@ abstract class Neo4jCypherIT {
                     p.name = __value.firstName, p.surname = __value.lastName,
                     p.createdBy = __header.createdBy,
                     p.createdAt = __timestamp
-                  """)])
+                  """,
+              )
+          ]
+  )
   @Test
   fun `should get message value from default timestamp, header, key and value binding`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     val timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 
@@ -706,7 +794,8 @@ abstract class Neo4jCypherIT {
         valueSchema = Schema.STRING_SCHEMA,
         value =
             ObjectMapper().writeValueAsString(mapOf("firstName" to "john", "lastName" to "doe")),
-        timestamp = timestamp)
+        timestamp = timestamp,
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
         .get("n")
@@ -719,7 +808,8 @@ abstract class Neo4jCypherIT {
                   "name" to "john",
                   "surname" to "doe",
                   "createdBy" to "john-doe",
-                  "createdAt" to timestamp.atZone(ZoneOffset.UTC))
+                  "createdAt" to timestamp.atZone(ZoneOffset.UTC),
+              )
         }
   }
 
@@ -738,11 +828,14 @@ abstract class Neo4jCypherIT {
                   bindTimestampAs = "custom_timestamp",
                   bindHeaderAs = "custom_header",
                   bindKeyAs = "custom_key",
-                  bindValueAs = "custom_value")])
+                  bindValueAs = "custom_value",
+              )
+          ]
+  )
   @Test
   fun `should get message value from custom timestamp, header, key and value binding`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     val timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS)
 
@@ -753,7 +846,8 @@ abstract class Neo4jCypherIT {
         valueSchema = Schema.STRING_SCHEMA,
         value =
             ObjectMapper().writeValueAsString(mapOf("firstName" to "john", "lastName" to "doe")),
-        timestamp = timestamp)
+        timestamp = timestamp,
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:Person) RETURN n", emptyMap()).single() }
         .get("n")
@@ -766,7 +860,8 @@ abstract class Neo4jCypherIT {
                   "name" to "john",
                   "surname" to "doe",
                   "createdBy" to "john-doe",
-                  "createdAt" to timestamp.atZone(ZoneOffset.UTC))
+                  "createdAt" to timestamp.atZone(ZoneOffset.UTC),
+              )
         }
   }
 
@@ -774,7 +869,7 @@ abstract class Neo4jCypherIT {
   @Test
   fun `should not create any data when invalid cypher is provided`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      session: Session
+      session: Session,
   ) = runTest {
     producer.publish(valueSchema = Schema.STRING_SCHEMA, value = "a value")
 

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
@@ -63,18 +63,20 @@ abstract class Neo4jNodePatternIT {
 
   @Neo4jSink(
       nodePattern =
-          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)])
+          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create node from json string`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"id": 1, "name": "john", "surname": "doe"}""")
+        value = """{"id": 1, "name": "john", "surname": "doe"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -89,12 +91,17 @@ abstract class Neo4jNodePatternIT {
       nodePattern =
           [
               NodePatternStrategy(
-                  TOPIC, "(:User{!id,name,surname,dob,place})", mergeNodeProperties = false)])
+                  TOPIC,
+                  "(:User{!id,name,surname,dob,place})",
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create node from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -115,12 +122,16 @@ abstract class Neo4jNodePatternIT {
                       .put("surname", "doe")
                       .put(
                           "dob",
-                          DynamicTypes.toConnectValue(
-                              PropertyType.schema, LocalDate.of(1995, 1, 1)))
+                          DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(1995, 1, 1)),
+                      )
                       .put(
                           "place",
                           DynamicTypes.toConnectValue(
-                              PropertyType.schema, Values.point(7203, 1.0, 2.5).asPoint())))
+                              PropertyType.schema,
+                              Values.point(7203, 1.0, 2.5).asPoint(),
+                          ),
+                      ),
+          )
         }
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
@@ -134,7 +145,8 @@ abstract class Neo4jNodePatternIT {
                   "name" to "john",
                   "surname" to "doe",
                   "dob" to LocalDate.of(1995, 1, 1),
-                  "place" to Values.point(7203, 1.0, 2.5).asPoint())
+                  "place" to Values.point(7203, 1.0, 2.5).asPoint(),
+              )
         }
   }
 
@@ -142,12 +154,17 @@ abstract class Neo4jNodePatternIT {
       nodePattern =
           [
               NodePatternStrategy(
-                  TOPIC, "(:User{!id,height,dob,tob,tsob})", mergeNodeProperties = false)])
+                  TOPIC,
+                  "(:User{!id,height,dob,tob,tsob})",
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create node from struct containing connect types`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -167,7 +184,8 @@ abstract class Neo4jNodePatternIT {
                       .put("height", BigDecimal.valueOf(185, 2))
                       .put("dob", DateSupport.date(1978, 1, 15))
                       .put("tob", DateSupport.time(7, 45, 12, 999))
-                      .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999)))
+                      .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999)),
+          )
         }
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
@@ -181,18 +199,20 @@ abstract class Neo4jNodePatternIT {
                   "height" to "1.85",
                   "dob" to LocalDate.of(1978, 1, 15),
                   "tob" to LocalTime.of(7, 45, 12, 999000000),
-                  "tsob" to LocalDateTime.of(1978, 1, 15, 7, 45, 12, 999000000))
+                  "tsob" to LocalDateTime.of(1978, 1, 15, 7, 45, 12, 999000000),
+              )
         }
   }
 
   @Neo4jSink(
       nodePattern =
-          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)])
+          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create node from json byte array`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -200,7 +220,8 @@ abstract class Neo4jNodePatternIT {
         valueSchema = Schema.BYTES_SCHEMA,
         value =
             ObjectMapper()
-                .writeValueAsBytes(mapOf("id" to 1L, "name" to "john", "surname" to "doe")))
+                .writeValueAsBytes(mapOf("id" to 1L, "name" to "john", "surname" to "doe")),
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -215,12 +236,17 @@ abstract class Neo4jNodePatternIT {
       nodePattern =
           [
               NodePatternStrategy(
-                  TOPIC, "(:User:Person{!id,name,surname})", mergeNodeProperties = false)])
+                  TOPIC,
+                  "(:User:Person{!id,name,surname})",
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create node with multiple labels pattern`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
@@ -229,7 +255,8 @@ abstract class Neo4jNodePatternIT {
         valueSchema = Schema.BYTES_SCHEMA,
         value =
             ObjectMapper()
-                .writeValueAsBytes(mapOf("id" to 1L, "name" to "john", "surname" to "doe")))
+                .writeValueAsBytes(mapOf("id" to 1L, "name" to "john", "surname" to "doe")),
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -246,18 +273,22 @@ abstract class Neo4jNodePatternIT {
               NodePatternStrategy(
                   TOPIC,
                   "(:User{!id: old_id,name: first_name,surname: last_name})",
-                  mergeNodeProperties = false)])
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create node with aliases`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"old_id": 1, "first_name": "john", "last_name": "doe"}""")
+        value = """{"old_id": 1, "first_name": "john", "last_name": "doe"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -274,12 +305,15 @@ abstract class Neo4jNodePatternIT {
               NodePatternStrategy(
                   TOPIC,
                   "(:User{!id: __value.old_id,name: __key.first_name,surname: last_name})",
-                  mergeNodeProperties = false)])
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create and delete node with aliases`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -287,7 +321,8 @@ abstract class Neo4jNodePatternIT {
         keySchema = Schema.STRING_SCHEMA,
         key = """{"first_name": "john"}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"old_id": 1, "last_name": "doe"}""")
+        value = """{"old_id": 1, "last_name": "doe"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -297,10 +332,7 @@ abstract class Neo4jNodePatternIT {
           it.asMap() shouldBe mapOf("id" to 1L, "name" to "john", "surname" to "doe")
         }
 
-    producer.publish(
-        keySchema = Schema.STRING_SCHEMA,
-        key = """{"old_id": 1}""",
-    )
+    producer.publish(keySchema = Schema.STRING_SCHEMA, key = """{"old_id": 1}""")
 
     eventually(30.seconds) {
       session
@@ -312,12 +344,13 @@ abstract class Neo4jNodePatternIT {
   }
 
   @Neo4jSink(
-      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)])
+      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should delete node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -328,10 +361,7 @@ abstract class Neo4jNodePatternIT {
         )
         .consume()
 
-    producer.publish(
-        keySchema = Schema.STRING_SCHEMA,
-        key = """{"id": 1}""",
-    )
+    producer.publish(keySchema = Schema.STRING_SCHEMA, key = """{"id": 1}""")
 
     eventually(30.seconds) {
       session
@@ -344,12 +374,13 @@ abstract class Neo4jNodePatternIT {
 
   @Neo4jSink(
       nodePattern =
-          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)])
+          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create, delete and recreate node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -358,13 +389,16 @@ abstract class Neo4jNodePatternIT {
             keySchema = Schema.STRING_SCHEMA,
             key = """{"id": 1}""",
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"name": "john", "surname": "doe"}"""),
+            value = """{"name": "john", "surname": "doe"}""",
+        ),
         KafkaMessage(keySchema = Schema.STRING_SCHEMA, key = """{"id": 1}"""),
         KafkaMessage(
             keySchema = Schema.STRING_SCHEMA,
             key = """{"id": 1}""",
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"name": "john-new", "surname": "doe-new"}"""))
+            value = """{"name": "john-new", "surname": "doe-new"}""",
+        ),
+    )
 
     eventually(60.seconds) {
       session.run("MATCH (n:User) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -377,12 +411,13 @@ abstract class Neo4jNodePatternIT {
 
   @Neo4jSink(
       nodePattern =
-          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)])
+          [NodePatternStrategy(TOPIC, "(:User{!id,name,surname})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create multiple nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -391,12 +426,15 @@ abstract class Neo4jNodePatternIT {
             keySchema = Schema.STRING_SCHEMA,
             key = """{"id": 1}""",
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"name": "john", "surname": "doe"}"""),
+            value = """{"name": "john", "surname": "doe"}""",
+        ),
         KafkaMessage(
             keySchema = Schema.STRING_SCHEMA,
             key = """{"id": 2}""",
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"name": "mary", "surname": "doe"}"""))
+            value = """{"name": "mary", "surname": "doe"}""",
+        ),
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n:User) RETURN n", emptyMap()).list { r ->
@@ -405,21 +443,25 @@ abstract class Neo4jNodePatternIT {
           listOf(
               mapOf(
                   "labels" to listOf("User"),
-                  "properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")),
+                  "properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe"),
+              ),
               mapOf(
                   "labels" to listOf("User"),
-                  "properties" to mapOf("id" to 2, "name" to "mary", "surname" to "doe")))
+                  "properties" to mapOf("id" to 2, "name" to "mary", "surname" to "doe"),
+              ),
+          )
     }
   }
 
   @Neo4jSink(
       nodePattern =
-          [NodePatternStrategy(TOPIC, "(:User{!id,!name,surname})", mergeNodeProperties = false)])
+          [NodePatternStrategy(TOPIC, "(:User{!id,!name,surname})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create node with composite key`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id_name", "User", "id", "name")
 
@@ -427,7 +469,8 @@ abstract class Neo4jNodePatternIT {
         keySchema = Schema.STRING_SCHEMA,
         key = """{"id": 1, "name": "john"}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"surname": "doe"}""")
+        value = """{"surname": "doe"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -439,19 +482,21 @@ abstract class Neo4jNodePatternIT {
   }
 
   @Neo4jSink(
-      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)])
+      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create node with nested properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
         value =
-            """{"id": 1, "name": "john", "surname": "doe", "address": {"city": "london", "country": "uk"}}""")
+            """{"id": 1, "name": "john", "surname": "doe", "address": {"city": "london", "country": "uk"}}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -464,27 +509,28 @@ abstract class Neo4jNodePatternIT {
                   "name" to "john",
                   "surname" to "doe",
                   "address.city" to "london",
-                  "address.country" to "uk")
+                  "address.country" to "uk",
+              )
         }
   }
 
   @Neo4jSink(
       nodePattern =
-          [
-              NodePatternStrategy(
-                  TOPIC, "(:User{!id, -name, -surname})", mergeNodeProperties = false)])
+          [NodePatternStrategy(TOPIC, "(:User{!id, -name, -surname})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create node with excluded properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
         value =
-            """{"id": 1, "name": "john", "surname": "doe", "dob": "2000-01-01", "address": {"city": "london", "country": "uk"}}""")
+            """{"id": 1, "name": "john", "surname": "doe", "dob": "2000-01-01", "address": {"city": "london", "country": "uk"}}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -496,7 +542,8 @@ abstract class Neo4jNodePatternIT {
                   "id" to 1L,
                   "dob" to "2000-01-01",
                   "address.city" to "london",
-                  "address.country" to "uk")
+                  "address.country" to "uk",
+              )
         }
   }
 
@@ -504,12 +551,17 @@ abstract class Neo4jNodePatternIT {
       nodePattern =
           [
               NodePatternStrategy(
-                  TOPIC, "(:User{!id, created_at: __timestamp})", mergeNodeProperties = false)])
+                  TOPIC,
+                  "(:User{!id, created_at: __timestamp})",
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create node with timestamp`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     val timestamp = Instant.now().truncatedTo(ChronoUnit.MILLIS)
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
@@ -517,7 +569,8 @@ abstract class Neo4jNodePatternIT {
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
         value = """{"id": 1, "name": "john", "surname": "doe"}""",
-        timestamp = timestamp)
+        timestamp = timestamp,
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -535,12 +588,15 @@ abstract class Neo4jNodePatternIT {
               NodePatternStrategy(
                   TOPIC,
                   "(:User{!id: __key.old_id, name: __key.first_name, surname: __key.last_name})",
-                  mergeNodeProperties = false)])
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create and delete node with explicit properties from message key`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -548,7 +604,8 @@ abstract class Neo4jNodePatternIT {
         keySchema = Schema.STRING_SCHEMA,
         key = """{"old_id": 1, "first_name": "john", "last_name": "doe"}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{}""")
+        value = """{}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -558,10 +615,7 @@ abstract class Neo4jNodePatternIT {
           it.asMap() shouldBe mapOf("id" to 1L, "name" to "john", "surname" to "doe")
         }
 
-    producer.publish(
-        keySchema = Schema.STRING_SCHEMA,
-        key = """{"old_id": 1}""",
-    )
+    producer.publish(keySchema = Schema.STRING_SCHEMA, key = """{"old_id": 1}""")
 
     eventually(30.seconds) {
       session
@@ -573,26 +627,29 @@ abstract class Neo4jNodePatternIT {
   }
 
   @Neo4jSink(
-      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)])
+      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should update node`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
     session
         .run(
             "CREATE (n:User) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 1L, "name" to "john", "surname" to "doe")))
+            mapOf("props" to mapOf("id" to 1L, "name" to "john", "surname" to "doe")),
+        )
         .consume()
 
     producer.publish(
         keySchema = Schema.STRING_SCHEMA,
         key = """{"id": 1}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"name": "john-updated", "surname": "doe-updated"}""")
+        value = """{"name": "john-updated", "surname": "doe-updated"}""",
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n:User) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -610,24 +667,29 @@ abstract class Neo4jNodePatternIT {
               NodePatternStrategy(
                   TOPIC,
                   "(:User{!id: old_id, name: first_name, surname: last_name})",
-                  mergeNodeProperties = false)])
+                  mergeNodeProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should update node with aliases`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
     session.run(
         "CREATE (n:User) SET n = ${'$'}props",
-        mapOf("props" to mapOf("id" to 1L, "name" to "john", "surname" to "doe")))
+        mapOf("props" to mapOf("id" to 1L, "name" to "john", "surname" to "doe")),
+    )
 
     producer.publish(
         keySchema = Schema.STRING_SCHEMA,
         key = """{"old_id": 1}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"first_name": "john-updated", "last_name": "doe-updated"}""")
+        value = """{"first_name": "john-updated", "last_name": "doe-updated"}""",
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n:User) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -643,13 +705,15 @@ abstract class Neo4jNodePatternIT {
       nodePattern =
           [
               NodePatternStrategy(TOPIC_1, "(:User{!id})", mergeNodeProperties = false),
-              NodePatternStrategy(TOPIC_2, "(:Account{!id})", mergeNodeProperties = false)])
+              NodePatternStrategy(TOPIC_2, "(:Account{!id})", mergeNodeProperties = false),
+          ]
+  )
   @Test
   fun `should create nodes from multiple topics`(
       @TopicProducer(TOPIC_1) producer1: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_2) producer2: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "account_id", "Account", "id")
@@ -658,7 +722,8 @@ abstract class Neo4jNodePatternIT {
         keySchema = Schema.STRING_SCHEMA,
         key = """{"id": 1}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"name": "john", "surname": "doe"}""")
+        value = """{"name": "john", "surname": "doe"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:User) RETURN n", emptyMap()).single() }
         .get("n")
@@ -672,7 +737,8 @@ abstract class Neo4jNodePatternIT {
         keySchema = Schema.STRING_SCHEMA,
         key = """{"id": 1}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"email": "john@doe.com"}""")
+        value = """{"email": "john@doe.com"}""",
+    )
 
     eventually(30.seconds) { session.run("MATCH (n:Account) RETURN n", emptyMap()).single() }
         .get("n")
@@ -684,12 +750,13 @@ abstract class Neo4jNodePatternIT {
   }
 
   @Neo4jSink(
-      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)])
+      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should create 1000 nodes`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
 
@@ -700,7 +767,9 @@ abstract class Neo4jNodePatternIT {
               keySchema = Schema.STRING_SCHEMA,
               key = """{"id": $i}""",
               valueSchema = Schema.STRING_SCHEMA,
-              value = """{"name": "john-$i", "surname": "doe-$i"}"""))
+              value = """{"name": "john-$i", "surname": "doe-$i"}""",
+          )
+      )
     }
 
     producer.publish(*kafkaMessages.toTypedArray())
@@ -719,20 +788,22 @@ abstract class Neo4jNodePatternIT {
   fun `should merge node properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session
         .run(
             "CREATE (n:User) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 1, "name" to "john", "surname" to "doe")))
+            mapOf("props" to mapOf("id" to 1, "name" to "john", "surname" to "doe")),
+        )
         .consume()
 
     producer.publish(
         keySchema = Schema.STRING_SCHEMA,
         key = """{"id": 1}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"born": 1970}""")
+        value = """{"born": 1970}""",
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n:User) RETURN n", emptyMap()).single().get("n").asNode() should
@@ -745,25 +816,28 @@ abstract class Neo4jNodePatternIT {
   }
 
   @Neo4jSink(
-      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)])
+      nodePattern = [NodePatternStrategy(TOPIC, "(:User{!id})", mergeNodeProperties = false)]
+  )
   @Test
   fun `should not merge node properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session
         .run(
             "CREATE (n:User) SET n = ${'$'}props",
-            mapOf("props" to mapOf("id" to 1, "name" to "john", "surname" to "doe")))
+            mapOf("props" to mapOf("id" to 1, "name" to "john", "surname" to "doe")),
+        )
         .consume()
 
     producer.publish(
         keySchema = Schema.STRING_SCHEMA,
         key = """{"id": 1}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"born": 1970}""")
+        value = """{"born": 1970}""",
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n:User) RETURN n", emptyMap()).single().get("n").asNode() should

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jNodePatternIT.kt
@@ -38,7 +38,7 @@ import org.apache.kafka.connect.data.Time
 import org.apache.kafka.connect.data.Timestamp
 import org.junit.jupiter.api.Test
 import org.neo4j.caniuse.Neo4j
-import org.neo4j.connectors.kafka.data.DynamicTypes
+import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.connectors.kafka.data.PropertyType
 import org.neo4j.connectors.kafka.data.PropertyType.schema
 import org.neo4j.connectors.kafka.testing.DateSupport
@@ -122,11 +122,11 @@ abstract class Neo4jNodePatternIT {
                       .put("surname", "doe")
                       .put(
                           "dob",
-                          DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(1995, 1, 1)),
+                          PayloadMode.EXTENDED.value(PropertyType.schema, LocalDate.of(1995, 1, 1)),
                       )
                       .put(
                           "place",
-                          DynamicTypes.toConnectValue(
+                          PayloadMode.EXTENDED.value(
                               PropertyType.schema,
                               Values.point(7203, 1.0, 2.5).asPoint(),
                           ),

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
@@ -37,7 +37,7 @@ import org.apache.kafka.connect.data.Time
 import org.apache.kafka.connect.data.Timestamp
 import org.junit.jupiter.api.Test
 import org.neo4j.caniuse.Neo4j
-import org.neo4j.connectors.kafka.data.DynamicTypes
+import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.connectors.kafka.data.PropertyType
 import org.neo4j.connectors.kafka.data.PropertyType.schema
 import org.neo4j.connectors.kafka.testing.DateSupport
@@ -96,11 +96,11 @@ abstract class Neo4jRelationshipPatternIT {
                       .put("productId", 2L)
                       .put(
                           "at",
-                          DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(1995, 1, 1)),
+                          PayloadMode.EXTENDED.value(PropertyType.schema, LocalDate.of(1995, 1, 1)),
                       )
                       .put(
                           "place",
-                          DynamicTypes.toConnectValue(
+                          PayloadMode.EXTENDED.value(
                               PropertyType.schema,
                               Values.point(7203, 1.0, 2.5).asPoint(),
                           ),

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jRelationshipPatternIT.kt
@@ -68,12 +68,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!userId})-[:BOUGHT]->(:Product{!productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship from struct`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "userId")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "productId")
@@ -93,12 +96,16 @@ abstract class Neo4jRelationshipPatternIT {
                       .put("productId", 2L)
                       .put(
                           "at",
-                          DynamicTypes.toConnectValue(
-                              PropertyType.schema, LocalDate.of(1995, 1, 1)))
+                          DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(1995, 1, 1)),
+                      )
                       .put(
                           "place",
                           DynamicTypes.toConnectValue(
-                              PropertyType.schema, Values.point(7203, 1.0, 2.5).asPoint())))
+                              PropertyType.schema,
+                              Values.point(7203, 1.0, 2.5).asPoint(),
+                          ),
+                      ),
+          )
         }
 
     eventually(30.seconds) {
@@ -117,7 +124,8 @@ abstract class Neo4jRelationshipPatternIT {
             it.asMap() shouldBe
                 mapOf(
                     "at" to LocalDate.of(1995, 1, 1),
-                    "place" to Values.point(7203, 1.0, 2.5).asPoint())
+                    "place" to Values.point(7203, 1.0, 2.5).asPoint(),
+                )
           }
 
       result.get("p").asNode() should
@@ -135,12 +143,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:Person{!id: p1Id})-[:GAVE_BIRTH]->(:Person{!id: p2Id,height,dob,tob})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship from struct containing connect types`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
@@ -162,7 +173,8 @@ abstract class Neo4jRelationshipPatternIT {
                       .put("height", BigDecimal.valueOf(185, 2))
                       .put("dob", DateSupport.date(1978, 1, 15))
                       .put("tob", DateSupport.time(7, 45, 12, 999))
-                      .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999)))
+                      .put("tsob", DateSupport.timestamp(1978, 1, 15, 7, 45, 12, 999)),
+          )
         }
 
     eventually(30.seconds) {
@@ -204,18 +216,23 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!userId})-[:BOUGHT]->(:Product{!productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship from json string`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "userId")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "productId")
 
     producer.publish(
-        valueSchema = Schema.STRING_SCHEMA, value = """{"userId": 1, "productId": 2}""")
+        valueSchema = Schema.STRING_SCHEMA,
+        value = """{"userId": 1, "productId": 2}""",
+    )
 
     eventually(30.seconds) {
       val result =
@@ -244,19 +261,23 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!userId})-[:BOUGHT]->(:Product{!productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship from byte array`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "userId")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "productId")
 
     producer.publish(
         valueSchema = Schema.BYTES_SCHEMA,
-        value = ObjectMapper().writeValueAsBytes(mapOf("userId" to 1L, "productId" to 2L)))
+        value = ObjectMapper().writeValueAsBytes(mapOf("userId" to 1L, "productId" to 2L)),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -285,12 +306,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!userId})-[:BOUGHT{-currency}]->(:Product{!productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship with excluded properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "userId")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "productId")
@@ -300,12 +324,9 @@ abstract class Neo4jRelationshipPatternIT {
         value =
             ObjectMapper()
                 .writeValueAsBytes(
-                    mapOf(
-                        "userId" to 1L,
-                        "productId" to 2L,
-                        "amount" to 5,
-                        "currency" to "EUR",
-                    )))
+                    mapOf("userId" to 1L, "productId" to 2L, "amount" to 5, "currency" to "EUR")
+                ),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -314,10 +335,7 @@ abstract class Neo4jRelationshipPatternIT {
       result.get("u").asNode() should
           {
             it.labels() shouldBe listOf("User")
-            it.asMap() shouldBe
-                mapOf(
-                    "userId" to 1L,
-                )
+            it.asMap() shouldBe mapOf("userId" to 1L)
           }
 
       result.get("r").asRelationship() should
@@ -329,10 +347,7 @@ abstract class Neo4jRelationshipPatternIT {
       result.get("p").asNode() should
           {
             it.labels() shouldBe listOf("Product")
-            it.asMap() shouldBe
-                mapOf(
-                    "productId" to 2L,
-                )
+            it.asMap() shouldBe mapOf("productId" to 2L)
           }
     }
   }
@@ -344,19 +359,23 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "User{!userId} BOUGHT Product{!productId}",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship with simpler pattern`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "userId")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "productId")
 
     producer.publish(
         valueSchema = Schema.BYTES_SCHEMA,
-        value = ObjectMapper().writeValueAsBytes(mapOf("userId" to 1L, "productId" to 2L)))
+        value = ObjectMapper().writeValueAsBytes(mapOf("userId" to 1L, "productId" to 2L)),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -385,19 +404,23 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT {!id: transactionId}]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship with aliased properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"userId": 1, "productId": 2, "transactionId": 3}""")
+        value = """{"userId": 1, "productId": 2, "transactionId": 3}""",
+    )
 
     eventually(30.seconds) {
       val result =
@@ -426,12 +449,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT{!id: transactionId, price, currency}]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship with relationship key and properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -440,7 +466,8 @@ abstract class Neo4jRelationshipPatternIT {
         keySchema = Schema.STRING_SCHEMA,
         key = """{"userId": 1, "productId": 2, "transactionId": 3}""}""",
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"price": 10.5, "currency": "EUR"}""")
+        value = """{"price": 10.5, "currency": "EUR"}""",
+    )
 
     eventually(30.seconds) {
       val result =
@@ -473,12 +500,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   """(:User{!id: __key.user_id, name: __value.first_name})-[:BOUGHT{!id: __key.transaction_id, price: __value.paid_price, currency}]->(:Product{!id: __key.product_id, name: __value.product_name})""",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship with explicit properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -488,7 +518,8 @@ abstract class Neo4jRelationshipPatternIT {
         key = """{"user_id": 1, "product_id": 2, "transaction_id": 3}""}""",
         valueSchema = Schema.STRING_SCHEMA,
         value =
-            """{"first_name": "John", "paid_price": 10.5, "currency": "EUR", "product_name": "computer"}""")
+            """{"first_name": "John", "paid_price": 10.5, "currency": "EUR", "product_name": "computer"}""",
+    )
 
     eventually(30.seconds) {
       val result =
@@ -503,12 +534,7 @@ abstract class Neo4jRelationshipPatternIT {
       result.get("r").asRelationship() should
           {
             it.type() shouldBe "BOUGHT"
-            it.asMap() shouldBe
-                mapOf(
-                    "id" to 3L,
-                    "price" to 10.5,
-                    "currency" to "EUR",
-                )
+            it.asMap() shouldBe mapOf("id" to 3L, "price" to 10.5, "currency" to "EUR")
           }
 
       result.get("p").asNode() should
@@ -526,12 +552,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User:Person{!id: userId})-[:BOUGHT]->(:Product:Item{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create nodes and relationship with multiple labels pattern`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
@@ -539,7 +568,9 @@ abstract class Neo4jRelationshipPatternIT {
     session.createNodeKeyConstraint(neo4j, "item_id", "Item", "id")
 
     producer.publish(
-        valueSchema = Schema.STRING_SCHEMA, value = """{"userId": 1, "productId": 2}""")
+        valueSchema = Schema.STRING_SCHEMA,
+        value = """{"userId": 1, "productId": 2}""",
+    )
 
     eventually(30.seconds) {
       val result =
@@ -568,19 +599,23 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should add non id values to relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"userId": 1, "productId": 2, "price": 10, "currency": "EUR"}""")
+        value = """{"userId": 1, "productId": 2, "price": 10, "currency": "EUR"}""",
+    )
 
     eventually(30.seconds) {
       val result =
@@ -613,12 +648,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should delete relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -627,7 +665,8 @@ abstract class Neo4jRelationshipPatternIT {
         .run(
             """CREATE (u:User) SET u.id = 1 
            CREATE (p:Product) SET p.id = 2 
-           MERGE (u)-[:BOUGHT]->(p)""")
+           MERGE (u)-[:BOUGHT]->(p)"""
+        )
         .consume()
 
     producer.publish(keySchema = Schema.STRING_SCHEMA, key = """{"userId": 1, "productId": 2}""")
@@ -636,7 +675,8 @@ abstract class Neo4jRelationshipPatternIT {
       session
           .run(
               "MATCH (:User {id: 1})-[r:BOUGHT]->(:Product {id: 2}) RETURN count(r) as count",
-              emptyMap())
+              emptyMap(),
+          )
           .single()
           .get("count")
           .asLong() shouldBe 0
@@ -650,12 +690,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT{price, currency}]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should add only relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -663,12 +706,14 @@ abstract class Neo4jRelationshipPatternIT {
     session
         .run(
             """CREATE (u:User) SET u.id = 1 
-           CREATE (p:Product) SET p.id = 2""")
+           CREATE (p:Product) SET p.id = 2"""
+        )
         .consume()
 
     producer.publish(
         valueSchema = Schema.STRING_SCHEMA,
-        value = """{"userId": 1, "productId": 2, "price": 10.5, "currency": "EUR"}""")
+        value = """{"userId": 1, "productId": 2, "price": 10.5, "currency": "EUR"}""",
+    )
 
     eventually(30.seconds) {
           session
@@ -690,12 +735,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: user_id, name: user_name})-[:BOUGHT {amount}]->(:Product{!id: product_id, name: product_name})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create, delete and recreate relationship`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -705,13 +753,16 @@ abstract class Neo4jRelationshipPatternIT {
             keySchema = Schema.STRING_SCHEMA,
             key = """{"user_id": 1, "product_id": 2}""",
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"user_name": "John", "amount": 1, "product_name": "computer"}"""),
+            value = """{"user_name": "John", "amount": 1, "product_name": "computer"}""",
+        ),
         KafkaMessage(keySchema = Schema.STRING_SCHEMA, key = """{"user_id": 1, "product_id": 2}"""),
         KafkaMessage(
             keySchema = Schema.STRING_SCHEMA,
             key = """{"user_id": 1, "product_id": 2}""",
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"user_name": "John-new", "amount": 5, "product_name": "computer-new"}"""))
+            value = """{"user_name": "John-new", "amount": 5, "product_name": "computer-new"}""",
+        ),
+    )
 
     eventually(30.seconds) {
       val result =
@@ -749,34 +800,39 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC_1,
                   "(:User{!id: userId})-[:BOUGHT]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false),
+                  mergeRelationshipProperties = false,
+              ),
               RelationshipPatternStrategy(
                   TOPIC_2,
                   "(:User{!id: userId})-[:SOLD]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              ),
+          ]
+  )
   @Test
   fun `should create multiple relationships from different topics`(
       @TopicProducer(TOPIC_1) producer1: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_2) producer2: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
 
     producer1.publish(
-        valueSchema = Schema.STRING_SCHEMA, value = """{"userId": 1, "productId": 2}""")
+        valueSchema = Schema.STRING_SCHEMA,
+        value = """{"userId": 1, "productId": 2}""",
+    )
 
     producer2.publish(
-        valueSchema = Schema.STRING_SCHEMA, value = """{"userId": 1, "productId": 2}""")
+        valueSchema = Schema.STRING_SCHEMA,
+        value = """{"userId": 1, "productId": 2}""",
+    )
 
     eventually(30.seconds) {
       session
-          .run(
-              "MATCH (u:User {id: 1})-[r]->(p:Product {id: 2}) RETURN r",
-              emptyMap(),
-          )
+          .run("MATCH (u:User {id: 1})-[r]->(p:Product {id: 2}) RETURN r", emptyMap())
           .list()
           .map { it.get("r").asRelationship().type() } shouldContainAll listOf("BOUGHT", "SOLD")
     }
@@ -789,12 +845,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT {!id: transactionId}]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should create 1000 relationships`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -804,17 +863,16 @@ abstract class Neo4jRelationshipPatternIT {
       kafkaMessages.add(
           KafkaMessage(
               valueSchema = Schema.STRING_SCHEMA,
-              value = """{"userId": 1, "productId": 2, "transactionId": $i}"""))
+              value = """{"userId": 1, "productId": 2, "transactionId": $i}""",
+          )
+      )
     }
 
     producer.publish(*kafkaMessages.toTypedArray())
 
     eventually(30.seconds) {
       session
-          .run(
-              "MATCH (u:User {id: 1})-[r]->(p:Product {id: 2}) RETURN r",
-              emptyMap(),
-          )
+          .run("MATCH (u:User {id: 1})-[r]->(p:Product {id: 2}) RETURN r", emptyMap())
           .list() shouldHaveSize 1000
     }
   }
@@ -826,33 +884,36 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId, born})-[:BOUGHT]->(:Product{!id: productId, price})",
                   mergeNodeProperties = true,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should merge node properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
 
     session
         .run(
-            """CREATE (:User {id: 1, name: "Joe", surname: "Doe"})-[:BOUGHT]->(:Product {id: 2, name: "computer"})""")
+            """CREATE (:User {id: 1, name: "Joe", surname: "Doe"})-[:BOUGHT]->(:Product {id: 2, name: "computer"})"""
+        )
         .consume()
 
     producer.publish(
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"userId": 1, "productId": 2, "born": 1970, "price": 10.5}"""))
+            value = """{"userId": 1, "productId": 2, "born": 1970, "price": 10.5}""",
+        )
+    )
 
     eventually(30.seconds) {
       val result =
           session
-              .run(
-                  "MATCH (u:User {id: 1})-[:BOUGHT]->(p:Product {id: 2}) RETURN u, p",
-                  emptyMap(),
-              )
+              .run("MATCH (u:User {id: 1})-[:BOUGHT]->(p:Product {id: 2}) RETURN u, p", emptyMap())
               .single()
 
       result.get("u").asNode() should
@@ -877,33 +938,36 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId, born})-[:BOUGHT]->(:Product{!id: productId, price})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should not merge node properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
 
     session
         .run(
-            """CREATE (:User {id: 1, name: "Joe", surname: "Doe"})-[:BOUGHT]->(:Product {id: 2, name: "computer"})""")
+            """CREATE (:User {id: 1, name: "Joe", surname: "Doe"})-[:BOUGHT]->(:Product {id: 2, name: "computer"})"""
+        )
         .consume()
 
     producer.publish(
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"userId": 1, "productId": 2, "born": 1970, "price": 10.5}"""))
+            value = """{"userId": 1, "productId": 2, "born": 1970, "price": 10.5}""",
+        )
+    )
 
     eventually(30.seconds) {
       val result =
           session
-              .run(
-                  "MATCH (u:User {id: 1})-[:BOUGHT]->(p:Product {id: 2}) RETURN u, p",
-                  emptyMap(),
-              )
+              .run("MATCH (u:User {id: 1})-[:BOUGHT]->(p:Product {id: 2}) RETURN u, p", emptyMap())
               .single()
 
       result.get("u").asNode() should
@@ -927,12 +991,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = true)])
+                  mergeRelationshipProperties = true,
+              )
+          ]
+  )
   @Test
   fun `should merge relationship properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -942,15 +1009,14 @@ abstract class Neo4jRelationshipPatternIT {
     producer.publish(
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"userId": 1, "productId": 2, "date": "2024-05-27"}"""))
+            value = """{"userId": 1, "productId": 2, "date": "2024-05-27"}""",
+        )
+    )
 
     eventually(30.seconds) {
       val result =
           session
-              .run(
-                  "MATCH (:User {id: 1})-[r:BOUGHT]->(:Product {id: 2}) RETURN r",
-                  emptyMap(),
-              )
+              .run("MATCH (:User {id: 1})-[r:BOUGHT]->(:Product {id: 2}) RETURN r", emptyMap())
               .single()
 
       result.get("r").asRelationship() should
@@ -968,12 +1034,15 @@ abstract class Neo4jRelationshipPatternIT {
                   TOPIC,
                   "(:User{!id: userId})-[:BOUGHT]->(:Product{!id: productId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)])
+                  mergeRelationshipProperties = false,
+              )
+          ]
+  )
   @Test
   fun `should not merge relationship properties`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "user_id", "User", "id")
     session.createNodeKeyConstraint(neo4j, "product_id", "Product", "id")
@@ -983,15 +1052,14 @@ abstract class Neo4jRelationshipPatternIT {
     producer.publish(
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"userId": 1, "productId": 2, "date": "2024-05-27"}"""))
+            value = """{"userId": 1, "productId": 2, "date": "2024-05-27"}""",
+        )
+    )
 
     eventually(30.seconds) {
       val result =
           session
-              .run(
-                  "MATCH (:User {id: 1})-[r:BOUGHT]->(:Product {id: 2}) RETURN r",
-                  emptyMap(),
-              )
+              .run("MATCH (:User {id: 1})-[r:BOUGHT]->(:Product {id: 2}) RETURN r", emptyMap())
               .single()
 
       result.get("r").asRelationship() should

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
@@ -115,15 +115,18 @@ abstract class Neo4jSinkErrorIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})")],
+                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report an error with all error headers when headers are enabled`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
@@ -165,17 +168,20 @@ abstract class Neo4jSinkErrorIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})")],
+                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "none",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should be in failed state when error tolerance is none`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
       sink: Neo4jSinkRegistration,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
     val schemaWithMissingSurname =
@@ -215,17 +221,20 @@ abstract class Neo4jSinkErrorIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})")],
+                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should still be in running state when error tolerance is all`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
       sink: Neo4jSinkRegistration,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
     val schemaWithMissingSurname =
@@ -265,16 +274,19 @@ abstract class Neo4jSinkErrorIT {
           [
               CypherStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})")],
+                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events with cypher strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
@@ -309,7 +321,8 @@ abstract class Neo4jSinkErrorIT {
         KafkaMessage(valueSchema = schema, value = struct2ToFail),
         KafkaMessage(valueSchema = schema, value = struct3),
         KafkaMessage(valueSchema = schema, value = struct4ToFail),
-        KafkaMessage(valueSchema = schema, value = struct5))
+        KafkaMessage(valueSchema = schema, value = struct5),
+    )
 
     eventually(30.seconds) {
       session.run("MATCH (n) RETURN n", emptyMap()).list().map {
@@ -318,7 +331,8 @@ abstract class Neo4jSinkErrorIT {
           listOf(
               (listOf("Person") to mapOf("id" to 1L, "name" to "John", "surname" to "Doe")),
               (listOf("Person") to mapOf("id" to 3L, "name" to "Mary", "surname" to "Doe")),
-              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")))
+              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")),
+          )
     }
 
     TopicVerifier.createForMap(errorConsumer)
@@ -349,37 +363,48 @@ abstract class Neo4jSinkErrorIT {
       nodePattern =
           [
               NodePatternStrategy(
-                  TOPIC, "(:Person{!id, name, surname})", mergeNodeProperties = false)],
+                  TOPIC,
+                  "(:Person{!id, name, surname})",
+                  mergeNodeProperties = false,
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events with node pattern strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
     val message1 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 1, "name": "John", "surname": "Doe"}""")
+            value = """{"id": 1, "name": "John", "surname": "Doe"}""",
+        )
     val message2ToFail =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 2, name: "Jane", "surname": "Doe"}""")
+            value = """{"id": 2, name: "Jane", "surname": "Doe"}""",
+        )
     val message3 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 3, "name": "Mary", "surname": "Doe"}""")
+            value = """{"id": 3, "name": "Mary", "surname": "Doe"}""",
+        )
     val message4ToFail =
         KafkaMessage(
-            valueSchema = Schema.STRING_SCHEMA, value = """{"name": "Martin", "surname": "Doe"}""")
+            valueSchema = Schema.STRING_SCHEMA,
+            value = """{"name": "Martin", "surname": "Doe"}""",
+        )
     val message5 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 5, "name": "Sue", "surname": "Doe"}""")
+            value = """{"id": 5, "name": "Sue", "surname": "Doe"}""",
+        )
 
     producer.publish(message1, message2ToFail, message3, message4ToFail, message5)
 
@@ -390,7 +415,8 @@ abstract class Neo4jSinkErrorIT {
           listOf(
               (listOf("Person") to mapOf("id" to 1L, "name" to "John", "surname" to "Doe")),
               (listOf("Person") to mapOf("id" to 3L, "name" to "Mary", "surname" to "Doe")),
-              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")))
+              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")),
+          )
     }
 
     TopicVerifier.create<String, String>(errorConsumer)
@@ -424,16 +450,19 @@ abstract class Neo4jSinkErrorIT {
                   TOPIC,
                   "(:Person{!id: personId})-[:OWNS]->(:Item{!id: itemId})",
                   mergeNodeProperties = false,
-                  mergeRelationshipProperties = false)],
+                  mergeRelationshipProperties = false,
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events with relationship pattern strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
     session.createNodeKeyConstraint(neo4j, "item_id", "Item", "id")
@@ -456,7 +485,8 @@ abstract class Neo4jSinkErrorIT {
           session
               .run(
                   "MATCH (p:Person {id: ${'$'}productId})-[r:OWNS]->(i:Item {id: ${'$'}itemId}) RETURN p,r,i",
-                  mapOf("productId" to 1L, "itemId" to 1L))
+                  mapOf("productId" to 1L, "itemId" to 1L),
+              )
               .single()
 
       result1.get("p").asNode() should
@@ -477,7 +507,8 @@ abstract class Neo4jSinkErrorIT {
           session
               .run(
                   "MATCH (p:Person {id: ${'$'}productId})-[r:OWNS]->(i:Item {id: ${'$'}itemId}) RETURN p,r,i",
-                  mapOf("productId" to 2L, "itemId" to 2L))
+                  mapOf("productId" to 2L, "itemId" to 2L),
+              )
               .single()
 
       result2.get("p").asNode() should
@@ -498,7 +529,8 @@ abstract class Neo4jSinkErrorIT {
           session
               .run(
                   "MATCH (p:Person {id: ${'$'}productId})-[r:OWNS]->(i:Item {id: ${'$'}itemId}) RETURN p,r,i",
-                  mapOf("productId" to 4L, "itemId" to 4L))
+                  mapOf("productId" to 4L, "itemId" to 4L),
+              )
               .single()
 
       result3.get("p").asNode() should
@@ -544,13 +576,14 @@ abstract class Neo4jSinkErrorIT {
       cud = [CudStrategy(TOPIC)],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events with cud strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
@@ -566,7 +599,8 @@ abstract class Neo4jSinkErrorIT {
                     "name": "John",
                     "surname": "Doe"
                   }
-                }""")
+                }""",
+        )
     val message2 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
@@ -580,7 +614,8 @@ abstract class Neo4jSinkErrorIT {
                     "name": "Jane",
                     "surname": "Doe"
                   }
-                }""")
+                }""",
+        )
     val message3ToFail =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
@@ -594,7 +629,8 @@ abstract class Neo4jSinkErrorIT {
                     "name": "Mary"
                     "surname": "Doe"
                   }
-                }""")
+                }""",
+        )
     val message4 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
@@ -608,7 +644,8 @@ abstract class Neo4jSinkErrorIT {
                     "name": "Martin",
                     "surname": "Doe"
                   }
-                }""")
+                }""",
+        )
     val message5 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
@@ -622,7 +659,8 @@ abstract class Neo4jSinkErrorIT {
                     "name": "Sue",
                     "surname": "Doe"
                   }
-                }""")
+                }""",
+        )
 
     producer.publish(message1ToFail, message2, message3ToFail, message4, message5)
 
@@ -633,7 +671,8 @@ abstract class Neo4jSinkErrorIT {
           listOf(
               (listOf("Person") to mapOf("id" to 2L, "name" to "Jane", "surname" to "Doe")),
               (listOf("Person") to mapOf("id" to 4L, "name" to "Martin", "surname" to "Doe")),
-              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")))
+              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")),
+          )
     }
 
     TopicVerifier.create<String, String>(errorConsumer)
@@ -664,13 +703,14 @@ abstract class Neo4jSinkErrorIT {
       cdcSchema = [CdcSchemaStrategy(TOPIC)],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events with cdc schema strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
@@ -684,8 +724,9 @@ abstract class Neo4jSinkErrorIT {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
-                NodeState(
-                    listOf("Person"), mapOf("id" to 1L, "name" to "John", "surname" to "Doe"))))
+                NodeState(listOf("Person"), mapOf("id" to 1L, "name" to "John", "surname" to "Doe")),
+            ),
+        )
 
     val event2 =
         newEvent(
@@ -697,8 +738,9 @@ abstract class Neo4jSinkErrorIT {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 2L))),
                 null,
-                NodeState(
-                    listOf("Person"), mapOf("id" to 2L, "name" to "Jane", "surname" to "Doe"))))
+                NodeState(listOf("Person"), mapOf("id" to 2L, "name" to "Jane", "surname" to "Doe")),
+            ),
+        )
 
     val event3ToFail =
         newEvent(
@@ -710,8 +752,9 @@ abstract class Neo4jSinkErrorIT {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 3L))),
                 null,
-                NodeState(
-                    listOf("Person"), mapOf("id" to 3L, "name" to "Mary", "surname" to "Doe"))))
+                NodeState(listOf("Person"), mapOf("id" to 3L, "name" to "Mary", "surname" to "Doe")),
+            ),
+        )
 
     val event4 =
         newEvent(
@@ -724,7 +767,11 @@ abstract class Neo4jSinkErrorIT {
                 mapOf("Person" to listOf(mapOf("id" to 4L))),
                 null,
                 NodeState(
-                    listOf("Person"), mapOf("id" to 4L, "name" to "Martin", "surname" to "Doe"))))
+                    listOf("Person"),
+                    mapOf("id" to 4L, "name" to "Martin", "surname" to "Doe"),
+                ),
+            ),
+        )
 
     val event5 =
         newEvent(
@@ -736,8 +783,9 @@ abstract class Neo4jSinkErrorIT {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 5L))),
                 null,
-                NodeState(
-                    listOf("Person"), mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe"))))
+                NodeState(listOf("Person"), mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")),
+            ),
+        )
 
     producer.publish(event1ToFail, event2, event3ToFail, event4, event5)
 
@@ -748,7 +796,8 @@ abstract class Neo4jSinkErrorIT {
           listOf(
               (listOf("Person") to mapOf("id" to 2L, "name" to "Jane", "surname" to "Doe")),
               (listOf("Person") to mapOf("id" to 4L, "name" to "Martin", "surname" to "Doe")),
-              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")))
+              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")),
+          )
     }
 
     TopicVerifier.create<ChangeEvent, ChangeEvent>(errorConsumer)
@@ -779,13 +828,14 @@ abstract class Neo4jSinkErrorIT {
       cdcSourceId = [CdcSourceIdStrategy(TOPIC, "SourceEvent", "sourceId")],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events with cdc source id strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
@@ -801,7 +851,10 @@ abstract class Neo4jSinkErrorIT {
                 null,
                 NodeState(
                     listOf("SourceEvent"),
-                    mapOf("id" to 1L, "name" to "John", "surname" to "Doe"))))
+                    mapOf("id" to 1L, "name" to "John", "surname" to "Doe"),
+                ),
+            ),
+        )
 
     val event2ToFail =
         newEvent(
@@ -815,7 +868,10 @@ abstract class Neo4jSinkErrorIT {
                 null,
                 NodeState(
                     listOf("SourceEvent"),
-                    mapOf("id" to 2L, "name" to "Jane", "surname" to "Doe"))))
+                    mapOf("id" to 2L, "name" to "Jane", "surname" to "Doe"),
+                ),
+            ),
+        )
 
     val event3 =
         newEvent(
@@ -828,7 +884,11 @@ abstract class Neo4jSinkErrorIT {
                 emptyMap(),
                 null,
                 NodeState(
-                    listOf("SourceEvent"), mapOf("id" to 3, "name" to "Mary", "surname" to "Doe"))))
+                    listOf("SourceEvent"),
+                    mapOf("id" to 3, "name" to "Mary", "surname" to "Doe"),
+                ),
+            ),
+        )
 
     val event4 =
         newEvent(
@@ -842,7 +902,10 @@ abstract class Neo4jSinkErrorIT {
                 null,
                 NodeState(
                     listOf("SourceEvent"),
-                    mapOf("id" to 4L, "name" to "Martin", "surname" to "Doe"))))
+                    mapOf("id" to 4L, "name" to "Martin", "surname" to "Doe"),
+                ),
+            ),
+        )
 
     val event5ToFail =
         newEvent(
@@ -855,7 +918,11 @@ abstract class Neo4jSinkErrorIT {
                 emptyMap(),
                 null,
                 NodeState(
-                    listOf("SourceEvent"), mapOf("id" to 5L, "name" to "Sue", "surname" to "*"))))
+                    listOf("SourceEvent"),
+                    mapOf("id" to 5L, "name" to "Sue", "surname" to "*"),
+                ),
+            ),
+        )
 
     producer.publish(event1, event2ToFail, event3, event4, event5ToFail)
 
@@ -870,7 +937,12 @@ abstract class Neo4jSinkErrorIT {
                   mapOf("sourceId" to "person3", "id" to 3L, "name" to "Mary", "surname" to "Doe")),
               (listOf("SourceEvent") to
                   mapOf(
-                      "sourceId" to "person4", "id" to 4L, "name" to "Martin", "surname" to "Doe")))
+                      "sourceId" to "person4",
+                      "id" to 4L,
+                      "name" to "Martin",
+                      "surname" to "Doe",
+                  )),
+          )
     }
 
     TopicVerifier.create<ChangeEvent, ChangeEvent>(errorConsumer)
@@ -901,25 +973,29 @@ abstract class Neo4jSinkErrorIT {
       nodePattern =
           [NodePatternStrategy(TOPIC, "(:User{!id, name, surname})", mergeNodeProperties = false)],
       errorTolerance = "none",
-      errorDlqTopic = DLQ_TOPIC)
+      errorDlqTopic = DLQ_TOPIC,
+  )
   @Test
   fun `should stop the process and only report first failed event when error tolerance is none`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) = runTest {
     val message1 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 1, "name": "John", "surname": "Doe"}""")
+            value = """{"id": 1, "name": "John", "surname": "Doe"}""",
+        )
     val message2ToFail =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 2, name: "Jane", "surname": "Doe"}""")
+            value = """{"id": 2, name: "Jane", "surname": "Doe"}""",
+        )
     val message3 =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 3, name: "Mary", "surname": "Doe"}""")
+            value = """{"id": 3, name: "Mary", "surname": "Doe"}""",
+        )
 
     producer.publish(message1, message2ToFail, message3)
 
@@ -942,21 +1018,28 @@ abstract class Neo4jSinkErrorIT {
           [
               CypherStrategy(
                   TOPIC_2,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})")],
+                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+              )
+          ],
       nodePattern =
           [
               NodePatternStrategy(
-                  TOPIC_3, "(:Person{!id, name, surname})", mergeNodeProperties = false)],
+                  TOPIC_3,
+                  "(:Person{!id, name, surname})",
+                  mergeNodeProperties = false,
+              )
+          ],
       errorDlqTopic = DLQ_TOPIC,
       errorTolerance = "all",
-      enableErrorHeaders = true)
+      enableErrorHeaders = true,
+  )
   @Test
   fun `should report failed events from different topics`(
       @TopicProducer(TOPIC_1) producer1: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_2) producer2: ConvertingKafkaProducer,
       @TopicProducer(TOPIC_3) producer3: ConvertingKafkaProducer,
       @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) = runTest {
     val cudMessageToFail =
         KafkaMessage(
@@ -970,12 +1053,14 @@ abstract class Neo4jSinkErrorIT {
                     "name": "John",
                     "surname": "Doe"
                   }
-                }""")
+                }""",
+        )
 
     val cypherMessage =
         KafkaMessage(
             valueSchema = Schema.STRING_SCHEMA,
-            value = """{"id": 1, "name": "John", "surname": "Doe"}""")
+            value = """{"id": 1, "name": "John", "surname": "Doe"}""",
+        )
 
     val nodePatternMessageToFail =
         KafkaMessage(valueSchema = Schema.STRING_SCHEMA, value = """{}""")
@@ -1034,8 +1119,10 @@ abstract class Neo4jSinkErrorIT {
               ZonedDateTime.now().minusSeconds(5),
               ZonedDateTime.now(),
               emptyMap(),
-              emptyMap()),
-          event)
+              emptyMap(),
+          ),
+          event,
+      )
 }
 
 @KeyValueConverter(key = AVRO, value = AVRO) class Neo4jSinkErrorAvroIT : Neo4jSinkErrorIT()

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkIT.kt
@@ -46,12 +46,7 @@ abstract class Neo4jSinkIT {
 
   @Neo4jSink(
       cypher =
-          [
-              CypherStrategy(
-                  TOPIC,
-                  "MERGE (p:Person {name: event.name, surname: event.surname})",
-              ),
-          ],
+          [CypherStrategy(TOPIC, "MERGE (p:Person {name: event.name, surname: event.surname})")]
   )
   @Test
   fun `writes messages to Neo4j via sink connector`(
@@ -86,16 +81,19 @@ abstract class Neo4jSinkIT {
               CypherStrategy(
                   TOPIC,
                   "MERGE (p:Person {name: event.name, surname: event.surname}) INVALID CYPHER",
-              ),
+              )
           ],
-      excludeErrorHandling = true)
+      excludeErrorHandling = true,
+  )
   @Test
   fun `should fail connector on errors when errant reporter is not set`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      sink: Neo4jSinkRegistration
+      sink: Neo4jSinkRegistration,
   ) = runTest {
     producer.publish(
-        value = "{ \"name\": \"Jane\", \"surname\": \"Doe\" }", valueSchema = Schema.STRING_SCHEMA)
+        value = "{ \"name\": \"Jane\", \"surname\": \"Doe\" }",
+        valueSchema = Schema.STRING_SCHEMA,
+    )
 
     // after the failure
     eventually(30.seconds) {

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkRawJsonIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkRawJsonIT.kt
@@ -43,8 +43,8 @@ class Neo4jSinkRawJsonIT {
               CypherStrategy(
                   TOPIC,
                   "WITH __value AS person MERGE (p:Person {name: person.name, surname: person.surname})",
-              ),
-          ],
+              )
+          ]
   )
   @Test
   fun `should support json map`(
@@ -73,8 +73,8 @@ class Neo4jSinkRawJsonIT {
               CypherStrategy(
                   TOPIC,
                   "WITH __value AS persons UNWIND persons AS person MERGE (p:Person {name: person.name, surname: person.surname})",
-              ),
-          ],
+              )
+          ]
   )
   @Test
   fun `should support json list`(
@@ -89,11 +89,7 @@ class Neo4jSinkRawJsonIT {
             ),
         valueSchema =
             SchemaBuilder.array(
-                    SchemaBuilder.map(
-                            Schema.STRING_SCHEMA,
-                            Schema.STRING_SCHEMA,
-                        )
-                        .build(),
+                    SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build()
                 )
                 .build(),
     )
@@ -109,24 +105,13 @@ class Neo4jSinkRawJsonIT {
     }
   }
 
-  @Neo4jSink(
-      cypher =
-          [
-              CypherStrategy(
-                  TOPIC,
-                  "WITH __value AS name MERGE (p:Person {name: name})",
-              ),
-          ],
-  )
+  @Neo4jSink(cypher = [CypherStrategy(TOPIC, "WITH __value AS name MERGE (p:Person {name: name})")])
   @Test
   fun `should support raw string value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
   ) {
-    producer.publish(
-        value = "John",
-        valueSchema = Schema.STRING_SCHEMA,
-    )
+    producer.publish(value = "John", valueSchema = Schema.STRING_SCHEMA)
 
     await().atMost(30.seconds.toJavaDuration()).untilAsserted {
       session
@@ -139,54 +124,31 @@ class Neo4jSinkRawJsonIT {
     }
   }
 
-  @Neo4jSink(
-      cypher =
-          [
-              CypherStrategy(
-                  TOPIC,
-                  "WITH __value AS age MERGE (p:Person {age: age})",
-              ),
-          ],
-  )
+  @Neo4jSink(cypher = [CypherStrategy(TOPIC, "WITH __value AS age MERGE (p:Person {age: age})")])
   @Test
   fun `should support raw numeric value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
   ) {
-    producer.publish(
-        value = 25L,
-        valueSchema = Schema.INT64_SCHEMA,
-    )
+    producer.publish(value = 25L, valueSchema = Schema.INT64_SCHEMA)
 
     await().atMost(30.seconds.toJavaDuration()).untilAsserted {
       session
-          .run(
-              "MATCH (p:Person {age: ${'$'}age}) RETURN count(p) as result",
-              mapOf("age" to 25L),
-          )
+          .run("MATCH (p:Person {age: ${'$'}age}) RETURN count(p) as result", mapOf("age" to 25L))
           .single()["result"]
           .asLong() shouldBe 1L
     }
   }
 
   @Neo4jSink(
-      cypher =
-          [
-              CypherStrategy(
-                  TOPIC,
-                  "WITH __value AS status MERGE (p:Person {single: status})",
-              ),
-          ],
+      cypher = [CypherStrategy(TOPIC, "WITH __value AS status MERGE (p:Person {single: status})")]
   )
   @Test
   fun `should support raw boolean value`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
       session: Session,
   ) {
-    producer.publish(
-        value = true,
-        valueSchema = Schema.BOOLEAN_SCHEMA,
-    )
+    producer.publish(value = true, valueSchema = Schema.BOOLEAN_SCHEMA)
 
     await().atMost(30.seconds.toJavaDuration()).untilAsserted {
       session

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Cypher5Renderer.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Cypher5Renderer.kt
@@ -39,8 +39,10 @@ internal class Cypher5Renderer(neo4j: Neo4j) : Renderer {
                     Dialect.DEFAULT
                   } else {
                     Dialect.NEO4J_5
-                  })
-              .build())
+                  }
+              )
+              .build()
+      )
 
   override fun render(statement: Statement?): String? {
     val rendered = delegateRenderer.render(statement)

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/SinkConfiguration.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/SinkConfiguration.kt
@@ -43,7 +43,7 @@ class SinkConfiguration : Neo4jConfiguration {
   @TestOnly
   constructor(
       originals: Map<String, *>,
-      renderer: Renderer?
+      renderer: Renderer?,
   ) : super(config(), originals, ConnectorType.SINK) {
     fixedRenderer = renderer
 
@@ -102,7 +102,8 @@ class SinkConfiguration : Neo4jConfiguration {
 
     if (sourceTopics != configuredTopics) {
       throw ConfigException(
-          "There is a mismatch between topics defined into the property `${SinkTask.TOPICS_CONFIG}` ($sourceTopics) and configured strategies ($configuredTopics)")
+          "There is a mismatch between topics defined into the property `${SinkTask.TOPICS_CONFIG}` ($sourceTopics) and configured strategies ($configuredTopics)"
+      )
     }
   }
 
@@ -151,11 +152,13 @@ class SinkConfiguration : Neo4jConfiguration {
       val cypherAliasForValue = config.value<String>(CYPHER_BIND_VALUE_AS).isNullOrEmpty()
       val cypherUseEventForValue =
           config.value<String>(CYPHER_BIND_VALUE_AS_EVENT)?.toBoolean() ?: true
-      if (!cypherUseEventForValue &&
-          (cypherAliasForHeader &&
-              cypherAliasForKey &&
-              cypherAliasForValue &&
-              cypherAliasForTimestamp)) {
+      if (
+          !cypherUseEventForValue &&
+              (cypherAliasForHeader &&
+                  cypherAliasForKey &&
+                  cypherAliasForValue &&
+                  cypherAliasForTimestamp)
+      ) {
         config
             .configValues()
             .filter {
@@ -165,11 +168,13 @@ class SinkConfiguration : Neo4jConfiguration {
                       CYPHER_BIND_HEADER_AS,
                       CYPHER_BIND_KEY_AS,
                       CYPHER_BIND_VALUE_AS,
-                      CYPHER_BIND_VALUE_AS_EVENT)
+                      CYPHER_BIND_VALUE_AS_EVENT,
+                  )
             }
             .forEach {
               it.addErrorMessage(
-                  "At least one variable binding must be specified for Cypher strategies.")
+                  "At least one variable binding must be specified for Cypher strategies."
+              )
             }
       }
     }
@@ -186,33 +191,38 @@ class SinkConfiguration : Neo4jConfiguration {
                   importance = ConfigDef.Importance.MEDIUM
                   defaultValue = ""
                   group = Groups.CONNECTOR.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CDC_SCHEMA_TOPICS, ConfigDef.Type.LIST) {
                   importance = ConfigDef.Importance.MEDIUM
                   defaultValue = ""
                   group = Groups.CONNECTOR.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CUD_TOPICS, ConfigDef.Type.LIST) {
                   importance = ConfigDef.Importance.MEDIUM
                   defaultValue = ""
                   group = Groups.CONNECTOR.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(BATCH_SIZE, ConfigDef.Type.INT) {
                   importance = ConfigDef.Importance.MEDIUM
                   defaultValue = DEFAULT_BATCH_SIZE
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = ConfigDef.Range.atLeast(1)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(BATCH_TIMEOUT, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
                   defaultValue = DEFAULT_BATCH_TIMEOUT.toSimpleString()
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CDC_SOURCE_ID_LABEL_NAME, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -220,7 +230,8 @@ class SinkConfiguration : Neo4jConfiguration {
                   group = Groups.CONNECTOR_ADVANCED.title
                   recommender =
                       Recommenders.visibleIfNotEmpty(Predicate.isEqual(CDC_SOURCE_ID_TOPICS))
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CDC_SOURCE_ID_PROPERTY_NAME, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -228,31 +239,36 @@ class SinkConfiguration : Neo4jConfiguration {
                   group = Groups.CONNECTOR_ADVANCED.title
                   recommender =
                       Recommenders.visibleIfNotEmpty(Predicate.isEqual(CDC_SOURCE_ID_TOPICS))
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CYPHER_BIND_TIMESTAMP_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
                   defaultValue = DEFAULT_BIND_TIMESTAMP_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CYPHER_BIND_HEADER_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_HEADER_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CYPHER_BIND_KEY_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_KEY_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CYPHER_BIND_VALUE_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_VALUE_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CYPHER_BIND_VALUE_AS_EVENT, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -260,31 +276,36 @@ class SinkConfiguration : Neo4jConfiguration {
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = Validators.bool()
                   recommender = Recommenders.bool()
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PATTERN_BIND_TIMESTAMP_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_TIMESTAMP_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PATTERN_BIND_HEADER_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_HEADER_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PATTERN_BIND_KEY_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_KEY_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PATTERN_BIND_VALUE_AS, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
                   defaultValue = DEFAULT_BIND_VALUE_ALIAS
                   group = Groups.CONNECTOR_ADVANCED.title
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PATTERN_MERGE_NODE_PROPERTIES, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -292,7 +313,8 @@ class SinkConfiguration : Neo4jConfiguration {
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = Validators.bool()
                   recommender = Recommenders.bool()
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PATTERN_MERGE_RELATIONSHIP_PROPERTIES, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -300,6 +322,7 @@ class SinkConfiguration : Neo4jConfiguration {
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = Validators.bool()
                   recommender = Recommenders.bool()
-                })
+                }
+            )
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/SinkStrategy.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/SinkStrategy.kt
@@ -82,8 +82,10 @@ data class SinkMessage(val record: SinkRecord) {
       DynamicTypes.fromConnectValue(it, value)?.let {
         // if incoming schema is a built-in BYTES or STRING, then we try a json parsing for backward
         // compatibility
-        if (schema.name().isNullOrEmpty() &&
-            (schema.type() == Schema.Type.STRING || schema.type() == Schema.Type.BYTES)) {
+        if (
+            schema.name().isNullOrEmpty() &&
+                (schema.type() == Schema.Type.STRING || schema.type() == Schema.Type.BYTES)
+        ) {
           try {
             JSONUtils.readValue<Any?>(it)
           } catch (ex: JsonParseException) {
@@ -105,14 +107,14 @@ enum class SinkStrategy(val description: String) {
   CYPHER("cypher"),
   CUD("cud"),
   NODE_PATTERN("node-pattern"),
-  RELATIONSHIP_PATTERN("relationship-pattern")
+  RELATIONSHIP_PATTERN("relationship-pattern"),
 }
 
 data class ChangeQuery(
     val txId: Long?,
     val seq: Int?,
     val messages: Iterable<SinkMessage>,
-    val query: Query
+    val query: Query,
 )
 
 interface SinkStrategyHandler {
@@ -150,7 +152,8 @@ interface SinkStrategyHandler {
                 bindHeaderAs = config.cypherBindHeaderAs,
                 bindKeyAs = config.cypherBindKeyAs,
                 bindValueAs = config.cypherBindValueAs,
-                bindValueAsEvent = config.cypherBindValueAsEvent)
+                bindValueAsEvent = config.cypherBindValueAsEvent,
+            )
       }
 
       val pattern = originals[SinkConfiguration.PATTERN_TOPIC_PREFIX + topic]
@@ -171,7 +174,8 @@ interface SinkStrategyHandler {
                       bindTimestampAs = config.patternBindTimestampAs,
                       bindHeaderAs = config.patternBindHeaderAs,
                       bindKeyAs = config.patternBindKeyAs,
-                      bindValueAs = config.patternBindValueAs)
+                      bindValueAs = config.patternBindValueAs,
+                  )
               is RelationshipPattern ->
                   RelationshipPatternHandler(
                       topic,
@@ -185,10 +189,12 @@ interface SinkStrategyHandler {
                       bindTimestampAs = config.patternBindTimestampAs,
                       bindHeaderAs = config.patternBindHeaderAs,
                       bindKeyAs = config.patternBindKeyAs,
-                      bindValueAs = config.patternBindValueAs)
+                      bindValueAs = config.patternBindValueAs,
+                  )
               else ->
                   throw IllegalArgumentException(
-                      "Invalid pattern provided for PatternHandler: ${parsedPattern.javaClass.name}")
+                      "Invalid pattern provided for PatternHandler: ${parsedPattern.javaClass.name}"
+                  )
             }
 
         patternHandler.validate(fetchConstraintData(config.driver, config.sessionConfig()))
@@ -251,7 +257,8 @@ interface SinkStrategyHandler {
           is RelationshipPattern -> SinkStrategy.RELATIONSHIP_PATTERN
           else ->
               throw IllegalArgumentException(
-                  "Invalid pattern provided for PatternHandler: ${parsedPattern.javaClass.name}")
+                  "Invalid pattern provided for PatternHandler: ${parsedPattern.javaClass.name}"
+              )
         }
       }
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/converters/MapValueConverter.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/converters/MapValueConverter.kt
@@ -37,7 +37,7 @@ open class MapValueConverter<T> : ValueConverter<MutableMap<String, T?>>() {
   override fun setBytesField(
       result: MutableMap<String, T?>?,
       fieldName: String,
-      value: ByteArray?
+      value: ByteArray?,
   ) {
     setValue(result, fieldName, value)
   }
@@ -58,7 +58,7 @@ open class MapValueConverter<T> : ValueConverter<MutableMap<String, T?>>() {
       result: MutableMap<String, T?>?,
       fieldName: String,
       schema: Schema?,
-      array: MutableList<Any?>?
+      array: MutableList<Any?>?,
   ) {
     val convertedArray = array?.map { convertInner(it) }
     setValue(result, fieldName, convertedArray)
@@ -85,7 +85,7 @@ open class MapValueConverter<T> : ValueConverter<MutableMap<String, T?>>() {
       result: MutableMap<String, T?>?,
       fieldName: String,
       schema: Schema?,
-      map: MutableMap<Any?, Any?>?
+      map: MutableMap<Any?, Any?>?,
   ) {
     if (map != null) {
       val converted = convert(map) as MutableMap<Any?, Any?>
@@ -118,7 +118,7 @@ open class MapValueConverter<T> : ValueConverter<MutableMap<String, T?>>() {
   override fun setDecimalField(
       result: MutableMap<String, T?>?,
       fieldName: String,
-      value: BigDecimal
+      value: BigDecimal,
   ) {
     setValue(result, fieldName, value)
   }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/converters/Neo4jValueConverter.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/converters/Neo4jValueConverter.kt
@@ -43,7 +43,7 @@ class Neo4jValueConverter : MapValueConverter<Any>() {
   override fun setDecimalField(
       result: MutableMap<String, Any?>?,
       fieldName: String,
-      value: BigDecimal
+      value: BigDecimal,
   ) {
     val doubleValue = value.toDouble()
     val fitsScale =
@@ -60,7 +60,7 @@ class Neo4jValueConverter : MapValueConverter<Any>() {
   override fun setTimestampField(
       result: MutableMap<String, Any?>?,
       fieldName: String,
-      value: Date
+      value: Date,
   ) {
     val localDate = value.toInstant().atZone(UTC).toLocalDateTime()
     setValue(result, fieldName, localDate)

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/converters/ValueConverter.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/converters/ValueConverter.kt
@@ -62,14 +62,14 @@ abstract class ValueConverter<T> {
       result: T?,
       fieldName: String,
       schema: Schema?,
-      array: MutableList<Any?>?
+      array: MutableList<Any?>?,
   )
 
   protected abstract fun setMap(
       result: T?,
       fieldName: String,
       schema: Schema?,
-      map: MutableMap<Any?, Any?>?
+      map: MutableMap<Any?, Any?>?,
   )
 
   protected abstract fun setNullField(result: T?, fieldName: String)
@@ -90,7 +90,7 @@ abstract class ValueConverter<T> {
                 Struct::class.java.getName(),
                 MutableMap::class.java.getName(),
                 value.javaClass.getName(),
-            ),
+            )
         )
       }
     }
@@ -152,10 +152,7 @@ abstract class ValueConverter<T> {
           setMap(result, fieldName, null, fieldValue as MutableMap<Any?, Any?>?)
         } else {
           throw DataException(
-              String.format(
-                  "%s is not a supported data type.",
-                  fieldValue.javaClass.getName(),
-              ),
+              String.format("%s is not a supported data type.", fieldValue.javaClass.getName())
           )
         }
       } catch (ex: Exception) {

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcHandler.kt
@@ -68,8 +68,10 @@ abstract class CdcHandler : SinkStrategyHandler {
                         }
                     else ->
                         throw IllegalArgumentException("unsupported event type ${event.eventType}")
-                  })
-            })
+                  },
+              )
+            },
+        )
         .onEach { logger.trace("mapped messages: {} to {}", it.key, it.value) }
         .values
   }
@@ -98,7 +100,8 @@ internal fun parseCdcChangeEvent(message: SinkMessage): ChangeEvent =
       is Struct -> value.toChangeEvent()
       else ->
           throw IllegalArgumentException(
-              "unexpected message value type ${value?.javaClass?.name} in $message")
+              "unexpected message value type ${value?.javaClass?.name} in $message"
+          )
     }
 
 internal fun parseStreamsChangeEvent(message: SinkMessage): ChangeEvent {

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandler.kt
@@ -135,10 +135,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
     return Query(renderer.render(stmt), stmt.parameters)
   }
 
-  private fun buildNode(
-      keys: Map<String, List<Map<String, Any>>>,
-      named: String,
-  ): Node {
+  private fun buildNode(keys: Map<String, List<Map<String, Any>>>, named: String): Node {
     val validKeys =
         keys
             .mapValues { kvp -> kvp.value.filter { it.isNotEmpty() } }
@@ -146,7 +143,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
 
     if (validKeys.isEmpty()) {
       throw InvalidDataException(
-          "schema strategy requires at least one node key with valid properties on node aliased '$named'.",
+          "schema strategy requires at least one node key with valid properties on node aliased '$named'."
       )
     }
 
@@ -165,7 +162,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
                               e.value,
                           ),
                       )
-                    },
+                    }
             )
             .named(named)
 
@@ -176,14 +173,14 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
       val start: Node,
       val end: Node,
       val relationship: Relationship,
-      val matchNodes: Boolean
+      val matchNodes: Boolean,
   )
 
   @Suppress("SameParameterValue")
   private fun buildRelationship(
       event: RelationshipEvent,
       named: String,
-      forCreate: Boolean
+      forCreate: Boolean,
   ): RelationshipOutput {
     val relationshipHasKeys = event.keys.filter { it.isNotEmpty() }.any()
 
@@ -191,18 +188,10 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
     // else we check whether relationship has its own keys or not
     val start =
         if (!forCreate && relationshipHasKeys) Cypher.anyNode("start")
-        else
-            buildNode(
-                event.start.keys,
-                "start",
-            )
+        else buildNode(event.start.keys, "start")
     val end =
         if (!forCreate && relationshipHasKeys) Cypher.anyNode("end")
-        else
-            buildNode(
-                event.end.keys,
-                "end",
-            )
+        else buildNode(event.end.keys, "end")
     val rel =
         start
             .relationshipTo(end, event.type)
@@ -218,7 +207,7 @@ class CdcSchemaHandler(val topic: String, private val renderer: Renderer) : CdcH
                               e.value,
                           ),
                       )
-                    },
+                    }
             )
             .named(named)
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSourceIdHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSourceIdHandler.kt
@@ -31,7 +31,7 @@ class CdcSourceIdHandler(
     val topic: String,
     private val renderer: Renderer,
     val labelName: String = SinkConfiguration.DEFAULT_SOURCE_ID_LABEL_NAME,
-    val propertyName: String = SinkConfiguration.DEFAULT_SOURCE_ID_PROPERTY_NAME
+    val propertyName: String = SinkConfiguration.DEFAULT_SOURCE_ID_PROPERTY_NAME,
 ) : CdcHandler() {
 
   override fun strategy() = SinkStrategy.CDC_SOURCE_ID
@@ -154,7 +154,7 @@ class CdcSourceIdHandler(
   @Suppress("SameParameterValue")
   private fun buildRelationship(
       event: RelationshipEvent,
-      named: String
+      named: String,
   ): Triple<Node, Node, Relationship> {
     val start = buildNode(event.start.elementId, "start")
     val end = buildNode(event.end.elementId, "end")

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CypherHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/CypherHandler.kt
@@ -38,7 +38,7 @@ class CypherHandler(
     bindHeaderAs: String = SinkConfiguration.DEFAULT_BIND_HEADER_ALIAS,
     bindKeyAs: String = SinkConfiguration.DEFAULT_BIND_KEY_ALIAS,
     bindValueAs: String = SinkConfiguration.DEFAULT_BIND_VALUE_ALIAS,
-    bindValueAsEvent: Boolean = SinkConfiguration.DEFAULT_CYPHER_BIND_VALUE_AS_EVENT
+    bindValueAsEvent: Boolean = SinkConfiguration.DEFAULT_CYPHER_BIND_VALUE_AS_EVENT,
 ) : SinkStrategyHandler {
   private val logger: Logger = LoggerFactory.getLogger(javaClass)
   private val rewrittenQuery: String
@@ -70,12 +70,15 @@ class CypherHandler(
 
                       if (isEmpty()) {
                         throw IllegalArgumentException(
-                            "no effective accessors specified for binding the message into cypher template for topic '$topic'")
+                            "no effective accessors specified for binding the message into cypher template for topic '$topic'"
+                        )
                       }
-                    })
+                    }
+                )
                 .callRawCypher("WITH * $query")
                 .returning(Cypher.literalNull())
-                .build())
+                .build()
+        )
 
     logger.debug("using cypher query '{}' for topic '{}'", rewrittenQuery, topic)
   }
@@ -95,7 +98,8 @@ class CypherHandler(
                       Instant.ofEpochMilli(it.record.timestamp()).atOffset(ZoneOffset.UTC),
                   "header" to it.headerFromConnectValue(),
                   "key" to it.keyFromConnectValue(),
-                  "value" to it.valueFromConnectValue())
+                  "value" to it.valueFromConnectValue(),
+              )
 
           logger.trace("message '{}' mapped to: '{}'", it, mapped)
 
@@ -108,7 +112,9 @@ class CypherHandler(
                   null,
                   null,
                   it.map { data -> data.message },
-                  Query(rewrittenQuery, mapOf("events" to it.map { data -> data.eventMap }))))
+                  Query(rewrittenQuery, mapOf("events" to it.map { data -> data.eventMap })),
+              )
+          )
         }
         .onEach { logger.trace("mapped messages: '{}'", it) }
         .toList()

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/PatternHandler.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/PatternHandler.kt
@@ -57,7 +57,9 @@ abstract class PatternHandler<T : Pattern>(
                   bindTimestampAs to
                       Instant.ofEpochMilli(message.record.timestamp()).atOffset(ZoneOffset.UTC),
                   bindHeaderAs to message.headerFromConnectValue(),
-                  bindKeyAs to message.keyFromConnectValue()))
+                  bindKeyAs to message.keyFromConnectValue(),
+              )
+          )
           if (message.value != null) {
             this[bindValueAs] =
                 when (val value = message.valueFromConnectValue()) {
@@ -92,7 +94,7 @@ abstract class PatternHandler<T : Pattern>(
       flattened: Map<String, Any?>,
       isTombstone: Boolean,
       usedTracker: MutableSet<String>,
-      vararg prefixes: String
+      vararg prefixes: String,
   ): Map<String, Any?> =
       pattern.keyProperties
           .associateBy { it.to }
@@ -105,11 +107,11 @@ abstract class PatternHandler<T : Pattern>(
               }
               if (mapping.from.startsWith("$bindKeyAs.")) {
                 throw InvalidDataException(
-                    "Key '${mapping.from.replace("$bindKeyAs.", "")}' could not be located in the keys.",
+                    "Key '${mapping.from.replace("$bindKeyAs.", "")}' could not be located in the keys."
                 )
               } else {
                 throw InvalidDataException(
-                    "Key '${mapping.from.replace("$bindValueAs.", "")}' could not be located in the values.",
+                    "Key '${mapping.from.replace("$bindValueAs.", "")}' could not be located in the values."
                 )
               }
             } else {
@@ -122,7 +124,7 @@ abstract class PatternHandler<T : Pattern>(
                 }
               }
               throw InvalidDataException(
-                  "Key '${mapping.from}' could not be located in the message.",
+                  "Key '${mapping.from}' could not be located in the message."
               )
             }
           }
@@ -144,7 +146,7 @@ abstract class PatternHandler<T : Pattern>(
   protected fun computeProperties(
       pattern: Pattern,
       flattened: Map<String, Any?>,
-      used: MutableSet<String>
+      used: MutableSet<String>,
   ): Map<String, Any?> {
     return buildMap {
       if (pattern.includeAllValueProperties) {
@@ -152,7 +154,8 @@ abstract class PatternHandler<T : Pattern>(
             flattened
                 .filterKeys { !used.contains(it) }
                 .filterKeys { it.startsWith(bindValueAs) }
-                .mapKeys { it.key.substring(bindValueAs.length + 1) })
+                .mapKeys { it.key.substring(bindValueAs.length + 1) }
+        )
       }
 
       pattern.includeProperties.forEach { mapping ->
@@ -167,7 +170,8 @@ abstract class PatternHandler<T : Pattern>(
                   .mapKeys {
                     used += it.key
                     mapping.to + it.key.substring(key.length)
-                  })
+                  }
+          )
         }
       }
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateNode.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateNode.kt
@@ -37,7 +37,8 @@ data class CreateNode(val labels: Set<String>, val properties: Map<String, Any?>
       return CreateNode(
           values.getIterable<String>(Keys.LABELS)?.toSet() ?: emptySet(),
           values.getMap<String, Any?>(Keys.PROPERTIES)
-              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"))
+              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateRelationship.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateRelationship.kt
@@ -27,7 +27,7 @@ data class CreateRelationship(
     val type: String,
     val start: NodeReference,
     val end: NodeReference,
-    val properties: Map<String, Any?>
+    val properties: Map<String, Any?>,
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (type.isEmpty()) {
@@ -36,7 +36,8 @@ data class CreateRelationship(
 
     if (start.ids.isEmpty() || end.ids.isEmpty()) {
       throw InvalidDataException(
-          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property.")
+          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property."
+      )
     }
 
     val startParam = Cypher.parameter("start")
@@ -53,7 +54,9 @@ data class CreateRelationship(
         mapOf(
             "start" to mapOf("keys" to start.ids),
             "end" to mapOf("keys" to end.ids),
-            "properties" to properties))
+            "properties" to properties,
+        ),
+    )
   }
 
   companion object {
@@ -63,12 +66,15 @@ data class CreateRelationship(
               ?: throw InvalidDataException("No ${Keys.RELATION_TYPE} found"),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.FROM)
-                  ?: throw InvalidDataException("No ${Keys.FROM} found")),
+                  ?: throw InvalidDataException("No ${Keys.FROM} found")
+          ),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.TO)
-                  ?: throw InvalidDataException("No ${Keys.TO} found")),
+                  ?: throw InvalidDataException("No ${Keys.TO} found")
+          ),
           values.getMap<String, Any?>(Keys.PROPERTIES)
-              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"))
+              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteNode.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteNode.kt
@@ -27,7 +27,7 @@ import org.neo4j.driver.Query
 data class DeleteNode(
     val labels: Set<String>,
     val ids: Map<String, Any?>,
-    val detach: Boolean = false
+    val detach: Boolean = false,
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (ids.isEmpty()) {
@@ -47,7 +47,8 @@ data class DeleteNode(
                     it.delete(node)
                   }
                 }
-                .build())
+                .build()
+        )
 
     return Query(stmt, mapOf("keys" to ids))
   }
@@ -57,7 +58,8 @@ data class DeleteNode(
       return DeleteNode(
           values.getIterable<String>(Keys.LABELS)?.toSet() ?: emptySet(),
           values.getMap<String, Any?>(Keys.IDS) ?: throw InvalidDataException("No IDS found"),
-          values.getTyped<Boolean>(Keys.DETACH) ?: false)
+          values.getTyped<Boolean>(Keys.DETACH) ?: false,
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteRelationship.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteRelationship.kt
@@ -27,7 +27,7 @@ data class DeleteRelationship(
     val type: String,
     val start: NodeReference,
     val end: NodeReference,
-    val ids: Map<String, Any?> = emptyMap()
+    val ids: Map<String, Any?> = emptyMap(),
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (type.isEmpty()) {
@@ -36,12 +36,14 @@ data class DeleteRelationship(
 
     if (start.op != LookupMode.MATCH || end.op != LookupMode.MATCH) {
       throw InvalidDataException(
-          "'${Keys.FROM}' and '${Keys.TO}' must have '${Keys.OPERATION}' as 'MATCH' for relationship deletion operations.")
+          "'${Keys.FROM}' and '${Keys.TO}' must have '${Keys.OPERATION}' as 'MATCH' for relationship deletion operations."
+      )
     }
 
     if (start.ids.isEmpty() || end.ids.isEmpty()) {
       throw InvalidDataException(
-          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property.")
+          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property."
+      )
     }
 
     val startParam = Cypher.parameter("start")
@@ -61,7 +63,9 @@ data class DeleteRelationship(
         mapOf(
             "start" to mapOf("keys" to start.ids),
             "end" to mapOf("keys" to end.ids),
-            "keys" to ids))
+            "keys" to ids,
+        ),
+    )
   }
 
   companion object {
@@ -71,11 +75,14 @@ data class DeleteRelationship(
               ?: throw InvalidDataException("No ${Keys.RELATION_TYPE} found"),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.FROM)
-                  ?: throw InvalidDataException("No ${Keys.FROM} found")),
+                  ?: throw InvalidDataException("No ${Keys.FROM} found")
+          ),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.TO)
-                  ?: throw InvalidDataException("No ${Keys.TO} found")),
-          values.getMap<String, Any?>(Keys.IDS) ?: emptyMap())
+                  ?: throw InvalidDataException("No ${Keys.TO} found")
+          ),
+          values.getMap<String, Any?>(Keys.IDS) ?: emptyMap(),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/Helpers.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/Helpers.kt
@@ -38,12 +38,13 @@ fun buildNode(labels: Set<String>, ids: Map<String, Any?>, keys: Expression): No
 fun <T : ExposesWhere> T.applyFilter(node: Node, ids: Map<String, Any?>, keys: Expression): T {
   return if (ids.containsKey(Keys.PHYSICAL_ID)) {
     this.where(
-        Cypher.raw("id(${'$'}E)", node.requiredSymbolicName).eq(keys.property(Keys.PHYSICAL_ID)))
-        as T
+        Cypher.raw("id(${'$'}E)", node.requiredSymbolicName).eq(keys.property(Keys.PHYSICAL_ID))
+    ) as T
   } else if (ids.containsKey(Keys.ELEMENT_ID)) {
     this.where(
         Cypher.raw("elementId(${'$'}E)", node.requiredSymbolicName)
-            .eq(keys.property(Keys.ELEMENT_ID))) as T
+            .eq(keys.property(Keys.ELEMENT_ID))
+    ) as T
   } else {
     this
   }
@@ -75,5 +76,6 @@ fun lookupNodes(
                   .with(startNode, endNode)
           LookupMode.MERGE -> it.merge(endNode).with(startNode, endNode)
         }
-      })
+      },
+  )
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeNode.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeNode.kt
@@ -26,7 +26,7 @@ import org.neo4j.driver.Query
 data class MergeNode(
     val labels: Set<String>,
     val ids: Map<String, Any?>,
-    val properties: Map<String, Any?>
+    val properties: Map<String, Any?>,
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (ids.isEmpty()) {
@@ -45,7 +45,8 @@ data class MergeNode(
                   .build()
             } else {
               Cypher.merge(node).mutate(node, propertiesParam).build()
-            })
+            }
+        )
 
     return Query(stmt, mapOf("keys" to ids, "properties" to properties))
   }
@@ -57,7 +58,8 @@ data class MergeNode(
           values.getMap<String, Any?>(Keys.IDS)
               ?: throw InvalidDataException("No ${Keys.IDS} found"),
           values.getMap<String, Any?>(Keys.PROPERTIES)
-              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"))
+              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeRelationship.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeRelationship.kt
@@ -28,7 +28,7 @@ data class MergeRelationship(
     val start: NodeReference,
     val end: NodeReference,
     val ids: Map<String, Any?> = emptyMap(),
-    val properties: Map<String, Any?>
+    val properties: Map<String, Any?>,
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (type.isEmpty()) {
@@ -37,7 +37,8 @@ data class MergeRelationship(
 
     if (start.ids.isEmpty() || end.ids.isEmpty()) {
       throw InvalidDataException(
-          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property.")
+          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property."
+      )
     }
 
     val startParam = Cypher.parameter("start")
@@ -60,7 +61,9 @@ data class MergeRelationship(
             "start" to mapOf("keys" to start.ids),
             "end" to mapOf("keys" to end.ids),
             "keys" to ids,
-            "properties" to properties))
+            "properties" to properties,
+        ),
+    )
   }
 
   companion object {
@@ -70,13 +73,16 @@ data class MergeRelationship(
               ?: throw InvalidDataException("No ${Keys.RELATION_TYPE} found"),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.FROM)
-                  ?: throw InvalidDataException("No ${Keys.FROM} found")),
+                  ?: throw InvalidDataException("No ${Keys.FROM} found")
+          ),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.TO)
-                  ?: throw InvalidDataException("No ${Keys.TO} found")),
+                  ?: throw InvalidDataException("No ${Keys.TO} found")
+          ),
           values.getMap<String, Any?>(Keys.IDS) ?: emptyMap(),
           values.getMap<String, Any?>(Keys.PROPERTIES)
-              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"))
+              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/NodeReference.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/NodeReference.kt
@@ -24,7 +24,7 @@ import org.neo4j.connectors.kafka.utils.MapUtils.getTyped
 data class NodeReference(
     val labels: Set<String>,
     val ids: Map<String, Any?>,
-    val op: LookupMode = LookupMode.MATCH
+    val op: LookupMode = LookupMode.MATCH,
 ) {
   companion object {
     fun from(values: Map<String, Any?>): NodeReference {
@@ -32,7 +32,8 @@ data class NodeReference(
           values.getIterable<String>(Keys.LABELS)?.toSet() ?: emptySet(),
           values.getMap<String, Any?>(Keys.IDS)?.toMap()
               ?: throw InvalidDataException("No ${Keys.IDS} found"),
-          LookupMode.fromString(values.getTyped<String>(Keys.OPERATION)) ?: LookupMode.MATCH)
+          LookupMode.fromString(values.getTyped<String>(Keys.OPERATION)) ?: LookupMode.MATCH,
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/Operation.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/Operation.kt
@@ -47,23 +47,28 @@ interface Operation {
                 is String -> type
                 else ->
                     throw IllegalArgumentException(
-                        "Unsupported data type ('$type') in CUD file type.")
-              }) ?: throw IllegalArgumentException("CUD file type must be specified.")
+                        "Unsupported data type ('$type') in CUD file type."
+                    )
+              }
+          ) ?: throw IllegalArgumentException("CUD file type must be specified.")
       val operation =
           OperationType.fromString(
               when (val operation = values[Keys.OPERATION]) {
                 is String -> operation
                 else ->
                     throw IllegalArgumentException(
-                        "Unsupported data type ('$operation') for CUD file operation")
-              }) ?: throw IllegalArgumentException("CUD file operation must be specified.")
+                        "Unsupported data type ('$operation') for CUD file operation"
+                    )
+              }
+          ) ?: throw IllegalArgumentException("CUD file operation must be specified.")
 
       val mapper = JSONUtils.getObjectMapper()
       val node = mapper.valueToTree<JsonNode>(values)
       val errors = SCHEMA.validate(node)
       if (errors.isNotEmpty()) {
         throw InvalidDataException(
-            errors.joinToString(", ") { "${it.evaluationPath}: ${it.message}" })
+            errors.joinToString(", ") { "${it.evaluationPath}: ${it.message}" }
+        )
       }
 
       return when (type to operation) {
@@ -77,7 +82,7 @@ interface Operation {
         RELATIONSHIP to DELETE -> DeleteRelationship.from(values)
         else ->
             throw IllegalArgumentException(
-                "Unknown type ('$type') and operation ('$operation') for CUD file",
+                "Unknown type ('$type') and operation ('$operation') for CUD file"
             )
       }
     }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateNode.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateNode.kt
@@ -26,7 +26,7 @@ import org.neo4j.driver.Query
 data class UpdateNode(
     val labels: Set<String>,
     val ids: Map<String, Any?>,
-    val properties: Map<String, Any?>
+    val properties: Map<String, Any?>,
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (ids.isEmpty()) {
@@ -41,7 +41,8 @@ data class UpdateNode(
             Cypher.match(node)
                 .applyFilter(node, ids, keysParam)
                 .mutate(node, propertiesParam)
-                .build())
+                .build()
+        )
 
     return Query(stmt, mapOf("keys" to ids, "properties" to properties))
   }
@@ -53,7 +54,8 @@ data class UpdateNode(
           values.getMap<String, Any?>(Keys.IDS)
               ?: throw InvalidDataException("No ${Keys.IDS} found"),
           values.getMap<String, Any?>(Keys.PROPERTIES)
-              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"))
+              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateRelationship.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateRelationship.kt
@@ -28,7 +28,7 @@ data class UpdateRelationship(
     val start: NodeReference,
     val end: NodeReference,
     val ids: Map<String, Any?> = emptyMap(),
-    val properties: Map<String, Any?>
+    val properties: Map<String, Any?>,
 ) : Operation {
   override fun toQuery(renderer: Renderer): Query {
     if (type.isEmpty()) {
@@ -37,7 +37,8 @@ data class UpdateRelationship(
 
     if (start.ids.isEmpty() || end.ids.isEmpty()) {
       throw InvalidDataException(
-          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property.")
+          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property."
+      )
     }
 
     val startParam = Cypher.parameter("start")
@@ -60,7 +61,9 @@ data class UpdateRelationship(
             "start" to mapOf("keys" to start.ids),
             "end" to mapOf("keys" to end.ids),
             "keys" to ids,
-            "properties" to properties))
+            "properties" to properties,
+        ),
+    )
   }
 
   companion object {
@@ -70,13 +73,16 @@ data class UpdateRelationship(
               ?: throw InvalidDataException("No ${Keys.RELATION_TYPE} found"),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.FROM)
-                  ?: throw InvalidDataException("No ${Keys.FROM} found")),
+                  ?: throw InvalidDataException("No ${Keys.FROM} found")
+          ),
           NodeReference.from(
               values.getMap<String, Any?>(Keys.TO)
-                  ?: throw InvalidDataException("No ${Keys.TO} found")),
+                  ?: throw InvalidDataException("No ${Keys.TO} found")
+          ),
           values.getMap<String, Any?>(Keys.IDS) ?: emptyMap(),
           values.getMap<String, Any?>(Keys.PROPERTIES)
-              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"))
+              ?: throw InvalidDataException("No ${Keys.PROPERTIES} found"),
+      )
     }
   }
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/NodePattern.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/NodePattern.kt
@@ -21,7 +21,7 @@ data class NodePattern(
     override val includeAllValueProperties: Boolean,
     override val keyProperties: Set<PropertyMapping>,
     override val includeProperties: Set<PropertyMapping>,
-    override val excludeProperties: Set<String>
+    override val excludeProperties: Set<String>,
 ) : Pattern {
   override val text: String
     get() {

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/Pattern.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/Pattern.kt
@@ -45,7 +45,8 @@ internal fun Pattern.propertiesAsText(): String {
         this.append(
             keyProperties.joinToString(", ") { m ->
               "!${trySanitize(m.to)}: ${trySanitize(m.from)}"
-            })
+            }
+        )
       }
       .apply {
         if (keyProperties.isNotEmpty() && includeProperties.isNotEmpty()) {
@@ -54,19 +55,24 @@ internal fun Pattern.propertiesAsText(): String {
         this.append(
             includeProperties.joinToString(", ") { m ->
               "${trySanitize(m.to)}: ${trySanitize(m.from)}"
-            })
+            }
+        )
       }
       .apply {
-        if ((keyProperties.isNotEmpty() || includeProperties.isNotEmpty()) &&
-            excludeProperties.isNotEmpty()) {
+        if (
+            (keyProperties.isNotEmpty() || includeProperties.isNotEmpty()) &&
+                excludeProperties.isNotEmpty()
+        ) {
           this.append(", ")
         }
         this.append(excludeProperties.joinToString(", ") { "-" + trySanitize(it) })
       }
       .apply {
-        if ((keyProperties.isNotEmpty() ||
-            includeProperties.isNotEmpty() ||
-            excludeProperties.isNotEmpty()) && includeAllValueProperties) {
+        if (
+            (keyProperties.isNotEmpty() ||
+                includeProperties.isNotEmpty() ||
+                excludeProperties.isNotEmpty()) && includeAllValueProperties
+        ) {
           this.append(", ")
         }
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternConstraintValidator.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternConstraintValidator.kt
@@ -26,7 +26,7 @@ object PatternConstraintValidator {
   fun checkNodeWarning(
       constraints: List<ConstraintData>,
       pattern: NodePattern,
-      patternString: String
+      patternString: String,
   ): String? {
     val typeConstraintMap =
         constraints
@@ -44,8 +44,10 @@ object PatternConstraintValidator {
         return null
       }
 
-      if (checkNodeUniqueness(label, keys, typeConstraintMap) &&
-          checkNodePropertyExistence(label, keys, typeConstraintMap)) {
+      if (
+          checkNodeUniqueness(label, keys, typeConstraintMap) &&
+              checkNodePropertyExistence(label, keys, typeConstraintMap)
+      ) {
         return null
       }
     }
@@ -56,7 +58,7 @@ object PatternConstraintValidator {
   fun checkRelationshipWarning(
       constraints: List<ConstraintData>,
       pattern: RelationshipPattern,
-      patternString: String
+      patternString: String,
   ): String? {
     val typeConstraintMap =
         constraints
@@ -74,8 +76,10 @@ object PatternConstraintValidator {
       return null
     }
 
-    if (checkRelationshipUniqueness(type, keys, typeConstraintMap) &&
-        checkRelationshipPropertyExistence(type, keys, typeConstraintMap)) {
+    if (
+        checkRelationshipUniqueness(type, keys, typeConstraintMap) &&
+            checkRelationshipPropertyExistence(type, keys, typeConstraintMap)
+    ) {
       return null
     }
 
@@ -85,7 +89,7 @@ object PatternConstraintValidator {
   private fun checkNodeKey(
       label: String,
       keys: List<String>,
-      typeConstraintMap: Map<String, List<ConstraintData>>
+      typeConstraintMap: Map<String, List<ConstraintData>>,
   ): Boolean {
     val nodeKeyConstraints =
         typeConstraintMap["${ConstraintType.NODE_KEY.value}-${label}"] ?: return false
@@ -100,7 +104,7 @@ object PatternConstraintValidator {
   private fun checkNodeUniqueness(
       label: String,
       keys: List<String>,
-      typeConstraintMap: Map<String, List<ConstraintData>>
+      typeConstraintMap: Map<String, List<ConstraintData>>,
   ): Boolean {
     val uniquenessConstraints =
         typeConstraintMap["${ConstraintType.NODE_UNIQUENESS.value}-${label}"] ?: return false
@@ -115,7 +119,7 @@ object PatternConstraintValidator {
   private fun checkNodePropertyExistence(
       label: String,
       keys: List<String>,
-      typeConstraintMap: Map<String, List<ConstraintData>>
+      typeConstraintMap: Map<String, List<ConstraintData>>,
   ): Boolean {
     val existenceConstraints =
         typeConstraintMap["${ConstraintType.NODE_EXISTENCE.value}-${label}"] ?: return false
@@ -126,7 +130,7 @@ object PatternConstraintValidator {
   private fun checkRelationshipKey(
       type: String,
       keys: List<String>,
-      typeConstraintMap: Map<String, List<ConstraintData>>
+      typeConstraintMap: Map<String, List<ConstraintData>>,
   ): Boolean {
     val relationshipKeyConstraints =
         typeConstraintMap["${ConstraintType.RELATIONSHIP_KEY.value}-${type}"] ?: return false
@@ -141,7 +145,7 @@ object PatternConstraintValidator {
   private fun checkRelationshipUniqueness(
       type: String,
       keys: List<String>,
-      typeConstraintMap: Map<String, List<ConstraintData>>
+      typeConstraintMap: Map<String, List<ConstraintData>>,
   ): Boolean {
     val uniquenessConstraints =
         typeConstraintMap["${ConstraintType.RELATIONSHIP_UNIQUENESS.value}-${type}"] ?: return false
@@ -156,7 +160,7 @@ object PatternConstraintValidator {
   private fun checkRelationshipPropertyExistence(
       type: String,
       keys: List<String>,
-      typeConstraintMap: Map<String, List<ConstraintData>>
+      typeConstraintMap: Map<String, List<ConstraintData>>,
   ): Boolean {
     val existenceConstraints =
         typeConstraintMap["${ConstraintType.RELATIONSHIP_EXISTENCE.value}-${type}"] ?: return false
@@ -168,17 +172,17 @@ object PatternConstraintValidator {
       pattern: NodePattern,
       patternString: String,
       typeConstraintMap: Map<String, List<ConstraintData>>,
-      keys: List<String>
+      keys: List<String>,
   ): String {
     val stringBuilder = StringBuilder()
     if (pattern.labels.size > 1) {
       stringBuilder.append(
-          "None of the labels ${pattern.labels.joinToString(", ") { "'$it'" }} match the key(s) defined by the pattern $patternString.",
+          "None of the labels ${pattern.labels.joinToString(", ") { "'$it'" }} match the key(s) defined by the pattern $patternString."
       )
       stringBuilder.append("\nPlease fix at least one of the following label constraints:")
     } else {
       stringBuilder.append(
-          "Label '${pattern.labels.first()}' does not match the key(s) defined by the pattern $patternString.",
+          "Label '${pattern.labels.first()}' does not match the key(s) defined by the pattern $patternString."
       )
       stringBuilder.append("\nPlease fix the label constraint:")
     }
@@ -188,10 +192,12 @@ object PatternConstraintValidator {
     stringBuilder.append("\n\t- ${getConstraintWarningText(ConstraintType.NODE_KEY.value, keys)}")
     stringBuilder.append("\nor:")
     stringBuilder.append(
-        "\n\t- ${getConstraintWarningText(ConstraintType.NODE_UNIQUENESS.value, keys)}")
+        "\n\t- ${getConstraintWarningText(ConstraintType.NODE_UNIQUENESS.value, keys)}"
+    )
     for (key in keys) {
       stringBuilder.append(
-          "\n\t- ${getConstraintWarningText(ConstraintType.NODE_EXISTENCE.value, listOf(key))}")
+          "\n\t- ${getConstraintWarningText(ConstraintType.NODE_EXISTENCE.value, listOf(key))}"
+      )
     }
     return stringBuilder.toString()
   }
@@ -200,14 +206,14 @@ object PatternConstraintValidator {
       pattern: RelationshipPattern,
       patternString: String,
       typeConstraintMap: Map<String, List<ConstraintData>>,
-      keys: List<String>
+      keys: List<String>,
   ): String {
     val stringBuilder = StringBuilder()
 
     val type = pattern.type!!
 
     stringBuilder.append(
-        "Relationship '$type' does not match the key(s) defined by the pattern $patternString.",
+        "Relationship '$type' does not match the key(s) defined by the pattern $patternString."
     )
     stringBuilder.append("\nPlease fix the relationship constraints:")
 
@@ -217,13 +223,16 @@ object PatternConstraintValidator {
 
     stringBuilder.append("\nExpected constraints:")
     stringBuilder.append(
-        "\n\t- ${getConstraintWarningText(ConstraintType.RELATIONSHIP_KEY.value, keys)}")
+        "\n\t- ${getConstraintWarningText(ConstraintType.RELATIONSHIP_KEY.value, keys)}"
+    )
     stringBuilder.append("\nor:")
     stringBuilder.append(
-        "\n\t- ${getConstraintWarningText(ConstraintType.RELATIONSHIP_UNIQUENESS.value, keys)}")
+        "\n\t- ${getConstraintWarningText(ConstraintType.RELATIONSHIP_UNIQUENESS.value, keys)}"
+    )
     for (key in keys) {
       stringBuilder.append(
-          "\n\t- ${getConstraintWarningText(ConstraintType.RELATIONSHIP_EXISTENCE.value, listOf(key))}")
+          "\n\t- ${getConstraintWarningText(ConstraintType.RELATIONSHIP_EXISTENCE.value, listOf(key))}"
+      )
     }
     return stringBuilder.toString()
   }
@@ -231,7 +240,7 @@ object PatternConstraintValidator {
   private fun addLabelConstraintsText(
       pattern: NodePattern,
       typeConstraintMap: Map<String, List<ConstraintData>>,
-      stringBuilder: StringBuilder
+      stringBuilder: StringBuilder,
   ) {
     for (label in pattern.labels) {
       val labelConstraints = getLabelConstraints(typeConstraintMap, label)
@@ -242,7 +251,7 @@ object PatternConstraintValidator {
   private fun addExistingConstraints(
       constraints: MutableList<ConstraintData>,
       labelOrType: String,
-      stringBuilder: StringBuilder
+      stringBuilder: StringBuilder,
   ) {
     if (constraints.isNotEmpty()) {
       stringBuilder.append("\n\t'$labelOrType' has:")
@@ -253,7 +262,7 @@ object PatternConstraintValidator {
                   constraint.constraintType,
                   constraint.properties,
               )
-            }",
+            }"
         )
       }
     } else {
@@ -266,34 +275,34 @@ object PatternConstraintValidator {
 
   private fun getLabelConstraints(
       typeConstraintMap: Map<String, List<ConstraintData>>,
-      label: String
+      label: String,
   ): MutableList<ConstraintData> {
     val labelConstraints = mutableListOf<ConstraintData>()
     labelConstraints.addAll(
-        typeConstraintMap["${ConstraintType.NODE_KEY.value}-${label}"] ?: emptyList(),
+        typeConstraintMap["${ConstraintType.NODE_KEY.value}-${label}"] ?: emptyList()
     )
     labelConstraints.addAll(
-        typeConstraintMap["${ConstraintType.NODE_UNIQUENESS.value}-${label}"] ?: emptyList(),
+        typeConstraintMap["${ConstraintType.NODE_UNIQUENESS.value}-${label}"] ?: emptyList()
     )
     labelConstraints.addAll(
-        typeConstraintMap["${ConstraintType.NODE_EXISTENCE.value}-${label}"] ?: emptyList(),
+        typeConstraintMap["${ConstraintType.NODE_EXISTENCE.value}-${label}"] ?: emptyList()
     )
     return labelConstraints
   }
 
   private fun getRelationshipConstraints(
       typeConstraintMap: Map<String, List<ConstraintData>>,
-      type: String
+      type: String,
   ): MutableList<ConstraintData> {
     val relationshipConstraints = mutableListOf<ConstraintData>()
     relationshipConstraints.addAll(
-        typeConstraintMap["${ConstraintType.RELATIONSHIP_KEY.value}-${type}"] ?: emptyList(),
+        typeConstraintMap["${ConstraintType.RELATIONSHIP_KEY.value}-${type}"] ?: emptyList()
     )
     relationshipConstraints.addAll(
-        typeConstraintMap["${ConstraintType.RELATIONSHIP_UNIQUENESS.value}-${type}"] ?: emptyList(),
+        typeConstraintMap["${ConstraintType.RELATIONSHIP_UNIQUENESS.value}-${type}"] ?: emptyList()
     )
     relationshipConstraints.addAll(
-        typeConstraintMap["${ConstraintType.RELATIONSHIP_EXISTENCE.value}-${type}"] ?: emptyList(),
+        typeConstraintMap["${ConstraintType.RELATIONSHIP_EXISTENCE.value}-${type}"] ?: emptyList()
     )
     return relationshipConstraints
   }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/RelationshipPattern.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/RelationshipPattern.kt
@@ -23,7 +23,7 @@ data class RelationshipPattern(
     override val includeAllValueProperties: Boolean,
     override val keyProperties: Set<PropertyMapping>,
     override val includeProperties: Set<PropertyMapping>,
-    override val excludeProperties: Set<String>
+    override val excludeProperties: Set<String>,
 ) : Pattern {
   override val text: String
     get() {

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/Visitors.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/Visitors.kt
@@ -39,11 +39,12 @@ internal object Visitors {
               line: Int,
               charPositionInLine: Int,
               msg: String,
-              e: RecognitionException?
+              e: RecognitionException?,
           ) {
             errors.add(String.format("line %d:%d, %s", line, charPositionInLine, msg))
           }
-        })
+        }
+    )
 
     val pattern = parser.pattern()
 
@@ -82,18 +83,23 @@ internal object Visitors {
               relPattern.properties().propertySelector().propSelector(),
               keyProperties,
               includeProperties,
-              excludeProperties)
+              excludeProperties,
+          )
         }
 
         val startNode =
             enforceKeyProperties(
                 visitCypherNodePattern(
-                    ctx.cypherNodePattern(if ((relPattern.rightArrow() != null)) 0 else 1)))
+                    ctx.cypherNodePattern(if ((relPattern.rightArrow() != null)) 0 else 1)
+                )
+            )
 
         val endNode =
             enforceKeyProperties(
                 visitCypherNodePattern(
-                    ctx.cypherNodePattern(if ((relPattern.rightArrow() != null)) 1 else 0)))
+                    ctx.cypherNodePattern(if ((relPattern.rightArrow() != null)) 1 else 0)
+                )
+            )
 
         return ensureImplicitWildcard(
             RelationshipPattern(
@@ -103,11 +109,14 @@ internal object Visitors {
                 includeProperties.contains(PropertyMapping.WILDCARD),
                 keyProperties,
                 includeProperties.filter { it != PropertyMapping.WILDCARD }.toSet(),
-                excludeProperties))
+                excludeProperties,
+            )
+        )
       }
 
       return ensureImplicitWildcard(
-          enforceKeyProperties(visitCypherNodePattern(ctx.cypherNodePattern(0))))
+          enforceKeyProperties(visitCypherNodePattern(ctx.cypherNodePattern(0)))
+      )
     }
 
     override fun visitSimplePattern(ctx: PatternParser.SimplePatternContext): Pattern {
@@ -122,7 +131,8 @@ internal object Visitors {
               relPattern.properties().propertySelector().propSelector(),
               keyProperties,
               includeProperties,
-              excludeProperties)
+              excludeProperties,
+          )
         }
 
         val startNode = enforceKeyProperties(visitSimpleNodePattern(ctx.simpleNodePattern(0)))
@@ -136,11 +146,14 @@ internal object Visitors {
                 includeProperties.contains(PropertyMapping.WILDCARD),
                 keyProperties,
                 includeProperties.filter { it != PropertyMapping.WILDCARD }.toSet(),
-                excludeProperties))
+                excludeProperties,
+            )
+        )
       }
 
       return ensureImplicitWildcard(
-          enforceKeyProperties(visitSimpleNodePattern(ctx.simpleNodePattern(0))))
+          enforceKeyProperties(visitSimpleNodePattern(ctx.simpleNodePattern(0)))
+      )
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -149,7 +162,12 @@ internal object Visitors {
         is NodePattern -> {
           if (pattern.includeProperties.isEmpty()) {
             return NodePattern(
-                pattern.labels, true, pattern.keyProperties, emptySet(), pattern.excludeProperties)
+                pattern.labels,
+                true,
+                pattern.keyProperties,
+                emptySet(),
+                pattern.excludeProperties,
+            )
                 as T
           }
         }
@@ -162,7 +180,8 @@ internal object Visitors {
                 true,
                 pattern.keyProperties,
                 emptySet(),
-                pattern.excludeProperties)
+                pattern.excludeProperties,
+            )
                 as T
           }
         }
@@ -184,12 +203,14 @@ internal object Visitors {
     private fun enforceExplicitInclusionOnly(pattern: NodePattern): NodePattern {
       if (pattern.excludeProperties.isNotEmpty()) {
         throw PatternException(
-            "Property exclusions are not allowed on start and end node patterns.")
+            "Property exclusions are not allowed on start and end node patterns."
+        )
       }
 
       if (pattern.includeAllValueProperties) {
         throw PatternException(
-            "Wildcard property inclusion is not allowed on start and end node patterns.")
+            "Wildcard property inclusion is not allowed on start and end node patterns."
+        )
       }
 
       return pattern
@@ -229,7 +250,8 @@ internal object Visitors {
           includeProperties.contains(PropertyMapping.WILDCARD),
           keyProperties,
           includeProperties.filter { it != PropertyMapping.WILDCARD }.toSet(),
-          excludeProperties)
+          excludeProperties,
+      )
     }
 
     private fun extractPropertySelectors(
@@ -243,7 +265,8 @@ internal object Visitors {
           includeProperties.add(PropertyMapping.WILDCARD)
         } else if (child.MINUS() != null) {
           excludeProperties.add(
-              PropertyKeyNameVisitor.visitPropertyKeyName(child.propertyKeyName()))
+              PropertyKeyNameVisitor.visitPropertyKeyName(child.propertyKeyName())
+          )
         } else if (child.EXCLAMATION() != null) {
           keyProperties += extractPropertyNameOrAlias(child.propertyKeyNameOrAlias())
         } else {
@@ -266,9 +289,12 @@ internal object Visitors {
     } else {
       PropertyMapping(
           PropertyKeyNameVisitor.visitPropertyKeyName(
-              ctx.aliasedPropertyKeyName().propertyKeyName(1)),
+              ctx.aliasedPropertyKeyName().propertyKeyName(1)
+          ),
           PropertyKeyNameVisitor.visitPropertyKeyName(
-              ctx.aliasedPropertyKeyName().propertyKeyName(0)))
+              ctx.aliasedPropertyKeyName().propertyKeyName(0)
+          ),
+      )
     }
   }
 

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/Cypher5RendererTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/Cypher5RendererTest.kt
@@ -53,74 +53,100 @@ class Cypher5RendererTest {
   class Cypher5PrefixSupportedVersions : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 21, 0),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(5, 21, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(5, 21, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 21, 0),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 26, 0),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(5, 26, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(5, 26, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 26, 0),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 26, 2),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(5, 26, 2), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(5, 26, 2), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 26, 2),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 27, 0),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(5, 27, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(5, 27, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 27, 0),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(2025, 1, 0),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(2025, 1, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(2025, 1, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(2025, 1, 0),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(
-                  Neo4jVersion.LATEST, Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)),
+              Neo4j(Neo4jVersion.LATEST, Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion.LATEST, Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion.LATEST, Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
       )
     }
   }
@@ -128,43 +154,56 @@ class Cypher5RendererTest {
   class UnsupportedCypher5PrefixVersions : ArgumentsProvider {
     override fun provideArguments(
         parameters: ParameterDeclarations?,
-        context: ExtensionContext?
+        context: ExtensionContext?,
     ): Stream<out Arguments?>? {
       return Stream.of(
           Arguments.of(
               Neo4j(
                   Neo4jVersion(4, 4, 41),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(4, 4, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(4, 4, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(4, 4, 41),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 8, 0),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(5, 8, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(5, 8, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
-              Neo4j(
-                  Neo4jVersion(5, 8, 0), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)),
+              Neo4j(Neo4jVersion(5, 8, 0), Neo4jEdition.COMMUNITY, Neo4jDeploymentType.SELF_MANAGED)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 20, 0),
                   Neo4jEdition.ENTERPRISE,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
           Arguments.of(
-              Neo4j(Neo4jVersion(5, 20, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)),
+              Neo4j(Neo4jVersion(5, 20, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.AURA)
+          ),
           Arguments.of(
               Neo4j(
                   Neo4jVersion(5, 20, 0),
                   Neo4jEdition.COMMUNITY,
-                  Neo4jDeploymentType.SELF_MANAGED)),
+                  Neo4jDeploymentType.SELF_MANAGED,
+              )
+          ),
       )
     }
   }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/SinkConfigurationTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/SinkConfigurationTest.kt
@@ -48,7 +48,8 @@ class SinkConfigurationTest {
               Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
               SinkConnector.TOPICS_CONFIG to "foo, bar",
               "${SinkConfiguration.CYPHER_TOPIC_PREFIX}foo" to
-                  "CREATE (p:Person{name: event.firstName})")
+                  "CREATE (p:Person{name: event.firstName})",
+          )
       SinkConfiguration(originals, Renderer.getDefaultRenderer())
     } shouldHaveMessage "Topic 'bar' is not assigned a sink strategy"
   }
@@ -65,7 +66,8 @@ class SinkConfigurationTest {
                   "CREATE (p:Person{name: event.firstName})",
               "${SinkConfiguration.CYPHER_TOPIC_PREFIX}bar" to
                   "CREATE (p:Person{name: event.firstName})",
-              SinkConfiguration.CDC_SOURCE_ID_TOPICS to "foo")
+              SinkConfiguration.CDC_SOURCE_ID_TOPICS to "foo",
+          )
 
       SinkConfiguration(originals, Renderer.getDefaultRenderer())
     } shouldHaveMessage "Topic 'foo' has multiple strategies defined"
@@ -81,7 +83,8 @@ class SinkConfigurationTest {
             "${SinkConfiguration.CYPHER_TOPIC_PREFIX}foo" to
                 "CREATE (p:Person{name: event.firstName})",
             SinkConfiguration.BATCH_SIZE to "10",
-            Neo4jConfiguration.DATABASE to "customers")
+            Neo4jConfiguration.DATABASE to "customers",
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.batchSize shouldBe 10
@@ -100,7 +103,8 @@ class SinkConfigurationTest {
             SinkConnector.TOPICS_CONFIG to "bar,foo",
             "${SinkConfiguration.PATTERN_TOPIC_PREFIX}foo" to "(:Foo{!fooId,fooName})",
             "${SinkConfiguration.PATTERN_TOPIC_PREFIX}bar" to "(:Bar{!barId,barName})",
-            SinkConfiguration.BATCH_SIZE to "10")
+            SinkConfiguration.BATCH_SIZE to "10",
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.batchSize shouldBe 10
@@ -112,7 +116,8 @@ class SinkConfigurationTest {
             false,
             setOf(PropertyMapping("fooId", "fooId")),
             setOf(PropertyMapping("fooName", "fooName")),
-            emptySet())
+            emptySet(),
+        )
 
     config.topicHandlers shouldHaveKey "bar"
     config.topicHandlers["bar"] shouldBe instanceOf<NodePatternHandler>()
@@ -122,7 +127,8 @@ class SinkConfigurationTest {
             false,
             setOf(PropertyMapping("barId", "barId")),
             setOf(PropertyMapping("barName", "barName")),
-            emptySet())
+            emptySet(),
+        )
   }
 
   @Test
@@ -136,7 +142,8 @@ class SinkConfigurationTest {
             SinkConnector.TOPICS_CONFIG to "bar,foo",
             SinkConfiguration.CDC_SOURCE_ID_TOPICS to "bar,foo",
             SinkConfiguration.CDC_SOURCE_ID_LABEL_NAME to testLabel,
-            SinkConfiguration.CDC_SOURCE_ID_PROPERTY_NAME to testId)
+            SinkConfiguration.CDC_SOURCE_ID_PROPERTY_NAME to testId,
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.topicHandlers shouldHaveKey "foo"
@@ -215,7 +222,8 @@ class SinkConfigurationTest {
             Neo4jConfiguration.URI to "bolt://neo4j:7687",
             Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
             SinkConnector.TOPICS_CONFIG to "bar",
-            SinkConfiguration.CYPHER_TOPIC_PREFIX + "bar" to "RETURN 1")
+            SinkConfiguration.CYPHER_TOPIC_PREFIX + "bar" to "RETURN 1",
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.userAgentComment() shouldBe "cypher"
@@ -230,7 +238,8 @@ class SinkConfigurationTest {
             Neo4jConfiguration.URI to "bolt://neo4j:7687",
             Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
             SinkConnector.TOPICS_CONFIG to "bar",
-            SinkConfiguration.PATTERN_TOPIC_PREFIX + "bar" to "Label{!id}")
+            SinkConfiguration.PATTERN_TOPIC_PREFIX + "bar" to "Label{!id}",
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.userAgentComment() shouldBe "node-pattern"
@@ -246,7 +255,8 @@ class SinkConfigurationTest {
             Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
             SinkConnector.TOPICS_CONFIG to "bar",
             SinkConfiguration.PATTERN_TOPIC_PREFIX + "bar" to
-                "LabelA{!id} REL_TYPE{id} LabelB{!targetId}")
+                "LabelA{!id} REL_TYPE{id} LabelB{!targetId}",
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.userAgentComment() shouldBe "relationship-pattern"
@@ -264,7 +274,8 @@ class SinkConfigurationTest {
             SinkConfiguration.CUD_TOPICS to "baz",
             SinkConfiguration.CDC_SOURCE_ID_TOPICS to "foo",
             SinkConfiguration.PATTERN_TOPIC_PREFIX + "bar" to
-                "LabelA{!id} REL_TYPE{id} LabelB{!targetId}")
+                "LabelA{!id} REL_TYPE{id} LabelB{!targetId}",
+        )
     val config = SinkConfiguration(originals, Renderer.getDefaultRenderer())
 
     config.userAgentComment() shouldBe "cdc-source-id; cud; relationship-pattern"

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/converters/MapValueConverterTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/converters/MapValueConverterTest.kt
@@ -98,19 +98,24 @@ class MapValueConverterTest {
                       Struct(LI_SCHEMA).put("value", "First UL - First Element"),
                       Struct(LI_SCHEMA)
                           .put("value", "First UL - Second Element")
-                          .put("class", listOf("ClassA", "ClassB"))))
+                          .put("class", listOf("ClassA", "ClassB")),
+                  ),
+              )
       val secondUL =
           Struct(UL_SCHEMA)
               .put(
                   "value",
                   listOf(
                       Struct(LI_SCHEMA).put("value", "Second UL - First Element"),
-                      Struct(LI_SCHEMA).put("value", "Second UL - Second Element")))
+                      Struct(LI_SCHEMA).put("value", "Second UL - Second Element"),
+                  ),
+              )
       val ulList = listOf(firstUL, secondUL)
       val pList =
           listOf(
               Struct(P_SCHEMA).put("value", "First Paragraph"),
-              Struct(P_SCHEMA).put("value", "Second Paragraph"))
+              Struct(P_SCHEMA).put("value", "Second Paragraph"),
+          )
       return Struct(BODY_SCHEMA).put("ul", ulList).put("p", pList)
     }
 
@@ -122,13 +127,18 @@ class MapValueConverterTest {
                       mapOf("value" to "First UL - First Element", "class" to null),
                       mapOf(
                           "value" to "First UL - Second Element",
-                          "class" to listOf("ClassA", "ClassB"))))
+                          "class" to listOf("ClassA", "ClassB"),
+                      ),
+                  )
+          )
       val secondULMap =
           mapOf(
               "value" to
                   listOf(
                       mapOf("value" to "Second UL - First Element", "class" to null),
-                      mapOf("value" to "Second UL - Second Element", "class" to null)))
+                      mapOf("value" to "Second UL - Second Element", "class" to null),
+                  )
+          )
       val ulListMap = listOf(firstULMap, secondULMap)
       val pListMap =
           listOf(mapOf("value" to "First Paragraph"), mapOf("value" to "Second Paragraph"))

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/converters/Neo4jValueConverterNestedStructTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/converters/Neo4jValueConverterNestedStructTest.kt
@@ -100,7 +100,8 @@ class Neo4jValueConverterNestedStructTest {
                     Struct(PREF_SCHEMA)
                         .put("preferenceType", it["preferenceType"])
                         .put("endEffectiveDate", it["endEffectiveDate"])
-                  })
+                  },
+              )
 
       val emailList = listOf(email)
       val tnsList =
@@ -113,7 +114,8 @@ class Neo4jValueConverterNestedStructTest {
                       Struct(PREF_SCHEMA)
                           .put("preferenceType", it["preferenceType"])
                           .put("endEffectiveDate", it["endEffectiveDate"])
-                    })
+                    },
+                )
           }
 
       return Struct(EVENT_SCHEMA)

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/converters/Neo4jValueConverterTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/converters/Neo4jValueConverterTest.kt
@@ -100,7 +100,8 @@ class Neo4jValueConverterTest {
     assertTrue { int64Timestamp is LocalDateTime }
     assertEquals(
         Date.from(Instant.ofEpochMilli(789)).toInstant().atZone(utc).toLocalDateTime(),
-        int64Timestamp)
+        int64Timestamp,
+    )
 
     val int32 = result["int32"]
     assertTrue { int32 is Int }
@@ -109,12 +110,16 @@ class Neo4jValueConverterTest {
     val int32Date = result["int32Date"]
     assertTrue { int32Date is LocalDate }
     assertEquals(
-        Date.from(Instant.ofEpochMilli(456)).toInstant().atZone(utc).toLocalDate(), int32Date)
+        Date.from(Instant.ofEpochMilli(456)).toInstant().atZone(utc).toLocalDate(),
+        int32Date,
+    )
 
     val int32Time = result["int32Time"]
     assertTrue { int32Time is LocalTime }
     assertEquals(
-        Date.from(Instant.ofEpochMilli(123)).toInstant().atZone(utc).toLocalTime(), int32Time)
+        Date.from(Instant.ofEpochMilli(123)).toInstant().atZone(utc).toLocalTime(),
+        int32Time,
+    )
 
     val nullField = result["nullField"]
     assertTrue { nullField == null }
@@ -198,7 +203,9 @@ class Neo4jValueConverterTest {
                     "long" to long,
                     "bigDouble" to bigDouble,
                     "string" to string,
-                    "date" to date))
+                    "date" to date,
+                )
+            )
 
     assertEquals(double, result["double"])
     assertEquals(long, result["long"])
@@ -236,7 +243,8 @@ class Neo4jValueConverterTest {
                 Struct(propertiesStruct)
                     .put("ID_NUM", 36950L)
                     .put("EMP_NAME", "Edythe")
-                    .put("PHONE", "3333"))
+                    .put("PHONE", "3333"),
+            )
 
     val actual = Neo4jValueConverter().convert(cudStruct) as Map<*, *>
     val expected =
@@ -246,7 +254,8 @@ class Neo4jValueConverterTest {
             "op" to "merge",
             "ids" to mapOf<String, Any?>("ID_NUM" to 36950L),
             "properties" to
-                mapOf<String, Any?>("ID_NUM" to 36950L, "EMP_NAME" to "Edythe", "PHONE" to "3333"))
+                mapOf<String, Any?>("ID_NUM" to 36950L, "EMP_NAME" to "Edythe", "PHONE" to "3333"),
+        )
     assertEquals(expected, actual)
   }
 
@@ -291,13 +300,15 @@ class Neo4jValueConverterTest {
                 Struct(fromNodeStruct)
                     .put("ids", Struct(fromIdStruct).put("person_id", 1L))
                     .put("op", "match")
-                    .put("labels", listOf("Person")))
+                    .put("labels", listOf("Person")),
+            )
             .put(
                 "to",
                 Struct(toNodeStruct)
                     .put("ids", Struct(toIdStruct).put("product_id", 10L))
                     .put("op", "merge")
-                    .put("labels", listOf("Product")))
+                    .put("labels", listOf("Product")),
+            )
             .put("properties", Struct(propertiesStruct).put("quantity", 10).put("year", "2023"))
 
     val actual = Neo4jValueConverter().convert(cudStruct) as Map<*, *>
@@ -310,13 +321,16 @@ class Neo4jValueConverterTest {
                 mapOf<String, Any?>(
                     "ids" to mapOf<String, Any?>("person_id" to 1L),
                     "labels" to listOf("Person"),
-                    "op" to "match"),
+                    "op" to "match",
+                ),
             "to" to
                 mapOf<String, Any?>(
                     "ids" to mapOf<String, Any?>("product_id" to 10L),
                     "labels" to listOf("Product"),
-                    "op" to "merge"),
-            "properties" to mapOf<String, Any?>("quantity" to 10, "year" to "2023"))
+                    "op" to "merge",
+                ),
+            "properties" to mapOf<String, Any?>("quantity" to 10, "year" to "2023"),
+        )
     assertEquals(expected, actual)
   }
 
@@ -378,7 +392,9 @@ class Neo4jValueConverterTest {
                     BigDecimal.valueOf(123.4),
                     Decimal.LOGICAL_NAME,
                     null,
-                    null))
+                    null,
+                ),
+            )
             .field(
                 "largeDecimal",
                 ConnectSchema(
@@ -387,14 +403,24 @@ class Neo4jValueConverterTest {
                     BigDecimal.valueOf(Double.MAX_VALUE).pow(2),
                     Decimal.LOGICAL_NAME,
                     null,
-                    null))
+                    null,
+                ),
+            )
             .field(
                 "byteArray",
                 ConnectSchema(
-                    Schema.Type.BYTES, false, "Foo".toByteArray(), "name.byteArray", null, null))
+                    Schema.Type.BYTES,
+                    false,
+                    "Foo".toByteArray(),
+                    "name.byteArray",
+                    null,
+                    null,
+                ),
+            )
             .field(
                 "int64",
-                ConnectSchema(Schema.Type.INT64, false, Long.MAX_VALUE, "name.int64", null, null))
+                ConnectSchema(Schema.Type.INT64, false, Long.MAX_VALUE, "name.int64", null, null),
+            )
             .field(
                 "int64Timestamp",
                 ConnectSchema(
@@ -403,7 +429,9 @@ class Neo4jValueConverterTest {
                     Date.from(Instant.ofEpochMilli(789)),
                     Timestamp.LOGICAL_NAME,
                     null,
-                    null))
+                    null,
+                ),
+            )
             .field("int32", ConnectSchema(Schema.Type.INT32, false, 123, "name.int32", null, null))
             .field(
                 "int32Date",
@@ -413,7 +441,9 @@ class Neo4jValueConverterTest {
                     Date.from(Instant.ofEpochMilli(456)),
                     org.apache.kafka.connect.data.Date.LOGICAL_NAME,
                     null,
-                    null))
+                    null,
+                ),
+            )
             .field(
                 "int32Time",
                 ConnectSchema(
@@ -422,13 +452,17 @@ class Neo4jValueConverterTest {
                     Date.from(Instant.ofEpochMilli(123)),
                     Time.LOGICAL_NAME,
                     null,
-                    null))
+                    null,
+                ),
+            )
             .field(
                 "nullField",
-                ConnectSchema(Schema.Type.INT64, false, null, Time.LOGICAL_NAME, null, null))
+                ConnectSchema(Schema.Type.INT64, false, null, Time.LOGICAL_NAME, null, null),
+            )
             .field(
                 "nullFieldBytes",
-                ConnectSchema(Schema.Type.BYTES, false, null, Time.LOGICAL_NAME, null, null))
+                ConnectSchema(Schema.Type.BYTES, false, null, Time.LOGICAL_NAME, null, null),
+            )
             .build()
 
     fun getTreeStruct(): Struct? {
@@ -440,19 +474,24 @@ class Neo4jValueConverterTest {
                       Struct(LI_SCHEMA).put("value", "First UL - First Element"),
                       Struct(LI_SCHEMA)
                           .put("value", "First UL - Second Element")
-                          .put("class", listOf("ClassA", "ClassB"))))
+                          .put("class", listOf("ClassA", "ClassB")),
+                  ),
+              )
       val secondUL =
           Struct(UL_SCHEMA)
               .put(
                   "value",
                   listOf(
                       Struct(LI_SCHEMA).put("value", "Second UL - First Element"),
-                      Struct(LI_SCHEMA).put("value", "Second UL - Second Element")))
+                      Struct(LI_SCHEMA).put("value", "Second UL - Second Element"),
+                  ),
+              )
       val ulList = listOf(firstUL, secondUL)
       val pList =
           listOf(
               Struct(P_SCHEMA).put("value", "First Paragraph"),
-              Struct(P_SCHEMA).put("value", "Second Paragraph"))
+              Struct(P_SCHEMA).put("value", "Second Paragraph"),
+          )
       return Struct(BODY_SCHEMA).put("ul", ulList).put("p", pList)
     }
 
@@ -464,13 +503,18 @@ class Neo4jValueConverterTest {
                       mapOf("value" to "First UL - First Element", "class" to null),
                       mapOf(
                           "value" to "First UL - Second Element",
-                          "class" to listOf("ClassA", "ClassB"))))
+                          "class" to listOf("ClassA", "ClassB"),
+                      ),
+                  )
+          )
       val secondULMap =
           mapOf(
               "value" to
                   listOf(
                       mapOf("value" to "Second UL - First Element", "class" to null),
-                      mapOf("value" to "Second UL - Second Element", "class" to null)))
+                      mapOf("value" to "Second UL - Second Element", "class" to null),
+                  )
+          )
       val ulListMap = listOf(firstULMap, secondULMap)
       val pListMap =
           listOf(mapOf("value" to "First Paragraph"), mapOf("value" to "Second Paragraph"))
@@ -485,13 +529,18 @@ class Neo4jValueConverterTest {
                       mapOf("value" to "First UL - First Element", "class" to null),
                       mapOf(
                           "value" to "First UL - Second Element",
-                          "class" to listOf("ClassA", "ClassB"))))
+                          "class" to listOf("ClassA", "ClassB"),
+                      ),
+                  )
+          )
       val secondULMap =
           mapOf(
               "value" to
                   listOf(
                       mapOf("value" to "Second UL - First Element", "class" to null),
-                      mapOf("value" to "Second UL - Second Element", "class" to null)))
+                      mapOf("value" to "Second UL - Second Element", "class" to null),
+                  )
+          )
       val ulListMap = listOf(firstULMap, secondULMap)
       val pListMap =
           listOf(mapOf("value" to "First Paragraph"), mapOf("value" to "Second Paragraph"))

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSchemaHandlerTest.kt
@@ -123,7 +123,7 @@ class CdcSchemaHandlerTest {
               .also {
                 it shouldHaveMessage
                     Regex(
-                        "^schema strategy requires at least one node key with valid properties on node aliased '(n|start|end)'.$",
+                        "^schema strategy requires at least one node key with valid properties on node aliased '(n|start|end)'.$"
                     )
               }
         }
@@ -141,11 +141,7 @@ class CdcSchemaHandlerTest {
                 null,
                 NodeState(
                     listOf("Person"),
-                    mapOf(
-                        "name" to "john",
-                        "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1),
-                    ),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
                 ),
             ),
             1,
@@ -172,8 +168,8 @@ class CdcSchemaHandlerTest {
                                 ),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
 
@@ -187,11 +183,7 @@ class CdcSchemaHandlerTest {
                 null,
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf(
-                        "name" to "john",
-                        "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1),
-                    ),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
                 ),
             ),
             1,
@@ -218,8 +210,8 @@ class CdcSchemaHandlerTest {
                                 ),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -236,11 +228,7 @@ class CdcSchemaHandlerTest {
                 NodeState(listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe")),
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf(
-                        "name" to "john",
-                        "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1),
-                    ),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
                 ),
             ),
             1,
@@ -262,8 +250,8 @@ class CdcSchemaHandlerTest {
                             "nProps" to mapOf("name" to "john", "dob" to LocalDate.of(1990, 1, 1)),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
 
@@ -280,11 +268,7 @@ class CdcSchemaHandlerTest {
                 ),
                 NodeState(
                     listOf("Person", "Manager"),
-                    mapOf(
-                        "name" to "john",
-                        "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1),
-                    ),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
                 ),
             ),
             1,
@@ -311,8 +295,8 @@ class CdcSchemaHandlerTest {
                                 ),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
 
@@ -332,11 +316,7 @@ class CdcSchemaHandlerTest {
                 ),
                 NodeState(
                     listOf("Person", "Manager"),
-                    mapOf(
-                        "name" to "john",
-                        "surname" to "doe",
-                        "dob" to LocalDate.of(1990, 1, 1),
-                    ),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
                 ),
             ),
             1,
@@ -364,8 +344,8 @@ class CdcSchemaHandlerTest {
                                 ),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -400,8 +380,8 @@ class CdcSchemaHandlerTest {
                         "MATCH (n:`Person` {name: ${'$'}nName, surname: ${'$'}nSurname}) DETACH DELETE n",
                         mapOf("nName" to "joe", "nSurname" to "doe"),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -450,8 +430,8 @@ class CdcSchemaHandlerTest {
                             "rProps" to mapOf("since" to LocalDate.of(2000, 1, 1)),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -508,8 +488,8 @@ class CdcSchemaHandlerTest {
                             "rProps" to mapOf("since" to LocalDate.of(1999, 1, 1)),
                         ),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
 
@@ -550,13 +530,10 @@ class CdcSchemaHandlerTest {
                     Query(
                         "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
                             "SET r += ${'$'}rProps",
-                        mapOf(
-                            "rId" to 1001L,
-                            "rProps" to mapOf("name" to "joe"),
-                        ),
+                        mapOf("rId" to 1001L, "rProps" to mapOf("name" to "joe")),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -601,8 +578,8 @@ class CdcSchemaHandlerTest {
                             "DELETE r",
                         mapOf("startId" to 1L, "endId" to 2L),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
 
@@ -642,12 +619,10 @@ class CdcSchemaHandlerTest {
                     listOf(sinkMessage1),
                     Query(
                         "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " + "DELETE r",
-                        mapOf(
-                            "rId" to 1001L,
-                        ),
+                        mapOf("rId" to 1001L),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -665,7 +640,7 @@ class CdcSchemaHandlerTest {
                 newChangeEventMessage(randomChangeEvent(), 1, 0),
                 newChangeEventMessage(randomChangeEvent(), 1, 1),
                 newChangeEventMessage(randomChangeEvent(), 2, 0),
-            ),
+            )
         )
 
     result
@@ -706,12 +681,10 @@ class CdcSchemaHandlerTest {
             { third ->
               third
                   .shouldHaveSize(1)
-                  .shouldMatchInOrder(
-                      { q1 ->
-                        q1.txId shouldBe 2
-                        q1.seq shouldBe 0
-                      },
-                  )
+                  .shouldMatchInOrder({ q1 ->
+                    q1.txId shouldBe 2
+                    q1.seq shouldBe 0
+                  })
             },
         )
   }
@@ -784,10 +757,7 @@ class CdcSchemaHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
-                NodeState(
-                    listOf("Person", "Employee"),
-                    mapOf("name" to "joe", "surname" to "doe"),
-                ),
+                NodeState(listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe")),
             ),
             1,
             0,
@@ -914,8 +884,8 @@ class CdcSchemaHandlerTest {
                         "MATCH (n:`Person` {name: ${'$'}nName}) DETACH DELETE n",
                         mapOf("nName" to "john"),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -931,12 +901,7 @@ class CdcSchemaHandlerTest {
                     listOf("Person"),
                     mapOf("Person" to listOf(mapOf("name" to "john"), mapOf("invalid" to null))),
                     null,
-                    NodeState(
-                        listOf("Person"),
-                        mapOf(
-                            "name" to "john",
-                        ),
-                    ),
+                    NodeState(listOf("Person"), mapOf("name" to "john")),
                 ),
             txId = 1,
             seq = 0,
@@ -951,16 +916,10 @@ class CdcSchemaHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MERGE (n:`Person` {name: ${'$'}nName}) SET n = ${'$'}nProps",
-                        mapOf(
-                            "nName" to "john",
-                            "nProps" to
-                                mapOf(
-                                    "name" to "john",
-                                ),
-                        ),
+                        mapOf("nName" to "john", "nProps" to mapOf("name" to "john")),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -1026,11 +985,7 @@ class CdcSchemaHandlerTest {
                     listOf("Person"),
                     mapOf("Person" to listOf(mapOf("name" to "john"))),
                 ),
-                Node(
-                    "end-element-id",
-                    listOf("Person"),
-                    mapOf("Person" to emptyList()),
-                ),
+                Node("end-element-id", listOf("Person"), mapOf("Person" to emptyList())),
                 listOf(mapOf("id" to 1L)),
                 EntityOperation.CREATE,
                 null,
@@ -1196,16 +1151,10 @@ class CdcSchemaHandlerTest {
                     Query(
                         "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
                             "SET r += ${'$'}rProps",
-                        mapOf(
-                            "rId" to 1L,
-                            "rProps" to
-                                mapOf(
-                                    "since" to LocalDate.of(2000, 1, 1),
-                                ),
-                        ),
+                        mapOf("rId" to 1L, "rProps" to mapOf("since" to LocalDate.of(2000, 1, 1))),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -1247,16 +1196,10 @@ class CdcSchemaHandlerTest {
                     Query(
                         "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " +
                             "SET r += ${'$'}rProps",
-                        mapOf(
-                            "rId" to 1L,
-                            "rProps" to
-                                mapOf(
-                                    "since" to LocalDate.of(2000, 1, 1),
-                                ),
-                        ),
+                        mapOf("rId" to 1L, "rProps" to mapOf("since" to LocalDate.of(2000, 1, 1))),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -1413,12 +1356,10 @@ class CdcSchemaHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " + "DELETE r",
-                        mapOf(
-                            "rId" to 1L,
-                        ),
+                        mapOf("rId" to 1L),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -1459,12 +1400,10 @@ class CdcSchemaHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MATCH (start)-[r:`KNOWS` {id: ${'$'}rId}]->(end) " + "DELETE r",
-                        mapOf(
-                            "rId" to 1L,
-                        ),
+                        mapOf("rId" to 1L),
                     ),
-                ),
-            ),
+                )
+            )
         ),
     )
   }
@@ -1751,7 +1690,7 @@ class CdcSchemaHandlerTest {
         .also {
           it shouldHaveMessage
               Regex(
-                  "^schema strategy requires at least one node key with valid properties on node aliased '$alias'.$",
+                  "^schema strategy requires at least one node key with valid properties on node aliased '$alias'.$"
               )
         }
   }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSourceIdHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CdcSourceIdHandlerTest.kt
@@ -50,9 +50,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 emptyMap(),
                 null,
-                NodeState(emptyList(), mapOf("name" to "john", "surname" to "doe"))),
+                NodeState(emptyList(), mapOf("name" to "john", "surname" to "doe")),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -65,7 +67,13 @@ class CdcSourceIdHandlerTest {
                         "MERGE (n:`SourceEvent` {sourceElementId: ${'$'}nElementId}) SET n += ${'$'}nProps",
                         mapOf(
                             "nElementId" to "node-element-id",
-                            "nProps" to mapOf("name" to "john", "surname" to "doe")))))))
+                            "nProps" to mapOf("name" to "john", "surname" to "doe"),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -77,10 +85,12 @@ class CdcSourceIdHandlerTest {
                 null,
                 NodeState(
                     listOf("Person"),
-                    mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
+                ),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -97,7 +107,14 @@ class CdcSourceIdHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "surname" to "doe",
-                                    "dob" to LocalDate.of(1990, 1, 1))))))))
+                                    "dob" to LocalDate.of(1990, 1, 1),
+                                ),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
 
     val sinkMessage2 =
         newChangeEventMessage(
@@ -109,10 +126,12 @@ class CdcSourceIdHandlerTest {
                 null,
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
+                ),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage2),
         listOf(
@@ -129,7 +148,14 @@ class CdcSourceIdHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "surname" to "doe",
-                                    "dob" to LocalDate.of(1990, 1, 1))))))))
+                                    "dob" to LocalDate.of(1990, 1, 1),
+                                ),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
   }
 
   @Test
@@ -142,9 +168,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 emptyMap(),
                 NodeState(emptyList(), mapOf("name" to "john")),
-                NodeState(emptyList(), mapOf("name" to "joe", "dob" to LocalDate.of(2000, 1, 1)))),
+                NodeState(emptyList(), mapOf("name" to "joe", "dob" to LocalDate.of(2000, 1, 1))),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -157,8 +185,13 @@ class CdcSourceIdHandlerTest {
                         "MERGE (n:`SourceEvent` {sourceElementId: ${'$'}nElementId}) SET n += ${'$'}nProps",
                         mapOf(
                             "nElementId" to "node-element-id",
-                            "nProps" to
-                                mapOf("name" to "joe", "dob" to LocalDate.of(2000, 1, 1))))))))
+                            "nProps" to mapOf("name" to "joe", "dob" to LocalDate.of(2000, 1, 1)),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -170,10 +203,12 @@ class CdcSourceIdHandlerTest {
                 NodeState(listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe")),
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
+                ),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -186,8 +221,13 @@ class CdcSourceIdHandlerTest {
                         "MERGE (n:`SourceEvent` {sourceElementId: ${'$'}nElementId}) SET n += ${'$'}nProps",
                         mapOf(
                             "nElementId" to "node-element-id",
-                            "nProps" to
-                                mapOf("name" to "john", "dob" to LocalDate.of(1990, 1, 1))))))))
+                            "nProps" to mapOf("name" to "john", "dob" to LocalDate.of(1990, 1, 1)),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
 
     val sinkMessage2 =
         newChangeEventMessage(
@@ -198,13 +238,16 @@ class CdcSourceIdHandlerTest {
                 mapOf("Person" to listOf(mapOf("name" to "john", "surname" to "doe"))),
                 NodeState(
                     listOf("Person", "Employee"),
-                    mapOf("name" to "joe", "surname" to "doe", "married" to true)),
+                    mapOf("name" to "joe", "surname" to "doe", "married" to true),
+                ),
                 NodeState(
                     listOf("Person", "Manager"),
-                    mapOf(
-                        "name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)))),
+                    mapOf("name" to "john", "surname" to "doe", "dob" to LocalDate.of(1990, 1, 1)),
+                ),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage2),
         listOf(
@@ -221,7 +264,14 @@ class CdcSourceIdHandlerTest {
                                 mapOf(
                                     "name" to "john",
                                     "dob" to LocalDate.of(1990, 1, 1),
-                                    "married" to null)))))))
+                                    "married" to null,
+                                ),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
   }
 
   @Test
@@ -234,9 +284,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 emptyMap(),
                 NodeState(emptyList(), mapOf("name" to "joe", "dob" to LocalDate.of(2000, 1, 1))),
-                null),
+                null,
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -247,7 +299,12 @@ class CdcSourceIdHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MATCH (n:`SourceEvent` {sourceElementId: ${'$'}nElementId}) DETACH DELETE n",
-                        mapOf("nElementId" to "node-element-id"))))))
+                        mapOf("nElementId" to "node-element-id"),
+                    ),
+                )
+            )
+        ),
+    )
   }
 
   @Test
@@ -262,9 +319,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 EntityOperation.CREATE,
                 null,
-                RelationshipState(mapOf("name" to "john", "surname" to "doe"))),
+                RelationshipState(mapOf("name" to "john", "surname" to "doe")),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -282,7 +341,13 @@ class CdcSourceIdHandlerTest {
                             "startElementId" to "start-element-id",
                             "endElementId" to "end-element-id",
                             "rElementId" to "rel-element-id",
-                            "rProps" to mapOf("name" to "john", "surname" to "doe")))))))
+                            "rProps" to mapOf("name" to "john", "surname" to "doe"),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
   }
 
   @Test
@@ -297,9 +362,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 EntityOperation.UPDATE,
                 RelationshipState(emptyMap()),
-                RelationshipState(mapOf("name" to "john", "surname" to "doe"))),
+                RelationshipState(mapOf("name" to "john", "surname" to "doe")),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -317,7 +384,13 @@ class CdcSourceIdHandlerTest {
                             "startElementId" to "start-element-id",
                             "endElementId" to "end-element-id",
                             "rElementId" to "rel-element-id",
-                            "rProps" to mapOf("name" to "john", "surname" to "doe")))))))
+                            "rProps" to mapOf("name" to "john", "surname" to "doe"),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
 
     val sinkMessage1 =
         newChangeEventMessage(
@@ -329,9 +402,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("name" to "john", "surname" to "doe")),
-                RelationshipState(mapOf("name" to "joe", "surname" to "doe"))),
+                RelationshipState(mapOf("name" to "joe", "surname" to "doe")),
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage1),
         listOf(
@@ -349,7 +424,13 @@ class CdcSourceIdHandlerTest {
                             "startElementId" to "start-element-id",
                             "endElementId" to "end-element-id",
                             "rElementId" to "rel-element-id",
-                            "rProps" to mapOf("name" to "joe")))))))
+                            "rProps" to mapOf("name" to "joe"),
+                        ),
+                    ),
+                )
+            )
+        ),
+    )
   }
 
   @Test
@@ -364,9 +445,11 @@ class CdcSourceIdHandlerTest {
                 emptyList(),
                 EntityOperation.DELETE,
                 RelationshipState(emptyMap()),
-                null),
+                null,
+            ),
             0,
-            1)
+            1,
+        )
     verify(
         listOf(sinkMessage),
         listOf(
@@ -377,7 +460,12 @@ class CdcSourceIdHandlerTest {
                     listOf(sinkMessage),
                     Query(
                         "MATCH ()-[r:`REL` {sourceElementId: ${'$'}rElementId}]->() DELETE r",
-                        mapOf("rElementId" to "rel-element-id"))))))
+                        mapOf("rElementId" to "rel-element-id"),
+                    ),
+                )
+            )
+        ),
+    )
   }
 
   @Test
@@ -387,7 +475,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val result =
         handler.handle(
@@ -397,7 +486,9 @@ class CdcSourceIdHandlerTest {
                 newChangeEventMessage(randomChangeEvent(), 0, 2),
                 newChangeEventMessage(randomChangeEvent(), 1, 0),
                 newChangeEventMessage(randomChangeEvent(), 1, 1),
-                newChangeEventMessage(randomChangeEvent(), 2, 0)))
+                newChangeEventMessage(randomChangeEvent(), 2, 0),
+            )
+        )
 
     result
         .shouldHaveSize(3)
@@ -417,7 +508,8 @@ class CdcSourceIdHandlerTest {
                       { q3 ->
                         q3.txId shouldBe 0
                         q3.seq shouldBe 2
-                      })
+                      },
+                  )
             },
             { second ->
               second
@@ -430,7 +522,8 @@ class CdcSourceIdHandlerTest {
                       { q2 ->
                         q2.txId shouldBe 1
                         q2.seq shouldBe 1
-                      })
+                      },
+                  )
             },
             { third ->
               third
@@ -439,7 +532,8 @@ class CdcSourceIdHandlerTest {
                     q1.txId shouldBe 2
                     q1.seq shouldBe 0
                   })
-            })
+            },
+        )
   }
 
   @Test
@@ -449,7 +543,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val nodeChangeEventMessage =
         newChangeEventMessage(
@@ -459,9 +554,11 @@ class CdcSourceIdHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(nodeChangeEventMessage))
@@ -475,7 +572,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val relationshipChangeEventMessage =
         newChangeEventMessage(
@@ -485,17 +583,21 @@ class CdcSourceIdHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.CREATE,
                 null,
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(relationshipChangeEventMessage))
@@ -509,7 +611,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val nodeChangeEventMessage =
         newChangeEventMessage(
@@ -519,10 +622,11 @@ class CdcSourceIdHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 null,
-                NodeState(
-                    listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe"))),
+                NodeState(listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe")),
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(nodeChangeEventMessage))
@@ -536,7 +640,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val relationshipChangeEventMessage =
         newChangeEventMessage(
@@ -546,17 +651,21 @@ class CdcSourceIdHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.UPDATE,
                 null,
-                RelationshipState(mapOf("name" to "john", "surname" to "doe"))),
+                RelationshipState(mapOf("name" to "john", "surname" to "doe")),
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(relationshipChangeEventMessage))
@@ -570,7 +679,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val nodeChangeEventMessage =
         newChangeEventMessage(
@@ -580,9 +690,11 @@ class CdcSourceIdHandlerTest {
                 listOf("Person"),
                 mapOf("Person" to listOf(mapOf("id" to 1L))),
                 NodeState(listOf("Person", "Employee"), mapOf("name" to "joe", "surname" to "doe")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(nodeChangeEventMessage))
@@ -596,7 +708,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val relationshipChangeEventMessage =
         newChangeEventMessage(
@@ -606,17 +719,21 @@ class CdcSourceIdHandlerTest {
                 Node(
                     "start-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 1L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 1L))),
+                ),
                 Node(
                     "end-element-id",
                     listOf("Person"),
-                    mapOf("Person" to listOf(mapOf("id" to 2L)))),
+                    mapOf("Person" to listOf(mapOf("id" to 2L))),
+                ),
                 emptyList(),
                 EntityOperation.UPDATE,
                 RelationshipState(mapOf("name" to "john", "surname" to "doe")),
-                null),
+                null,
+            ),
             1,
-            0)
+            0,
+        )
 
     assertThrows<InvalidDataException> {
       handler.handle(listOf(relationshipChangeEventMessage))
@@ -629,7 +746,8 @@ class CdcSourceIdHandlerTest {
             "my-topic",
             Renderer.getRenderer(Configuration.defaultConfig()),
             "SourceEvent",
-            "sourceElementId")
+            "sourceElementId",
+        )
 
     val result = handler.handle(messages)
 

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CudHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CudHandlerTest.kt
@@ -46,7 +46,8 @@ class CudHandlerTest : HandlerTest() {
                     "foo": "foo-value"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -57,7 +58,11 @@ class CudHandlerTest : HandlerTest() {
                     Query(
                         CypherParser.parse("CREATE (n:`Foo`:`Bar` {}) SET n = ${'$'}properties")
                             .cypher,
-                        mapOf("properties" to mapOf("id" to 1, "foo" to "foo-value"))))))
+                        mapOf("properties" to mapOf("id" to 1, "foo" to "foo-value")),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -76,7 +81,8 @@ class CudHandlerTest : HandlerTest() {
                     "foo": "foo-value"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -86,7 +92,11 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse("CREATE (n {}) SET n = ${'$'}properties").cypher,
-                        mapOf("properties" to mapOf("id" to 1, "foo" to "foo-value"))))))
+                        mapOf("properties" to mapOf("id" to 1, "foo" to "foo-value")),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -109,7 +119,8 @@ class CudHandlerTest : HandlerTest() {
                     "foo": "foo-value"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -119,11 +130,17 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse(
-                                "MATCH (n:`Foo`:`Bar` {id: ${'$'}keys.id}) SET n += ${'$'}properties")
+                                "MATCH (n:`Foo`:`Bar` {id: ${'$'}keys.id}) SET n += ${'$'}properties"
+                            )
                             .cypher,
                         mapOf(
                             "keys" to mapOf("id" to 0),
-                            "properties" to mapOf("id" to 1, "foo" to "foo-value"))))))
+                            "properties" to mapOf("id" to 1, "foo" to "foo-value"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -145,7 +162,8 @@ class CudHandlerTest : HandlerTest() {
                     "foo": "foo-value"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -155,11 +173,17 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse(
-                                "MATCH (n {id: ${'$'}keys.id}) SET n += ${'$'}properties")
+                                "MATCH (n {id: ${'$'}keys.id}) SET n += ${'$'}properties"
+                            )
                             .cypher,
                         mapOf(
                             "keys" to mapOf("id" to 0),
-                            "properties" to mapOf("id" to 1, "foo" to "foo-value"))))))
+                            "properties" to mapOf("id" to 1, "foo" to "foo-value"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -182,7 +206,8 @@ class CudHandlerTest : HandlerTest() {
                     "foo": "foo-value"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -192,11 +217,17 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse(
-                                "MERGE (n:`Foo`:`Bar` {id: ${'$'}keys.id}) SET n += ${'$'}properties")
+                                "MERGE (n:`Foo`:`Bar` {id: ${'$'}keys.id}) SET n += ${'$'}properties"
+                            )
                             .cypher,
                         mapOf(
                             "keys" to mapOf("id" to 0),
-                            "properties" to mapOf("id" to 1, "foo" to "foo-value"))))))
+                            "properties" to mapOf("id" to 1, "foo" to "foo-value"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -218,7 +249,8 @@ class CudHandlerTest : HandlerTest() {
                     "foo": "foo-value"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -228,11 +260,17 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse(
-                                "MERGE (n {id: ${'$'}keys.id}) SET n += ${'$'}properties")
+                                "MERGE (n {id: ${'$'}keys.id}) SET n += ${'$'}properties"
+                            )
                             .cypher,
                         mapOf(
                             "keys" to mapOf("id" to 0),
-                            "properties" to mapOf("id" to 1, "foo" to "foo-value"))))))
+                            "properties" to mapOf("id" to 1, "foo" to "foo-value"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -252,7 +290,8 @@ class CudHandlerTest : HandlerTest() {
                   },
                   "detach": true
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -262,9 +301,14 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse(
-                                "MATCH (n:`Foo`:`Bar` {id: ${'$'}keys.id}) DETACH DELETE n")
+                                "MATCH (n:`Foo`:`Bar` {id: ${'$'}keys.id}) DETACH DELETE n"
+                            )
                             .cypher,
-                        mapOf("keys" to mapOf("id" to 0))))))
+                        mapOf("keys" to mapOf("id" to 0)),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -283,7 +327,8 @@ class CudHandlerTest : HandlerTest() {
                   },
                   "detach": true
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -293,7 +338,11 @@ class CudHandlerTest : HandlerTest() {
                     listOf(sinkMessage),
                     Query(
                         CypherParser.parse("MATCH (n {id: ${'$'}keys.id}) DETACH DELETE n").cypher,
-                        mapOf("keys" to mapOf("id" to 0))))))
+                        mapOf("keys" to mapOf("id" to 0)),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -312,7 +361,8 @@ class CudHandlerTest : HandlerTest() {
                     "id": 0
                   }                
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -323,7 +373,11 @@ class CudHandlerTest : HandlerTest() {
                     Query(
                         CypherParser.parse("MATCH (n:`Foo`:`Bar` {id: ${'$'}keys.id}) DELETE n")
                             .cypher,
-                        mapOf("keys" to mapOf("id" to 0))))))
+                        mapOf("keys" to mapOf("id" to 0)),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -354,7 +408,8 @@ class CudHandlerTest : HandlerTest() {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -369,12 +424,18 @@ class CudHandlerTest : HandlerTest() {
                               MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               CREATE (start)-[r:`RELATED_TO`]->(end)
                               SET r = ${'$'}properties
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
-                            "properties" to mapOf("by" to "incident"))))))
+                            "properties" to mapOf("by" to "incident"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -407,7 +468,8 @@ class CudHandlerTest : HandlerTest() {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -422,12 +484,18 @@ class CudHandlerTest : HandlerTest() {
                               MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               CREATE (start)-[r:`RELATED_TO`]->(end)
                               SET r = ${'$'}properties
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
-                            "properties" to mapOf("by" to "incident"))))))
+                            "properties" to mapOf("by" to "incident"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -459,7 +527,8 @@ class CudHandlerTest : HandlerTest() {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -474,13 +543,19 @@ class CudHandlerTest : HandlerTest() {
                               MERGE (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               MATCH (start)-[r:`RELATED_TO` {}]->(end)
                               SET r += ${'$'}properties
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
                             "keys" to emptyMap(),
-                            "properties" to mapOf("by" to "incident"))))))
+                            "properties" to mapOf("by" to "incident"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -515,7 +590,8 @@ class CudHandlerTest : HandlerTest() {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -530,13 +606,19 @@ class CudHandlerTest : HandlerTest() {
                               MERGE (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               MATCH (start)-[r:`RELATED_TO` {id: ${'$'}keys.id}]->(end)
                               SET r += ${'$'}properties
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
                             "keys" to mapOf("id" to 5),
-                            "properties" to mapOf("by" to "incident"))))))
+                            "properties" to mapOf("by" to "incident"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -568,7 +650,8 @@ class CudHandlerTest : HandlerTest() {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -583,13 +666,19 @@ class CudHandlerTest : HandlerTest() {
                               MERGE (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               MERGE (start)-[r:`RELATED_TO` {}]->(end)
                               SET r += ${'$'}properties
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
                             "keys" to emptyMap(),
-                            "properties" to mapOf("by" to "incident"))))))
+                            "properties" to mapOf("by" to "incident"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -624,7 +713,8 @@ class CudHandlerTest : HandlerTest() {
                     "by": "incident"
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -639,13 +729,19 @@ class CudHandlerTest : HandlerTest() {
                               MERGE (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               MERGE (start)-[r:`RELATED_TO` {id: ${'$'}keys.id}]->(end)
                               SET r += ${'$'}properties
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
                             "keys" to mapOf("id" to 5),
-                            "properties" to mapOf("by" to "incident"))))))
+                            "properties" to mapOf("by" to "incident"),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -673,7 +769,8 @@ class CudHandlerTest : HandlerTest() {
                     }
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -688,12 +785,18 @@ class CudHandlerTest : HandlerTest() {
                               MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               MATCH (start)-[r:`RELATED_TO` {}]->(end)
                               DELETE r
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
-                            "keys" to emptyMap())))))
+                            "keys" to emptyMap(),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -724,7 +827,8 @@ class CudHandlerTest : HandlerTest() {
                     "id": 5
                   }
                 }
-                """)
+                """,
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -739,12 +843,18 @@ class CudHandlerTest : HandlerTest() {
                               MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end
                               MATCH (start)-[r:`RELATED_TO` {id: ${'$'}keys.id}]->(end)
                               DELETE r
-                            """)
+                            """
+                            )
                             .cypher,
                         mapOf(
                             "start" to mapOf("keys" to mapOf("id" to 0)),
                             "end" to mapOf("keys" to mapOf("id" to 1)),
-                            "keys" to mapOf("id" to 5))))))
+                            "keys" to mapOf("id" to 5),
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @ParameterizedTest
@@ -763,14 +873,16 @@ class CudHandlerTest : HandlerTest() {
                         "type" to "NODE",
                         "op" to "CREATE",
                         "labels" to listOf("Foo"),
-                        "properties" to mapOf("id" to id))
+                        "properties" to mapOf("id" to id),
+                    )
                 1 ->
                     mapOf(
                         "type" to "NODE",
                         "op" to "UPDATE",
                         "labels" to listOf("Foo"),
                         "ids" to mapOf("id" to id),
-                        "properties" to mapOf("id" to id, "prop1" to "a value"))
+                        "properties" to mapOf("id" to id, "prop1" to "a value"),
+                    )
                 2 ->
                     mapOf(
                         "type" to "NODE",
@@ -778,13 +890,15 @@ class CudHandlerTest : HandlerTest() {
                         "labels" to listOf("Foo"),
                         "ids" to mapOf("id" to id),
                         "properties" to
-                            mapOf("id" to id, "prop1" to "a value", "prop2" to "b value"))
+                            mapOf("id" to id, "prop1" to "a value", "prop2" to "b value"),
+                    )
                 3 ->
                     mapOf(
                         "type" to "NODE",
                         "op" to "DELETE",
                         "labels" to listOf("Foo"),
-                        "ids" to mapOf("id" to id))
+                        "ids" to mapOf("id" to id),
+                    )
                 else -> throw IllegalArgumentException("unexpected")
               }
             }
@@ -805,26 +919,33 @@ class CudHandlerTest : HandlerTest() {
                     0 ->
                         Query(
                             "CREATE (n:`Foo` {}) SET n = ${'$'}properties",
-                            mapOf("properties" to mapOf("id" to id)))
+                            mapOf("properties" to mapOf("id" to id)),
+                        )
                     1 ->
                         Query(
                             "MATCH (n:`Foo` {id: ${'$'}keys.id}) SET n += ${'$'}properties",
                             mapOf(
                                 "keys" to mapOf("id" to id),
-                                "properties" to mapOf("id" to id, "prop1" to "a value")))
+                                "properties" to mapOf("id" to id, "prop1" to "a value"),
+                            ),
+                        )
                     2 ->
                         Query(
                             "MERGE (n:`Foo` {id: ${'$'}keys.id}) SET n += ${'$'}properties",
                             mapOf(
                                 "keys" to mapOf("id" to id),
                                 "properties" to
-                                    mapOf("id" to id, "prop1" to "a value", "prop2" to "b value")))
+                                    mapOf("id" to id, "prop1" to "a value", "prop2" to "b value"),
+                            ),
+                        )
                     3 ->
                         Query(
                             "MATCH (n:`Foo` {id: ${'$'}keys.id}) DELETE n",
-                            mapOf("keys" to mapOf("id" to id)))
+                            mapOf("keys" to mapOf("id" to id)),
+                        )
                     else -> throw IllegalArgumentException("unexpected")
-                  })
+                  },
+              )
             }
             .chunked(batchSize)
   }
@@ -847,7 +968,8 @@ class CudHandlerTest : HandlerTest() {
                         "rel_type" to "RELATED_TO",
                         "from" to mapOf("labels" to listOf("Foo"), "ids" to mapOf("id" to id)),
                         "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to id)),
-                        "properties" to mapOf("id" to id))
+                        "properties" to mapOf("id" to id),
+                    )
                 1 ->
                     mapOf(
                         "type" to "RELATIONSHIP",
@@ -855,7 +977,8 @@ class CudHandlerTest : HandlerTest() {
                         "rel_type" to "RELATED_TO",
                         "from" to mapOf("labels" to listOf("Foo"), "ids" to mapOf("id" to id)),
                         "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to id)),
-                        "properties" to mapOf("id" to id, "prop1" to "a value"))
+                        "properties" to mapOf("id" to id, "prop1" to "a value"),
+                    )
                 2 ->
                     mapOf(
                         "type" to "relationship",
@@ -864,14 +987,16 @@ class CudHandlerTest : HandlerTest() {
                         "from" to mapOf("labels" to listOf("Foo"), "ids" to mapOf("id" to id)),
                         "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to id)),
                         "properties" to
-                            mapOf("id" to id, "prop1" to "a value", "prop2" to "b value"))
+                            mapOf("id" to id, "prop1" to "a value", "prop2" to "b value"),
+                    )
                 3 ->
                     mapOf(
                         "type" to "relationship",
                         "op" to "delete",
                         "rel_type" to "RELATED_TO",
                         "from" to mapOf("labels" to listOf("Foo"), "ids" to mapOf("id" to id)),
-                        "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to id)))
+                        "to" to mapOf("labels" to listOf("Bar"), "ids" to mapOf("id" to id)),
+                    )
                 else -> throw IllegalArgumentException("unexpected")
               }
             }
@@ -895,7 +1020,9 @@ class CudHandlerTest : HandlerTest() {
                             mapOf(
                                 "start" to mapOf("keys" to mapOf("id" to id)),
                                 "end" to mapOf("keys" to mapOf("id" to id)),
-                                "properties" to mapOf("id" to id)))
+                                "properties" to mapOf("id" to id),
+                            ),
+                        )
                     1 ->
                         Query(
                             "MATCH (start:`Foo` {id: ${'$'}start.keys.id}) WITH start MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end MATCH (start)-[r:`RELATED_TO` {}]->(end) SET r += ${'$'}properties",
@@ -903,7 +1030,9 @@ class CudHandlerTest : HandlerTest() {
                                 "start" to mapOf("keys" to mapOf("id" to id)),
                                 "end" to mapOf("keys" to mapOf("id" to id)),
                                 "keys" to emptyMap(),
-                                "properties" to mapOf("id" to id, "prop1" to "a value")))
+                                "properties" to mapOf("id" to id, "prop1" to "a value"),
+                            ),
+                        )
                     2 ->
                         Query(
                             "MATCH (start:`Foo` {id: ${'$'}start.keys.id}) WITH start MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end MERGE (start)-[r:`RELATED_TO` {}]->(end) SET r += ${'$'}properties",
@@ -912,16 +1041,21 @@ class CudHandlerTest : HandlerTest() {
                                 "end" to mapOf("keys" to mapOf("id" to id)),
                                 "keys" to emptyMap(),
                                 "properties" to
-                                    mapOf("id" to id, "prop1" to "a value", "prop2" to "b value")))
+                                    mapOf("id" to id, "prop1" to "a value", "prop2" to "b value"),
+                            ),
+                        )
                     3 ->
                         Query(
                             "MATCH (start:`Foo` {id: ${'$'}start.keys.id}) WITH start MATCH (end:`Bar` {id: ${'$'}end.keys.id}) WITH start, end MATCH (start)-[r:`RELATED_TO` {}]->(end) DELETE r",
                             mapOf(
                                 "start" to mapOf("keys" to mapOf("id" to id)),
                                 "end" to mapOf("keys" to mapOf("id" to id)),
-                                "keys" to emptyMap()))
+                                "keys" to emptyMap(),
+                            ),
+                        )
                     else -> throw IllegalArgumentException("unexpected")
-                  })
+                  },
+              )
             }
             .chunked(batchSize)
   }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CypherHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/CypherHandlerTest.kt
@@ -43,7 +43,8 @@ class CypherHandlerTest : HandlerTest() {
             "",
             "",
             "",
-            true)
+            true,
+        )
 
     val sinkMessage = newMessage(Schema.STRING_SCHEMA, "{}")
     handler.handle(listOf(sinkMessage)) shouldBe
@@ -64,7 +65,14 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to emptyMap<String, Any>(),
                                         "key" to null,
-                                        "value" to emptyMap<String, Any>())))))))
+                                        "value" to emptyMap<String, Any>(),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -79,7 +87,8 @@ class CypherHandlerTest : HandlerTest() {
             "",
             "",
             "__value",
-            true)
+            true,
+        )
 
     val sinkMessage = newMessage(Schema.STRING_SCHEMA, "{}")
     handler.handle(listOf(sinkMessage)) shouldBe
@@ -100,7 +109,14 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to emptyMap<String, Any>(),
                                         "key" to null,
-                                        "value" to emptyMap<String, Any>())))))))
+                                        "value" to emptyMap<String, Any>(),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -115,7 +131,8 @@ class CypherHandlerTest : HandlerTest() {
             "",
             "__key",
             "__value",
-            true)
+            true,
+        )
 
     val sinkMessage = newMessage(Schema.STRING_SCHEMA, "{}", Schema.INT64_SCHEMA, 32L)
     handler.handle(listOf(sinkMessage)) shouldBe
@@ -136,7 +153,14 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to emptyMap<String, Any>(),
                                         "key" to 32L,
-                                        "value" to emptyMap<String, Any>())))))))
+                                        "value" to emptyMap<String, Any>(),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -151,7 +175,8 @@ class CypherHandlerTest : HandlerTest() {
             "__header",
             "__key",
             "__value",
-            true)
+            true,
+        )
 
     val sinkMessage =
         newMessage(
@@ -159,7 +184,8 @@ class CypherHandlerTest : HandlerTest() {
             "{}",
             Schema.INT64_SCHEMA,
             32L,
-            listOf(ConnectHeader("age", SchemaAndValue(Schema.INT32_SCHEMA, 24))))
+            listOf(ConnectHeader("age", SchemaAndValue(Schema.INT32_SCHEMA, 24))),
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -178,7 +204,14 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to mapOf<String, Any>("age" to 24),
                                         "key" to 32L,
-                                        "value" to emptyMap<String, Any>())))))))
+                                        "value" to emptyMap<String, Any>(),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -193,7 +226,8 @@ class CypherHandlerTest : HandlerTest() {
             "__header",
             "__key",
             "__value",
-            false)
+            false,
+        )
 
     val sinkMessage =
         newMessage(
@@ -201,7 +235,8 @@ class CypherHandlerTest : HandlerTest() {
             "{}",
             Schema.INT64_SCHEMA,
             32L,
-            listOf(ConnectHeader("age", SchemaAndValue(Schema.INT32_SCHEMA, 24))))
+            listOf(ConnectHeader("age", SchemaAndValue(Schema.INT32_SCHEMA, 24))),
+        )
 
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
@@ -221,7 +256,14 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to mapOf<String, Any>("age" to 24),
                                         "key" to 32L,
-                                        "value" to emptyMap<String, Any>())))))))
+                                        "value" to emptyMap<String, Any>(),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -236,7 +278,8 @@ class CypherHandlerTest : HandlerTest() {
             "__header",
             "__key",
             "__value",
-            false)
+            false,
+        )
 
     val sinkMessage =
         newMessage(
@@ -244,7 +287,8 @@ class CypherHandlerTest : HandlerTest() {
             "{}",
             Schema.INT64_SCHEMA,
             32L,
-            listOf(ConnectHeader("age", SchemaAndValue(Schema.INT32_SCHEMA, 24))))
+            listOf(ConnectHeader("age", SchemaAndValue(Schema.INT32_SCHEMA, 24))),
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -263,7 +307,14 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to mapOf<String, Any>("age" to 24),
                                         "key" to 32L,
-                                        "value" to emptyMap<String, Any>())))))))
+                                        "value" to emptyMap<String, Any>(),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -278,7 +329,8 @@ class CypherHandlerTest : HandlerTest() {
           "",
           "",
           "",
-          false)
+          false,
+      )
     } shouldHaveMessage
         "no effective accessors specified for binding the message into cypher template for topic 'my-topic'"
   }
@@ -295,7 +347,8 @@ class CypherHandlerTest : HandlerTest() {
             "__header",
             "__key",
             "__value",
-            false)
+            false,
+        )
 
     val messages = (1..13).map { newMessage(Schema.INT64_SCHEMA, it.toLong()) }
     val result = handler.handle(messages)
@@ -317,8 +370,13 @@ class CypherHandlerTest : HandlerTest() {
                                           Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC),
                                       "header" to emptyMap<String, Any>(),
                                       "key" to null,
-                                      "value" to seq)
-                                })))),
+                                      "value" to seq,
+                                  )
+                                }
+                        ),
+                    ),
+                )
+            ),
             listOf(
                 ChangeQuery(
                     null,
@@ -334,8 +392,13 @@ class CypherHandlerTest : HandlerTest() {
                                           Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC),
                                       "header" to emptyMap<String, Any>(),
                                       "key" to null,
-                                      "value" to seq)
-                                })))),
+                                      "value" to seq,
+                                  )
+                                }
+                        ),
+                    ),
+                )
+            ),
             listOf(
                 ChangeQuery(
                     null,
@@ -351,8 +414,14 @@ class CypherHandlerTest : HandlerTest() {
                                           Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC),
                                       "header" to emptyMap<String, Any>(),
                                       "key" to null,
-                                      "value" to seq)
-                                })))))
+                                      "value" to seq,
+                                  )
+                                }
+                        ),
+                    ),
+                )
+            ),
+        )
   }
 
   @Test
@@ -380,10 +449,14 @@ class CypherHandlerTest : HandlerTest() {
                                         "header" to emptyMap<String, Any>(),
                                         "key" to null,
                                         "value" to
-                                            mapOf(
-                                                "x" to 123,
-                                                "y" to listOf(1, 2, 3),
-                                                "z" to true))))))))
+                                            mapOf("x" to 123, "y" to listOf(1, 2, 3), "z" to true),
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -412,7 +485,14 @@ class CypherHandlerTest : HandlerTest() {
                                         "header" to emptyMap<String, Any>(),
                                         "key" to
                                             mapOf("x" to 123, "y" to listOf(1, 2, 3), "z" to true),
-                                        "value" to null)))))))
+                                        "value" to null,
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -431,7 +511,12 @@ class CypherHandlerTest : HandlerTest() {
                 ConnectHeader(
                     "test",
                     SchemaAndValue(
-                        Schema.STRING_SCHEMA, "{\"x\": 123, \"y\": [1,2,3], \"z\": true}"))))
+                        Schema.STRING_SCHEMA,
+                        "{\"x\": 123, \"y\": [1,2,3], \"z\": true}",
+                    ),
+                ),
+            ),
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -455,9 +540,18 @@ class CypherHandlerTest : HandlerTest() {
                                                     mapOf(
                                                         "x" to 123,
                                                         "y" to listOf(1, 2, 3),
-                                                        "z" to true)),
+                                                        "z" to true,
+                                                    ),
+                                            ),
                                         "key" to 32L,
-                                        "value" to null)))))))
+                                        "value" to null,
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 
   @Test
@@ -471,7 +565,8 @@ class CypherHandlerTest : HandlerTest() {
             "{]",
             Schema.BYTES_SCHEMA,
             "{a: b}".toByteArray(),
-            listOf(ConnectHeader("test", SchemaAndValue(Schema.STRING_SCHEMA, "b"))))
+            listOf(ConnectHeader("test", SchemaAndValue(Schema.STRING_SCHEMA, "b"))),
+        )
     handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
@@ -490,6 +585,13 @@ class CypherHandlerTest : HandlerTest() {
                                                 .atOffset(ZoneOffset.UTC),
                                         "header" to mapOf<String, Any>("test" to "b"),
                                         "key" to "{a: b}".toByteArray(),
-                                        "value" to "{]")))))))
+                                        "value" to "{]",
+                                    )
+                                )
+                        ),
+                    ),
+                )
+            )
+        )
   }
 }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/HandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/HandlerTest.kt
@@ -30,7 +30,7 @@ open class HandlerTest {
       value: Any?,
       keySchema: Schema? = null,
       key: Any? = null,
-      headers: Iterable<Header> = emptyList()
+      headers: Iterable<Header> = emptyList(),
   ): SinkMessage {
     return SinkMessage(
         SinkRecord(
@@ -43,7 +43,9 @@ open class HandlerTest {
             0,
             TIMESTAMP,
             TimestampType.CREATE_TIME,
-            headers))
+            headers,
+        )
+    )
   }
 
   companion object {

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/NodePatternHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/NodePatternHandlerTest.kt
@@ -29,9 +29,9 @@ import org.junit.jupiter.api.assertThrows
 import org.neo4j.connectors.kafka.data.ConstraintData
 import org.neo4j.connectors.kafka.data.ConstraintEntityType
 import org.neo4j.connectors.kafka.data.ConstraintType
-import org.neo4j.connectors.kafka.data.DynamicTypes
 import org.neo4j.connectors.kafka.data.PropertyType
 import org.neo4j.connectors.kafka.data.PropertyType.schema
+import org.neo4j.connectors.kafka.data.converter.ExtendedValueConverter
 import org.neo4j.connectors.kafka.exceptions.InvalidDataException
 import org.neo4j.connectors.kafka.sink.ChangeQuery
 import org.neo4j.cypherdsl.core.renderer.Renderer
@@ -329,7 +329,7 @@ class NodePatternHandlerTest : HandlerTest() {
                 .put("surname", "doe")
                 .put(
                     "dob",
-                    DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(2000, 1, 1)),
+                    ExtendedValueConverter().value(PropertyType.schema, LocalDate.of(2000, 1, 1)),
                 ),
         expected =
             listOf(

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/NodePatternHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/NodePatternHandlerTest.kt
@@ -48,7 +48,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!id})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -73,7 +74,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 }
                 RETURN sum(created) AS created, sum(deleted) AS deleted                 
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -85,7 +87,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!id: aProperty})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -110,7 +113,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 }
                 RETURN sum(created) AS created, sum(deleted) AS deleted                 
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -122,7 +126,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!idA: aProperty, !idB: bProperty})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -147,7 +152,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 }
                 RETURN sum(created) AS created, sum(deleted) AS deleted                 
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -159,7 +165,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!id: aProperty})",
             mergeProperties = false,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -185,7 +192,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 }
                 RETURN sum(created) AS created, sum(deleted) AS deleted                 
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -197,7 +205,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel:BLabel{!id: aProperty})",
             mergeProperties = false,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -223,7 +232,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 }
                 RETURN sum(created) AS created, sum(deleted) AS deleted                 
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -235,7 +245,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:`ALabel With Space`:BLabel{ !id: aProperty, !`another id`: bProperty, name: `another property`, `last name`: last_name})",
             mergeProperties = false,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -261,7 +272,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 }
                 RETURN sum(created) AS created, sum(deleted) AS deleted                 
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -278,7 +290,14 @@ class NodePatternHandlerTest : HandlerTest() {
                         "keys" to mapOf("id" to 1),
                         "properties" to
                             mapOf<String, Any?>(
-                                "name" to "john", "surname" to "doe", "dob" to "2000-01-01")))))
+                                "name" to "john",
+                                "surname" to "doe",
+                                "dob" to "2000-01-01",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -286,7 +305,8 @@ class NodePatternHandlerTest : HandlerTest() {
     assertQueryAndParameters(
         "(:ALabel{!id: __value.old_id})",
         key = """{"old_id": 1}""",
-        expected = listOf(listOf("D", mapOf("keys" to mapOf("id" to 1)))))
+        expected = listOf(listOf("D", mapOf("keys" to mapOf("id" to 1)))),
+    )
   }
 
   @Test
@@ -309,7 +329,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 .put("surname", "doe")
                 .put(
                     "dob",
-                    DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(2000, 1, 1))),
+                    DynamicTypes.toConnectValue(PropertyType.schema, LocalDate.of(2000, 1, 1)),
+                ),
         expected =
             listOf(
                 listOf(
@@ -320,7 +341,12 @@ class NodePatternHandlerTest : HandlerTest() {
                             mapOf<String, Any?>(
                                 "name" to "john",
                                 "surname" to "doe",
-                                "dob" to LocalDate.of(2000, 1, 1))))))
+                                "dob" to LocalDate.of(2000, 1, 1),
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -341,8 +367,12 @@ class NodePatternHandlerTest : HandlerTest() {
                                 "surname" to "doe",
                                 "dob" to "2000-01-01",
                                 "address.city" to "london",
-                                "address.country" to "uk"),
-                    ))))
+                                "address.country" to "uk",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -359,7 +389,10 @@ class NodePatternHandlerTest : HandlerTest() {
                         "keys" to mapOf("id" to 1),
                         "properties" to
                             mapOf<String, Any?>("surname" to "doe", "address.country" to "uk"),
-                    ))))
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -376,8 +409,13 @@ class NodePatternHandlerTest : HandlerTest() {
                         "keys" to mapOf("id" to 1),
                         "properties" to
                             mapOf<String, Any?>(
-                                "address.city" to "london", "address.country" to "uk"),
-                    ))))
+                                "address.city" to "london",
+                                "address.country" to "uk",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -396,8 +434,12 @@ class NodePatternHandlerTest : HandlerTest() {
                             mapOf<String, Any?>(
                                 "dob" to "2000-01-01",
                                 "address.country" to "uk",
-                                "address.city" to "london"),
-                    ))))
+                                "address.city" to "london",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -417,8 +459,12 @@ class NodePatternHandlerTest : HandlerTest() {
                                 "name" to "john",
                                 "surname" to "doe",
                                 "dob" to "2000-01-01",
-                                "address.country" to "uk"),
-                    ))))
+                                "address.country" to "uk",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -435,8 +481,14 @@ class NodePatternHandlerTest : HandlerTest() {
                         "keys" to mapOf("id" to 1),
                         "properties" to
                             mapOf<String, Any?>(
-                                "name" to "john", "surname" to "doe", "dob" to "2000-01-01"),
-                    ))))
+                                "name" to "john",
+                                "surname" to "doe",
+                                "dob" to "2000-01-01",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -453,7 +505,10 @@ class NodePatternHandlerTest : HandlerTest() {
                         "keys" to mapOf("id" to 1),
                         "properties" to
                             mapOf<String, Any?>("first_name" to "john", "last_name" to "doe"),
-                    ))))
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -472,8 +527,12 @@ class NodePatternHandlerTest : HandlerTest() {
                             mapOf<String, Any?>(
                                 "first_name" to "john",
                                 "last_name" to "doe",
-                                "lives_in" to "london"),
-                    ))))
+                                "lives_in" to "london",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -493,8 +552,12 @@ class NodePatternHandlerTest : HandlerTest() {
                                 "first_name" to "john",
                                 "last_name" to "doe",
                                 "home_address.city" to "london",
-                                "home_address.country" to "uk"),
-                    ))))
+                                "home_address.country" to "uk",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -509,8 +572,11 @@ class NodePatternHandlerTest : HandlerTest() {
                     "C",
                     mapOf(
                         "keys" to mapOf("id" to 1),
-                        "properties" to
-                            mapOf<String, Any?>("name" to "john", "surname" to "doe")))))
+                        "properties" to mapOf<String, Any?>("name" to "john", "surname" to "doe"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -527,7 +593,14 @@ class NodePatternHandlerTest : HandlerTest() {
                         "keys" to mapOf("id" to 1),
                         "properties" to
                             mapOf<String, Any?>(
-                                "name" to "john", "surname" to "doe", "city" to "london")))))
+                                "name" to "john",
+                                "surname" to "doe",
+                                "city" to "london",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -547,8 +620,12 @@ class NodePatternHandlerTest : HandlerTest() {
                                 "name" to "john",
                                 "surname" to "doe",
                                 "home_address.city" to "london",
-                                "home_address.country" to "uk"),
-                    ))))
+                                "home_address.country" to "uk",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -568,8 +645,12 @@ class NodePatternHandlerTest : HandlerTest() {
                                 "name" to "john",
                                 "last_name" to "doe",
                                 "home_address.city" to "london",
-                                "home_address.country" to "uk"),
-                    ))))
+                                "home_address.country" to "uk",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -590,8 +671,12 @@ class NodePatternHandlerTest : HandlerTest() {
                                 "name" to "john",
                                 "surname" to "doe",
                                 "created_at" to
-                                    Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC)),
-                    ))))
+                                    Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC),
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -599,13 +684,8 @@ class NodePatternHandlerTest : HandlerTest() {
     assertQueryAndParameters(
         "(:ALabel {!id: __key.id, name: __value.name, surname: __value.surname, created_at: __timestamp})",
         key = """{"id": 1}""",
-        expected =
-            listOf(
-                listOf(
-                    "D",
-                    mapOf(
-                        "keys" to mapOf("id" to 1),
-                    ))))
+        expected = listOf(listOf("D", mapOf("keys" to mapOf("id" to 1)))),
+    )
   }
 
   @Test
@@ -616,13 +696,8 @@ class NodePatternHandlerTest : HandlerTest() {
         "(:ALabel {!id: __key.id, name: __value.name, surname: __value.surname, created_at: __timestamp})",
         keySchema = schema,
         key = Struct(schema).put("id", 1),
-        expected =
-            listOf(
-                listOf(
-                    "D",
-                    mapOf(
-                        "keys" to mapOf("id" to 1),
-                    ))))
+        expected = listOf(listOf("D", mapOf("keys" to mapOf("id" to 1)))),
+    )
   }
 
   @Test
@@ -630,13 +705,8 @@ class NodePatternHandlerTest : HandlerTest() {
     assertQueryAndParameters(
         "(:ALabel {!id, name: __value.name, surname: __value.surname, created_at: __timestamp})",
         key = """{"id": 1}""",
-        expected =
-            listOf(
-                listOf(
-                    "D",
-                    mapOf(
-                        "keys" to mapOf("id" to 1),
-                    ))))
+        expected = listOf(listOf("D", mapOf("keys" to mapOf("id" to 1)))),
+    )
   }
 
   @Test
@@ -645,7 +715,8 @@ class NodePatternHandlerTest : HandlerTest() {
         pattern = "(:Person{!id, !secondary_id, name, surname})",
         key = """{}""",
         value = """{"name": "John", "surname": "Doe"}""",
-        message = "Key 'id' could not be located in the message.")
+        message = "Key 'id' could not be located in the message.",
+    )
   }
 
   @Test
@@ -654,7 +725,8 @@ class NodePatternHandlerTest : HandlerTest() {
         pattern = "(:Person{!id: __key.old_id, name, surname})",
         key = """{}""",
         value = """{"name": "John", "surname": "Doe"}""",
-        message = "Key 'old_id' could not be located in the keys.")
+        message = "Key 'old_id' could not be located in the keys.",
+    )
   }
 
   @Test
@@ -663,7 +735,8 @@ class NodePatternHandlerTest : HandlerTest() {
         pattern = "(:Person{!id: __value.old_id, name, surname})",
         key = """{}""",
         value = """{"name": "John", "surname": "Doe"}""",
-        message = "Key 'old_id' could not be located in the values.")
+        message = "Key 'old_id' could not be located in the values.",
+    )
   }
 
   @Test
@@ -672,7 +745,8 @@ class NodePatternHandlerTest : HandlerTest() {
         pattern = "(:Person{!id, !second_id, name, surname})",
         key = """{"id": 1}""",
         value = """{"name": "John", "surname": "Doe"}""",
-        message = "Key 'second_id' could not be located in the message.")
+        message = "Key 'second_id' could not be located in the message.",
+    )
   }
 
   @Test
@@ -683,7 +757,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!id, !second_id, name})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -691,7 +766,9 @@ class NodePatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "ALabel",
-                properties = listOf("id", "second_id")))
+                properties = listOf("id", "second_id"),
+            )
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -706,7 +783,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!id, !second_id, name})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -714,17 +792,21 @@ class NodePatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_UNIQUENESS.value,
                 labelOrType = "ALabel",
-                properties = listOf("id", "second_id")),
+                properties = listOf("id", "second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_EXISTENCE.value,
                 labelOrType = "ALabel",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_EXISTENCE.value,
                 labelOrType = "ALabel",
-                properties = listOf("second_id")))
+                properties = listOf("second_id"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -739,7 +821,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel{!id, !second_id, name})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints = emptyList<ConstraintData>()
 
@@ -755,7 +838,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 "\nor:" +
                 "\n\t- UNIQUENESS (id, second_id)" +
                 "\n\t- NODE_PROPERTY_EXISTENCE (id)" +
-                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)")
+                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)"
+        )
   }
 
   @Test
@@ -766,7 +850,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel:BLabel{!id, !second_id, name})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints = emptyList<ConstraintData>()
 
@@ -783,7 +868,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 "\nor:" +
                 "\n\t- UNIQUENESS (id, second_id)" +
                 "\n\t- NODE_PROPERTY_EXISTENCE (id)" +
-                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)")
+                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)"
+        )
   }
 
   @Test
@@ -794,7 +880,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel:BLabel{!id, !second_id, name})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -802,12 +889,15 @@ class NodePatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "ALabel",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "BLabel",
-                properties = listOf("id")))
+                properties = listOf("id"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -824,7 +914,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 "\nor:" +
                 "\n\t- UNIQUENESS (id, second_id)" +
                 "\n\t- NODE_PROPERTY_EXISTENCE (id)" +
-                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)")
+                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)"
+        )
   }
 
   @Test
@@ -835,7 +926,8 @@ class NodePatternHandlerTest : HandlerTest() {
             "(:ALabel:BLabel{!id, !second_id, name})",
             mergeProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -843,27 +935,33 @@ class NodePatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_UNIQUENESS.value,
                 labelOrType = "ALabel",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_EXISTENCE.value,
                 labelOrType = "ALabel",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_EXISTENCE.value,
                 labelOrType = "ALabel",
-                properties = listOf("second_id")),
+                properties = listOf("second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_UNIQUENESS.value,
                 labelOrType = "BLabel",
-                properties = listOf("id", "second_id")),
+                properties = listOf("id", "second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_EXISTENCE.value,
                 labelOrType = "BLabel",
-                properties = listOf("id")))
+                properties = listOf("id"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -883,7 +981,8 @@ class NodePatternHandlerTest : HandlerTest() {
                 "\nor:" +
                 "\n\t- UNIQUENESS (id, second_id)" +
                 "\n\t- NODE_PROPERTY_EXISTENCE (id)" +
-                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)")
+                "\n\t- NODE_PROPERTY_EXISTENCE (second_id)"
+        )
   }
 
   private fun assertQueryAndParameters(
@@ -892,15 +991,11 @@ class NodePatternHandlerTest : HandlerTest() {
       key: Any? = null,
       valueSchema: Schema = Schema.STRING_SCHEMA,
       value: Any? = null,
-      expected: List<List<Any>> = emptyList()
+      expected: List<List<Any>> = emptyList(),
   ) {
     val handler = NodePatternHandler("my-topic", pattern, false, Renderer.getDefaultRenderer(), 1)
     val sinkMessage = newMessage(valueSchema, value, keySchema = keySchema, key = key)
-    handler.handle(
-        listOf(
-            sinkMessage,
-        ),
-    ) shouldBe
+    handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
                 ChangeQuery(
@@ -931,13 +1026,13 @@ class NodePatternHandlerTest : HandlerTest() {
                             }
                             RETURN sum(created) AS created, sum(deleted) AS deleted
                           """
-                                    .trimIndent(),
+                                    .trimIndent()
                             )
                             .cypher,
                         mapOf("events" to expected),
                     ),
-                ),
-            ),
+                )
+            )
         )
   }
 
@@ -947,7 +1042,7 @@ class NodePatternHandlerTest : HandlerTest() {
       key: Any? = null,
       valueSchema: Schema = Schema.STRING_SCHEMA,
       value: Any? = null,
-      message: String? = null
+      message: String? = null,
   ) {
     val handler = NodePatternHandler("my-topic", pattern, false, Renderer.getDefaultRenderer(), 1)
     val sinkMessage = newMessage(valueSchema, value, keySchema = keySchema, key = key)

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/RelationshipPatternHandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/RelationshipPatternHandlerTest.kt
@@ -45,7 +45,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -74,7 +75,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -87,7 +89,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -116,7 +119,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -129,7 +133,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -158,7 +163,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -171,7 +177,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = false,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -202,7 +209,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -215,7 +223,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = false,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -245,7 +254,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -258,7 +268,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = false,
             mergeRelationshipProperties = false,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -290,7 +301,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -303,7 +315,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -332,7 +345,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -345,7 +359,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -374,7 +389,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -387,7 +403,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     handler.query shouldBe
         CypherParser.parse(
@@ -416,7 +433,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                   }
                   RETURN sum(created) AS created, sum(deleted) AS deleted
                   """
-                    .trimIndent())
+                    .trimIndent()
+            )
             .cypher
   }
 
@@ -433,13 +451,19 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
-                        "properties" to mapOf<String, Any?>("foo" to "foo", "bar" to "bar")))))
+                        "properties" to mapOf<String, Any?>("foo" to "foo", "bar" to "bar"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -456,18 +480,25 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
                             mapOf<String, Any?>(
                                 "foo" to "foo",
                                 "bar" to "bar",
                                 "nested.baz" to "baz",
-                                "nested.bak" to "bak")))))
+                                "nested.bak" to "bak",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -484,14 +515,20 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
-                            mapOf<String, Any?>("nested.baz" to "baz", "nested.bak" to "bak")))))
+                            mapOf<String, Any?>("nested.baz" to "baz", "nested.bak" to "bak"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -508,14 +545,19 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
-                        "properties" to
-                            mapOf<String, Any?>("bar" to "bar", "nested.baz" to "baz")))))
+                        "properties" to mapOf<String, Any?>("bar" to "bar", "nested.baz" to "baz"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -532,13 +574,19 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
-                        "properties" to mapOf<String, Any?>("foo" to "foo", "bar" to "bar")))))
+                        "properties" to mapOf<String, Any?>("foo" to "foo", "bar" to "bar"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -555,14 +603,19 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
-                        "properties" to
-                            mapOf<String, Any?>("new_foo" to "foo", "new_bar" to "bar")))))
+                        "properties" to mapOf<String, Any?>("new_foo" to "foo", "new_bar" to "bar"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -579,17 +632,24 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
                             mapOf<String, Any?>(
                                 "new_foo" to "foo",
                                 "new_bar" to "bar",
-                                "new_nested_baz" to "baz")))))
+                                "new_nested_baz" to "baz",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -606,18 +666,25 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
                             mapOf<String, Any?>(
                                 "new_foo" to "foo",
                                 "new_bar" to "bar",
                                 "new_nested.baz" to "baz",
-                                "new_nested.bak" to "bak")))))
+                                "new_nested.bak" to "bak",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -633,13 +700,19 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
-                        "properties" to mapOf<String, Any?>("foo" to "foo", "bar" to "bar")))))
+                        "properties" to mapOf<String, Any?>("foo" to "foo", "bar" to "bar"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -656,14 +729,20 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
-                            mapOf<String, Any?>("foo" to "foo", "bar" to "bar", "baz" to "baz")))))
+                            mapOf<String, Any?>("foo" to "foo", "bar" to "bar", "baz" to "baz"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -680,18 +759,25 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
                             mapOf<String, Any?>(
                                 "foo" to "foo",
                                 "bar" to "bar",
                                 "new_nested.baz" to "baz",
-                                "new_nested.bak" to "bak")))))
+                                "new_nested.bak" to "bak",
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -708,14 +794,20 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
-                            mapOf<String, Any?>("foo" to "foo", "bar" to "bar", "baz" to "baz")))))
+                            mapOf<String, Any?>("foo" to "foo", "bar" to "bar", "baz" to "baz"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -733,18 +825,25 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                         "start" to
                             mapOf(
                                 "keys" to mapOf("id" to 1),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
-                                "properties" to emptyMap<String, Any?>()),
+                                "properties" to emptyMap<String, Any?>(),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
                         "properties" to
                             mapOf<String, Any?>(
                                 "foo" to "foo",
                                 "bar" to "bar",
                                 "created_at" to
-                                    Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC))))))
+                                    Instant.ofEpochMilli(TIMESTAMP).atOffset(ZoneOffset.UTC),
+                            ),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -764,15 +863,27 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                                 "keys" to mapOf("id" to 1),
                                 "properties" to
                                     mapOf<String, Any?>(
-                                        "propA" to "a", "foo" to "foo", "nested.baz" to "baz")),
+                                        "propA" to "a",
+                                        "foo" to "foo",
+                                        "nested.baz" to "baz",
+                                    ),
+                            ),
                         "end" to
                             mapOf(
                                 "keys" to mapOf("id" to 2),
                                 "properties" to
                                     mapOf<String, Any?>(
-                                        "propB" to "b", "foo" to "foo", "nested.bak" to "bak")),
+                                        "propB" to "b",
+                                        "foo" to "foo",
+                                        "nested.bak" to "bak",
+                                    ),
+                            ),
                         "keys" to mapOf<String, Any?>("id" to 3),
-                        "properties" to mapOf<String, Any?>("bar" to "bar")))))
+                        "properties" to mapOf<String, Any?>("bar" to "bar"),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -788,7 +899,11 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                     mapOf(
                         "start" to mapOf("keys" to mapOf("id" to 1)),
                         "end" to mapOf("keys" to mapOf("id" to 2)),
-                        "keys" to mapOf<String, Any?>("id" to 3)))))
+                        "keys" to mapOf<String, Any?>("id" to 3),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -804,7 +919,11 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                     mapOf(
                         "start" to mapOf("keys" to mapOf("id" to 1)),
                         "end" to mapOf("keys" to mapOf("id" to 2)),
-                        "keys" to mapOf<String, Any?>("id" to 3)))))
+                        "keys" to mapOf<String, Any?>("id" to 3),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -828,7 +947,11 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                     mapOf(
                         "start" to mapOf("keys" to mapOf("id" to 1)),
                         "end" to mapOf("keys" to mapOf("id" to 2)),
-                        "keys" to mapOf<String, Any?>("id" to 3)))))
+                        "keys" to mapOf<String, Any?>("id" to 3),
+                    ),
+                )
+            ),
+    )
   }
 
   @Test
@@ -836,7 +959,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: end})",
         key = """{"rel_id": 1, "end": 1}""",
-        message = "Key 'start' could not be located in the message.")
+        message = "Key 'start' could not be located in the message.",
+    )
   }
 
   @Test
@@ -844,7 +968,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: end})",
         key = """{"start": 1, "end": 1}""",
-        message = "Key 'rel_id' could not be located in the message.")
+        message = "Key 'rel_id' could not be located in the message.",
+    )
   }
 
   @Test
@@ -852,7 +977,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: end})",
         key = """{"start": 1, "rel_id": 1}""",
-        message = "Key 'end' could not be located in the message.")
+        message = "Key 'end' could not be located in the message.",
+    )
   }
 
   @Test
@@ -860,7 +986,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: __key.start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: end})",
         key = """{"rel_id": 1, "end": 1}""",
-        message = "Key 'start' could not be located in the keys.")
+        message = "Key 'start' could not be located in the keys.",
+    )
   }
 
   @Test
@@ -868,7 +995,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: __key.start})-[:REL_TYPE{!id: __key.rel_id}]->(:LabelB{!id: end})",
         key = """{"start": 1, "end": 1}""",
-        message = "Key 'rel_id' could not be located in the keys.")
+        message = "Key 'rel_id' could not be located in the keys.",
+    )
   }
 
   @Test
@@ -876,7 +1004,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: __key.start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: __key.end})",
         key = """{"start": 1, "rel_id": 1}""",
-        message = "Key 'end' could not be located in the keys.")
+        message = "Key 'end' could not be located in the keys.",
+    )
   }
 
   @Test
@@ -884,7 +1013,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: __value.start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: end})",
         value = """{"rel_id": 1, "end": 1}""",
-        message = "Key 'start' could not be located in the values.")
+        message = "Key 'start' could not be located in the values.",
+    )
   }
 
   @Test
@@ -892,7 +1022,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: start})-[:REL_TYPE{!id: __value.rel_id}]->(:LabelB{!id: end})",
         value = """{"start": 1, "end": 1}""",
-        message = "Key 'rel_id' could not be located in the values.")
+        message = "Key 'rel_id' could not be located in the values.",
+    )
   }
 
   @Test
@@ -900,7 +1031,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
     assertThrowsHandler<InvalidDataException>(
         pattern = "(:LabelA{!id: start})-[:REL_TYPE{!id: rel_id}]->(:LabelB{!id: __value.end})",
         value = """{"start": 1, "rel_id": 1}""",
-        message = "Key 'end' could not be located in the values.")
+        message = "Key 'end' could not be located in the values.",
+    )
   }
 
   @Test
@@ -912,7 +1044,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -920,17 +1053,21 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelA",
-                properties = listOf("idStart")),
+                properties = listOf("idStart"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_KEY.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("id", "second_id")),
+                properties = listOf("id", "second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelB",
-                properties = listOf("idEnd")))
+                properties = listOf("idEnd"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -946,7 +1083,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -954,27 +1092,33 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelA",
-                properties = listOf("idStart")),
+                properties = listOf("idStart"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_UNIQUENESS.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("id", "second_id")),
+                properties = listOf("id", "second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_EXISTENCE.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_EXISTENCE.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("second_id")),
+                properties = listOf("second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelB",
-                properties = listOf("idEnd")))
+                properties = listOf("idEnd"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -990,7 +1134,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints = emptyList<ConstraintData>()
 
@@ -1042,7 +1187,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -1050,17 +1196,21 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelA",
-                properties = listOf("idStart")),
+                properties = listOf("idStart"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_KEY.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelB",
-                properties = listOf("idEnd")))
+                properties = listOf("idEnd"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -1088,7 +1238,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = true,
             mergeRelationshipProperties = true,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
 
     val constraints =
         listOf(
@@ -1096,22 +1247,27 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelA",
-                properties = listOf("idStart")),
+                properties = listOf("idStart"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_UNIQUENESS.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("id", "second_id")),
+                properties = listOf("id", "second_id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.RELATIONSHIP.value,
                 constraintType = ConstraintType.RELATIONSHIP_EXISTENCE.value,
                 labelOrType = "REL_TYPE",
-                properties = listOf("id")),
+                properties = listOf("id"),
+            ),
             ConstraintData(
                 entityType = ConstraintEntityType.NODE.value,
                 constraintType = ConstraintType.NODE_KEY.value,
                 labelOrType = "LabelB",
-                properties = listOf("idEnd")))
+                properties = listOf("idEnd"),
+            ),
+        )
 
     val warningMessages = handler.checkConstraints(constraints)
 
@@ -1148,13 +1304,10 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = mergeNodeProperties,
             mergeRelationshipProperties = mergeRelationshipProperties,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
     val sinkMessage = newMessage(valueSchema, value, keySchema = keySchema, key = key)
-    handler.handle(
-        listOf(
-            sinkMessage,
-        ),
-    ) shouldBe
+    handler.handle(listOf(sinkMessage)) shouldBe
         listOf(
             listOf(
                 ChangeQuery(
@@ -1191,12 +1344,13 @@ class RelationshipPatternHandlerTest : HandlerTest() {
                                 }
                                 RETURN sum(created) AS created, sum(deleted) AS deleted
                                 """
-                                    .trimIndent())
+                                    .trimIndent()
+                            )
                             .cypher,
                         mapOf("events" to expected),
                     ),
-                ),
-            ),
+                )
+            )
         )
   }
 
@@ -1206,7 +1360,7 @@ class RelationshipPatternHandlerTest : HandlerTest() {
       key: Any? = null,
       valueSchema: Schema = Schema.STRING_SCHEMA,
       value: Any? = null,
-      message: String? = null
+      message: String? = null,
   ) {
     val handler =
         RelationshipPatternHandler(
@@ -1215,7 +1369,8 @@ class RelationshipPatternHandlerTest : HandlerTest() {
             mergeNodeProperties = false,
             mergeRelationshipProperties = false,
             renderer = Renderer.getDefaultRenderer(),
-            batchSize = 1)
+            batchSize = 1,
+        )
     val sinkMessage = newMessage(valueSchema, value, keySchema = keySchema, key = key)
 
     if (message != null) {

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/TestUtils.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/TestUtils.kt
@@ -57,8 +57,10 @@ object TestUtils {
                 ZonedDateTime.now().minusSeconds(1),
                 ZonedDateTime.now(),
                 mapOf("user" to "app_user", "app" to "hr"),
-                emptyMap()),
-            event)
+                emptyMap(),
+            ),
+            event,
+        )
     val changeConnect = ChangeEventConverter().toConnectValue(change)
 
     return SinkMessage(
@@ -72,7 +74,9 @@ object TestUtils {
             0,
             System.currentTimeMillis(),
             TimestampType.CREATE_TIME,
-            Headers.from(change)))
+            Headers.from(change),
+        )
+    )
   }
 
   fun randomChangeEvent(): Event =
@@ -86,7 +90,8 @@ object TestUtils {
               listOf("Person"),
               mapOf("Person" to listOf(mapOf("id" to id))),
               null,
-              NodeState(listOf("Person"), mapOf("id" to id)))
+              NodeState(listOf("Person"), mapOf("id" to id)),
+          )
         }
         1 -> {
           val id = random.nextInt()
@@ -99,15 +104,18 @@ object TestUtils {
               Node(
                   UUID.randomUUID().toString(),
                   listOf("Person"),
-                  mapOf("Person" to listOf(mapOf("id" to startId)))),
+                  mapOf("Person" to listOf(mapOf("id" to startId))),
+              ),
               Node(
                   UUID.randomUUID().toString(),
                   listOf("Person"),
-                  mapOf("Person" to listOf(mapOf("id" to endId)))),
+                  mapOf("Person" to listOf(mapOf("id" to endId))),
+              ),
               listOf(mapOf("id" to id)),
               EntityOperation.CREATE,
               null,
-              RelationshipState(emptyMap()))
+              RelationshipState(emptyMap()),
+          )
         }
         else -> throw IllegalArgumentException("unexpected value from random.nextBits")
       }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/TestUtils.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/TestUtils.kt
@@ -32,6 +32,7 @@ import org.neo4j.cdc.client.model.NodeEvent
 import org.neo4j.cdc.client.model.NodeState
 import org.neo4j.cdc.client.model.RelationshipEvent
 import org.neo4j.cdc.client.model.RelationshipState
+import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.connectors.kafka.data.ChangeEventConverter
 import org.neo4j.connectors.kafka.data.Headers
 import org.neo4j.connectors.kafka.sink.SinkMessage
@@ -61,7 +62,7 @@ object TestUtils {
             ),
             event,
         )
-    val changeConnect = ChangeEventConverter().toConnectValue(change)
+    val changeConnect = ChangeEventConverter(PayloadMode.EXTENDED).toConnectValue(change)
 
     return SinkMessage(
         SinkRecord(

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateNodeTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateNodeTest.kt
@@ -30,19 +30,23 @@ class CreateNodeTest {
     operation.toQuery() shouldBe
         Query(
             "CREATE (n:`Person` {}) SET n = ${'$'}properties",
-            mapOf("properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")))
+            mapOf("properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")),
+        )
   }
 
   @Test
   fun `should create correct statement with multiple labels`() {
     val operation =
         CreateNode(
-            setOf("Person", "Employee"), mapOf("id" to 1, "name" to "john", "surname" to "doe"))
+            setOf("Person", "Employee"),
+            mapOf("id" to 1, "name" to "john", "surname" to "doe"),
+        )
 
     operation.toQuery() shouldBe
         Query(
             "CREATE (n:`Person`:`Employee` {}) SET n = ${'$'}properties",
-            mapOf("properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")))
+            mapOf("properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")),
+        )
   }
 
   @Test
@@ -52,6 +56,7 @@ class CreateNodeTest {
     operation.toQuery() shouldBe
         Query(
             "CREATE (n {}) SET n = ${'$'}properties",
-            mapOf("properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")))
+            mapOf("properties" to mapOf("id" to 1, "name" to "john", "surname" to "doe")),
+        )
   }
 }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateRelationshipTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CreateRelationshipTest.kt
@@ -33,7 +33,8 @@ class CreateRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -45,12 +46,14 @@ class CreateRelationshipTest {
                       WITH start, end 
                       CREATE (start)-[r:`RELATED`]->(end) SET r = ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -61,7 +64,8 @@ class CreateRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MERGE),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -73,12 +77,14 @@ class CreateRelationshipTest {
                       WITH start, end 
                       CREATE (start)-[r:`RELATED`]->(end) SET r = ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -89,7 +95,8 @@ class CreateRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("_id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_id" to 2), LookupMode.MATCH),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -101,12 +108,14 @@ class CreateRelationshipTest {
                       WITH start, end 
                       CREATE (start)-[r:`RELATED`]->(end) SET r = ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("_id" to 1)),
                 "end" to mapOf("keys" to mapOf("_id" to 2)),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -117,7 +126,8 @@ class CreateRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("_elementId" to "db:1"), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_elementId" to "db:2"), LookupMode.MATCH),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -133,7 +143,8 @@ class CreateRelationshipTest {
             mapOf(
                 "start" to mapOf("keys" to mapOf("_elementId" to "db:1")),
                 "end" to mapOf("keys" to mapOf("_elementId" to "db:2")),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -144,7 +155,8 @@ class CreateRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MERGE),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -156,12 +168,14 @@ class CreateRelationshipTest {
                       WITH start, end 
                       CREATE (start)-[r:`RELATED`]->(end) SET r = ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -174,7 +188,11 @@ class CreateRelationshipTest {
       withClue("from: $from, to: $to") {
         val operation =
             CreateRelationship(
-                "RELATED", from, to, mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+                "RELATED",
+                from,
+                to,
+                mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
 
         assertThrows<InvalidDataException> { operation.toQuery() } shouldHaveMessage
             "'from' and 'to' must contain at least one ID property."
@@ -189,7 +207,8 @@ class CreateRelationshipTest {
             "",
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MERGE),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     assertThrows<InvalidDataException> { operation.toQuery() } shouldHaveMessage
         "'rel_type' must be specified."

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteNodeTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteNodeTest.kt
@@ -32,7 +32,8 @@ class DeleteNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n:`Person` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) DELETE n",
-            mapOf("keys" to mapOf("name" to "john", "surname" to "doe")))
+            mapOf("keys" to mapOf("name" to "john", "surname" to "doe")),
+        )
   }
 
   @Test
@@ -50,7 +51,8 @@ class DeleteNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n) WHERE elementId(n) = ${'$'}keys._elementId DELETE n",
-            mapOf("keys" to mapOf("_elementId" to "db:1")))
+            mapOf("keys" to mapOf("_elementId" to "db:1")),
+        )
   }
 
   @Test
@@ -60,7 +62,8 @@ class DeleteNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n:`Person` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) DETACH DELETE n",
-            mapOf("keys" to mapOf("name" to "john", "surname" to "doe")))
+            mapOf("keys" to mapOf("name" to "john", "surname" to "doe")),
+        )
   }
 
   @Test
@@ -71,7 +74,8 @@ class DeleteNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n:`Person`:`Employee` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) DETACH DELETE n",
-            mapOf("keys" to mapOf("name" to "john", "surname" to "doe")))
+            mapOf("keys" to mapOf("name" to "john", "surname" to "doe")),
+        )
   }
 
   @Test

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteRelationshipTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteRelationshipTest.kt
@@ -32,7 +32,8 @@ class DeleteRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
-            emptyMap())
+            emptyMap(),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -45,12 +46,15 @@ class DeleteRelationshipTest {
                       MATCH (start)-[r:`RELATED` {}]->(end)
                       DELETE r
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
-                "keys" to emptyMap()))
+                "keys" to emptyMap(),
+            ),
+        )
   }
 
   @Test
@@ -60,7 +64,8 @@ class DeleteRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
-            mapOf("id" to 3))
+            mapOf("id" to 3),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -73,12 +78,15 @@ class DeleteRelationshipTest {
                       MATCH (start)-[r:`RELATED` {id: ${'$'}keys.id}]->(end)
                       DELETE r
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
-                "keys" to mapOf("id" to 3)))
+                "keys" to mapOf("id" to 3),
+            ),
+        )
   }
 
   @Test
@@ -88,7 +96,8 @@ class DeleteRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("_id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_id" to 2), LookupMode.MATCH),
-            emptyMap())
+            emptyMap(),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -101,12 +110,15 @@ class DeleteRelationshipTest {
                       MATCH (start)-[r:`RELATED` {}]->(end) 
                       DELETE r
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("_id" to 1)),
                 "end" to mapOf("keys" to mapOf("_id" to 2)),
-                "keys" to emptyMap()))
+                "keys" to emptyMap(),
+            ),
+        )
   }
 
   @Test
@@ -116,7 +128,8 @@ class DeleteRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA"), mapOf("_elementId" to "db:1"), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_elementId" to "db:2"), LookupMode.MATCH),
-            emptyMap())
+            emptyMap(),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -133,7 +146,9 @@ class DeleteRelationshipTest {
             mapOf(
                 "start" to mapOf("keys" to mapOf("_elementId" to "db:1")),
                 "end" to mapOf("keys" to mapOf("_elementId" to "db:2")),
-                "keys" to emptyMap()))
+                "keys" to emptyMap(),
+            ),
+        )
   }
 
   @Test
@@ -143,7 +158,8 @@ class DeleteRelationshipTest {
             "RELATED",
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MATCH),
-            emptyMap())
+            emptyMap(),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -155,12 +171,15 @@ class DeleteRelationshipTest {
                       WITH start, end 
                       MATCH (start)-[r:`RELATED` {}]->(end) DELETE r
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
-                "keys" to emptyMap()))
+                "keys" to emptyMap(),
+            ),
+        )
   }
 
   @Test
@@ -186,7 +205,8 @@ class DeleteRelationshipTest {
             "",
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MERGE),
-            emptyMap())
+            emptyMap(),
+        )
 
     org.junit.jupiter.api.assertThrows<InvalidDataException> {
       operation.toQuery()

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeNodeTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeNodeTest.kt
@@ -34,7 +34,9 @@ class MergeNodeTest {
             "MERGE (n:`Person` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) SET n += ${'$'}properties",
             mapOf(
                 "keys" to mapOf("name" to "john", "surname" to "doe"),
-                "properties" to mapOf("age" to 18)))
+                "properties" to mapOf("age" to 18),
+            ),
+        )
   }
 
   @Test
@@ -44,7 +46,8 @@ class MergeNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n) WHERE id(n) = ${'$'}keys._id SET n += ${'$'}properties",
-            mapOf("keys" to mapOf("_id" to 1), "properties" to mapOf("age" to 18)))
+            mapOf("keys" to mapOf("_id" to 1), "properties" to mapOf("age" to 18)),
+        )
   }
 
   @Test
@@ -54,7 +57,8 @@ class MergeNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n) WHERE elementId(n) = ${'$'}keys._elementId SET n += ${'$'}properties",
-            mapOf("keys" to mapOf("_elementId" to "db:1"), "properties" to mapOf("age" to 18)))
+            mapOf("keys" to mapOf("_elementId" to "db:1"), "properties" to mapOf("age" to 18)),
+        )
   }
 
   @Test
@@ -63,14 +67,17 @@ class MergeNodeTest {
         MergeNode(
             setOf("Person", "Employee"),
             mapOf("name" to "john", "surname" to "doe"),
-            mapOf("age" to 18))
+            mapOf("age" to 18),
+        )
 
     operation.toQuery() shouldBe
         Query(
             "MERGE (n:`Person`:`Employee` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) SET n += ${'$'}properties",
             mapOf(
                 "keys" to mapOf("name" to "john", "surname" to "doe"),
-                "properties" to mapOf("age" to 18)))
+                "properties" to mapOf("age" to 18),
+            ),
+        )
   }
 
   @Test

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeRelationshipTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/MergeRelationshipTest.kt
@@ -33,7 +33,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -46,13 +47,16 @@ class MergeRelationshipTest {
                       MERGE (start)-[r:`RELATED` {}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -63,7 +67,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -76,13 +81,16 @@ class MergeRelationshipTest {
                       MERGE (start)-[r:`RELATED` {}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -93,7 +101,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
             mapOf("id" to 3),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -106,13 +115,16 @@ class MergeRelationshipTest {
                       MERGE (start)-[r:`RELATED` {id: ${'$'}keys.id}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to mapOf("id" to 3),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -123,7 +135,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("_id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_id" to 2), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -136,13 +149,15 @@ class MergeRelationshipTest {
                       MERGE (start)-[r:`RELATED` {}]->(end) 
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("_id" to 1)),
                 "end" to mapOf("keys" to mapOf("_id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -154,7 +169,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("_elementId" to "db:1"), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_elementId" to "db:2"), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -172,7 +188,8 @@ class MergeRelationshipTest {
                 "start" to mapOf("keys" to mapOf("_elementId" to "db:1")),
                 "end" to mapOf("keys" to mapOf("_elementId" to "db:2")),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -184,7 +201,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -197,13 +215,16 @@ class MergeRelationshipTest {
                       MERGE (start)-[r:`RELATED` {}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -230,7 +251,8 @@ class MergeRelationshipTest {
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MERGE),
             emptyMap(),
-            mapOf("prop1" to 1))
+            mapOf("prop1" to 1),
+        )
 
     org.junit.jupiter.api.assertThrows<InvalidDataException> {
       operation.toQuery()

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/OperationTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/OperationTest.kt
@@ -32,11 +32,15 @@ class OperationTest {
                 Keys.TYPE to Type.NODE.name,
                 Keys.OPERATION to OperationType.CREATE.name,
                 Keys.LABELS to listOf("LabelA", "LabelB"),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         CreateNode(
-            setOf("LabelA", "LabelB"), mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            setOf("LabelA", "LabelB"),
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -48,13 +52,16 @@ class OperationTest {
                 Keys.OPERATION to OperationType.UPDATE.name,
                 Keys.LABELS to listOf("LabelA", "LabelB"),
                 Keys.IDS to mapOf("id1" to 1, "id2" to "string"),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         UpdateNode(
             setOf("LabelA", "LabelB"),
             mapOf("id1" to 1, "id2" to "string"),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -66,13 +73,16 @@ class OperationTest {
                 Keys.OPERATION to OperationType.MERGE.name,
                 Keys.LABELS to listOf("LabelA", "LabelB"),
                 Keys.IDS to mapOf("id1" to 1, "id2" to "string"),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         MergeNode(
             setOf("LabelA", "LabelB"),
             mapOf("id1" to 1, "id2" to "string"),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -83,7 +93,9 @@ class OperationTest {
                 Keys.TYPE to Type.NODE.name,
                 Keys.OPERATION to OperationType.DELETE.name,
                 Keys.LABELS to listOf("LabelA", "LabelB"),
-                Keys.IDS to mapOf("id1" to 1, "id2" to "string")))
+                Keys.IDS to mapOf("id1" to 1, "id2" to "string"),
+            )
+        )
 
     operation shouldBe
         DeleteNode(setOf("LabelA", "LabelB"), mapOf("id1" to 1, "id2" to "string"), false)
@@ -98,7 +110,9 @@ class OperationTest {
                 Keys.OPERATION to OperationType.DELETE.name,
                 Keys.LABELS to listOf("LabelA", "LabelB"),
                 Keys.IDS to mapOf("id1" to 1, "id2" to "string"),
-                Keys.DETACH to true))
+                Keys.DETACH to true,
+            )
+        )
 
     operation shouldBe
         DeleteNode(setOf("LabelA", "LabelB"), mapOf("id1" to 1, "id2" to "string"), true)
@@ -112,24 +126,19 @@ class OperationTest {
                 Keys.TYPE to Type.RELATIONSHIP.name,
                 Keys.OPERATION to OperationType.CREATE.name,
                 Keys.RELATION_TYPE to "RELATED_TO",
-                Keys.FROM to
-                    mapOf(
-                        Keys.LABELS to listOf("LabelA"),
-                        Keys.IDS to mapOf("id" to 1),
-                    ),
-                Keys.TO to
-                    mapOf(
-                        Keys.LABELS to listOf("LabelB"),
-                        Keys.IDS to mapOf("id" to 2),
-                    ),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                Keys.FROM to mapOf(Keys.LABELS to listOf("LabelA"), Keys.IDS to mapOf("id" to 1)),
+                Keys.TO to mapOf(Keys.LABELS to listOf("LabelB"), Keys.IDS to mapOf("id" to 2)),
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         CreateRelationship(
             "RELATED_TO",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -144,20 +153,25 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE"),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                        Keys.OPERATION to "MERGE",
+                    ),
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         CreateRelationship(
             "RELATED_TO",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -172,13 +186,17 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE"),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                        Keys.OPERATION to "MERGE",
+                    ),
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         UpdateRelationship(
@@ -186,7 +204,8 @@ class OperationTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -201,14 +220,18 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE"),
+                        Keys.OPERATION to "MERGE",
+                    ),
                 Keys.IDS to mapOf("id" to 3),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         UpdateRelationship(
@@ -216,7 +239,8 @@ class OperationTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
             mapOf("id" to 3),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -231,13 +255,17 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE"),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                        Keys.OPERATION to "MERGE",
+                    ),
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         MergeRelationship(
@@ -245,7 +273,8 @@ class OperationTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -260,14 +289,18 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE"),
+                        Keys.OPERATION to "MERGE",
+                    ),
                 Keys.IDS to mapOf("id" to 3),
-                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                Keys.PROPERTIES to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            )
+        )
 
     operation shouldBe
         MergeRelationship(
@@ -275,7 +308,8 @@ class OperationTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
             mapOf("id" to 3),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
   }
 
   @Test
@@ -290,19 +324,24 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE")))
+                        Keys.OPERATION to "MERGE",
+                    ),
+            )
+        )
 
     operation shouldBe
         DeleteRelationship(
             "RELATED_TO",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
-            emptyMap())
+            emptyMap(),
+        )
   }
 
   @Test
@@ -317,20 +356,25 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "MATCH"),
+                        Keys.OPERATION to "MATCH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "MERGE"),
-                Keys.IDS to mapOf("id" to 3)))
+                        Keys.OPERATION to "MERGE",
+                    ),
+                Keys.IDS to mapOf("id" to 3),
+            )
+        )
 
     operation shouldBe
         DeleteRelationship(
             "RELATED_TO",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
-            mapOf("id" to 3))
+            mapOf("id" to 3),
+        )
   }
 
   @Test
@@ -345,20 +389,25 @@ class OperationTest {
                     mapOf(
                         Keys.LABELS to listOf("LabelA"),
                         Keys.IDS to mapOf("id" to 1),
-                        Keys.OPERATION to "mAtcH"),
+                        Keys.OPERATION to "mAtcH",
+                    ),
                 Keys.TO to
                     mapOf(
                         Keys.LABELS to listOf("LabelB"),
                         Keys.IDS to mapOf("id" to 2),
-                        Keys.OPERATION to "mErgE"),
-                Keys.IDS to mapOf("id" to 3)))
+                        Keys.OPERATION to "mErgE",
+                    ),
+                Keys.IDS to mapOf("id" to 3),
+            )
+        )
 
     operation shouldBe
         DeleteRelationship(
             "RELATED_TO",
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
-            mapOf("id" to 3))
+            mapOf("id" to 3),
+        )
   }
 
   @Test
@@ -377,7 +426,8 @@ class OperationTest {
             "prop2": "value"
           }
         }
-        """)
+        """
+    )
   }
 
   @Test
@@ -389,7 +439,8 @@ class OperationTest {
           "op": "create",
           "labels": []
         }
-        """)
+        """
+    )
   }
 
   @Test
@@ -405,7 +456,8 @@ class OperationTest {
             "prop1": 1
           }
         }
-        """)
+        """
+      )
     }
   }
 
@@ -424,7 +476,8 @@ class OperationTest {
             "prop1": 1
           }
         }
-        """)
+        """
+    )
   }
 
   @Test
@@ -451,7 +504,8 @@ class OperationTest {
             "prop2": "value"
           }
         }
-        """)
+        """
+    )
   }
 
   @Test
@@ -471,7 +525,8 @@ class OperationTest {
             "ids": { "id": 2 } 
           }
         }
-        """)
+        """
+    )
   }
 
   @Test
@@ -494,7 +549,8 @@ class OperationTest {
             "prop1": 1
           }
         }
-        """)
+        """
+      )
     }
   }
 
@@ -518,7 +574,8 @@ class OperationTest {
             "prop1": 1
           }
         }
-        """)
+        """
+    )
   }
 
   private fun assertDataExceptionThrown(json: String): InvalidDataException {

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateNodeTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateNodeTest.kt
@@ -34,7 +34,9 @@ class UpdateNodeTest {
             "MATCH (n:`Person` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) SET n += ${'$'}properties",
             mapOf(
                 "keys" to mapOf("name" to "john", "surname" to "doe"),
-                "properties" to mapOf("age" to 18)))
+                "properties" to mapOf("age" to 18),
+            ),
+        )
   }
 
   @Test
@@ -44,7 +46,8 @@ class UpdateNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n) WHERE id(n) = ${'$'}keys._id SET n += ${'$'}properties",
-            mapOf("keys" to mapOf("_id" to 1), "properties" to mapOf("age" to 18)))
+            mapOf("keys" to mapOf("_id" to 1), "properties" to mapOf("age" to 18)),
+        )
   }
 
   @Test
@@ -54,7 +57,8 @@ class UpdateNodeTest {
     operation.toQuery() shouldBe
         Query(
             "MATCH (n) WHERE elementId(n) = ${'$'}keys._elementId SET n += ${'$'}properties",
-            mapOf("keys" to mapOf("_elementId" to "db:1"), "properties" to mapOf("age" to 18)))
+            mapOf("keys" to mapOf("_elementId" to "db:1"), "properties" to mapOf("age" to 18)),
+        )
   }
 
   @Test
@@ -63,14 +67,17 @@ class UpdateNodeTest {
         UpdateNode(
             setOf("Person", "Employee"),
             mapOf("name" to "john", "surname" to "doe"),
-            mapOf("age" to 18))
+            mapOf("age" to 18),
+        )
 
     operation.toQuery() shouldBe
         Query(
             "MATCH (n:`Person`:`Employee` {name: ${'$'}keys.name, surname: ${'$'}keys.surname}) SET n += ${'$'}properties",
             mapOf(
                 "keys" to mapOf("name" to "john", "surname" to "doe"),
-                "properties" to mapOf("age" to 18)))
+                "properties" to mapOf("age" to 18),
+            ),
+        )
   }
 
   @Test

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateRelationshipTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateRelationshipTest.kt
@@ -33,7 +33,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -46,13 +47,16 @@ class UpdateRelationshipTest {
                       MATCH (start)-[r:`RELATED` {}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -63,7 +67,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MERGE),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -76,13 +81,16 @@ class UpdateRelationshipTest {
                       MATCH (start)-[r:`RELATED` {}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -93,7 +101,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("id" to 2), LookupMode.MATCH),
             mapOf("id" to 3),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -106,13 +115,16 @@ class UpdateRelationshipTest {
                       MATCH (start)-[r:`RELATED` {id: ${'$'}keys.id}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to mapOf("id" to 3),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -123,7 +135,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("_id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_id" to 2), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -136,13 +149,15 @@ class UpdateRelationshipTest {
                       MATCH (start)-[r:`RELATED` {}]->(end) 
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("_id" to 1)),
                 "end" to mapOf("keys" to mapOf("_id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -154,7 +169,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA"), mapOf("_elementId" to "db:1"), LookupMode.MATCH),
             NodeReference(setOf("LabelB"), mapOf("_elementId" to "db:2"), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -172,7 +188,8 @@ class UpdateRelationshipTest {
                 "start" to mapOf("keys" to mapOf("_elementId" to "db:1")),
                 "end" to mapOf("keys" to mapOf("_elementId" to "db:2")),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)),
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
         )
   }
 
@@ -184,7 +201,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MATCH),
             emptyMap(),
-            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true))
+            mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+        )
 
     operation.toQuery() shouldBe
         Query(
@@ -197,13 +215,16 @@ class UpdateRelationshipTest {
                       MATCH (start)-[r:`RELATED` {}]->(end)
                       SET r += ${'$'}properties
                     """
-                        .trimIndent())
+                        .trimIndent()
+                )
                 .cypher,
             mapOf(
                 "start" to mapOf("keys" to mapOf("id" to 1)),
                 "end" to mapOf("keys" to mapOf("id" to 2)),
                 "keys" to emptyMap(),
-                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true)))
+                "properties" to mapOf("prop1" to 1, "prop2" to "test", "prop3" to true),
+            ),
+        )
   }
 
   @Test
@@ -230,7 +251,8 @@ class UpdateRelationshipTest {
             NodeReference(setOf("LabelA", "LabelC"), mapOf("id" to 1), LookupMode.MATCH),
             NodeReference(setOf("LabelB", "LabelD"), mapOf("id" to 2), LookupMode.MERGE),
             emptyMap(),
-            mapOf("prop1" to 1))
+            mapOf("prop1" to 1),
+        )
 
     org.junit.jupiter.api.assertThrows<InvalidDataException> {
       operation.toQuery()

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternTest.kt
@@ -41,7 +41,8 @@ class PatternTest {
               true,
               setOf(PropertyMapping("id", "id")),
               emptySet(),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA:LabelB {!id: id, *})"
     }
 
@@ -56,7 +57,8 @@ class PatternTest {
               false,
               setOf(PropertyMapping("id", "id")),
               setOf(PropertyMapping("foo", "foo"), PropertyMapping("bar", "bar")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA {!id: id, foo: foo, bar: bar})"
     }
 
@@ -65,7 +67,9 @@ class PatternTest {
         strings =
             [
                 "(:`LabelA`:`Label B`{!`id`,`a foo`,`b bar`,`c dar`: `c bar`})",
-                "`LabelA`:`Label B`{!`id`,`a foo`,`b bar`,`c dar`: `c bar`}"])
+                "`LabelA`:`Label B`{!`id`,`a foo`,`b bar`,`c dar`: `c bar`}",
+            ]
+    )
     fun `should extract escaped labels and properties`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -77,8 +81,10 @@ class PatternTest {
               setOf(
                   PropertyMapping("a foo", "a foo"),
                   PropertyMapping("b bar", "b bar"),
-                  PropertyMapping("c bar", "c dar")),
-              emptySet())
+                  PropertyMapping("c bar", "c dar"),
+              ),
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA:`Label B` {!id: id, `a foo`: `a foo`, `b bar`: `b bar`, `c dar`: `c bar`})"
     }
@@ -94,7 +100,8 @@ class PatternTest {
               false,
               setOf(PropertyMapping("id", "id")),
               setOf(PropertyMapping("foo.bar", "foo.bar")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA {!id: id, `foo.bar`: `foo.bar`})"
     }
 
@@ -109,7 +116,8 @@ class PatternTest {
               false,
               setOf(PropertyMapping("idA", "idA"), PropertyMapping("idB", "idB")),
               setOf(PropertyMapping("foo", "foo"), PropertyMapping("bar", "bar")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA {!idA: idA, !idB: idB, foo: foo, bar: bar})"
     }
 
@@ -124,13 +132,15 @@ class PatternTest {
               true,
               setOf(PropertyMapping("id", "id")),
               emptySet(),
-              setOf("foo", "bar"))
+              setOf("foo", "bar"),
+          )
       result.text shouldBe "(:LabelA {!id: id, -foo, -bar, *})"
     }
 
     @ParameterizedTest
     @ValueSource(
-        strings = ["(:LabelA:LabelB{!id: customer.id,*})", "LabelA:LabelB{!id: customer.id,*}"])
+        strings = ["(:LabelA:LabelB{!id: customer.id,*})", "LabelA:LabelB{!id: customer.id,*}"]
+    )
     fun `should extract all params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -140,7 +150,8 @@ class PatternTest {
               true,
               setOf(PropertyMapping("customer.id", "id")),
               emptySet(),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA:LabelB {!id: `customer.id`, *})"
     }
 
@@ -149,7 +160,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id:product.id,foo: product.foo,bar:product.bar})",
-                "LabelA{!id:product.id,foo: product.foo,bar:product.bar}"])
+                "LabelA{!id:product.id,foo: product.foo,bar:product.bar}",
+            ]
+    )
     fun `should extract all fixed params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -159,7 +172,8 @@ class PatternTest {
               false,
               setOf(PropertyMapping("product.id", "id")),
               setOf(PropertyMapping("product.foo", "foo"), PropertyMapping("product.bar", "bar")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA {!id: `product.id`, foo: `product.foo`, bar: `product.bar`})"
     }
 
@@ -168,7 +182,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id:product.id,foo.bar: product.foo.bar})",
-                "LabelA{!id:product.id,foo.bar:product.foo.bar}"])
+                "LabelA{!id:product.id,foo.bar:product.foo.bar}",
+            ]
+    )
     fun `should extract complex params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -178,7 +194,8 @@ class PatternTest {
               false,
               setOf(PropertyMapping("product.id", "id")),
               setOf(PropertyMapping("product.foo.bar", "foo.bar")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe "(:LabelA {!id: `product.id`, `foo.bar`: `product.foo.bar`})"
     }
 
@@ -187,7 +204,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!idA: product.id,!idB: stock.id,foo: product.foo,bar})",
-                "LabelA{!idA:product.id,!idB:stock.id,foo:product.foo,bar}"])
+                "LabelA{!idA:product.id,!idB:stock.id,foo:product.foo,bar}",
+            ]
+    )
     fun `should extract composite keys with fixed params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -197,14 +216,16 @@ class PatternTest {
               false,
               setOf(PropertyMapping("product.id", "idA"), PropertyMapping("stock.id", "idB")),
               setOf(PropertyMapping("product.foo", "foo"), PropertyMapping("bar", "bar")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!idA: `product.id`, !idB: `stock.id`, foo: `product.foo`, bar: bar})"
     }
 
     @ParameterizedTest
     @ValueSource(
-        strings = ["(:LabelA{!id:product.id,-foo,-bar})", "LabelA{!id:product.id,-foo,-bar}"])
+        strings = ["(:LabelA{!id:product.id,-foo,-bar})", "LabelA{!id:product.id,-foo,-bar}"]
+    )
     fun `should extract all excluded params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -214,7 +235,8 @@ class PatternTest {
               true,
               setOf(PropertyMapping("product.id", "id")),
               emptySet(),
-              setOf("foo", "bar"))
+              setOf("foo", "bar"),
+          )
       result.text shouldBe "(:LabelA {!id: `product.id`, -foo, -bar, *})"
     }
 
@@ -265,7 +287,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!idA,aa})-[:REL_TYPE]->(:LabelB{!idB,bb})",
-                "LabelA{!idA,aa} REL_TYPE LabelB{!idB,bb}"])
+                "LabelA{!idA,aa} REL_TYPE LabelB{!idB,bb}",
+            ]
+    )
     fun `should extract all params`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -277,17 +301,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("idA", "idA")),
                   setOf(PropertyMapping("aa", "aa")),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("idB", "idB")),
                   setOf(PropertyMapping("bb", "bb")),
-                  emptySet()),
+                  emptySet(),
+              ),
               true,
               emptySet(),
               emptySet(),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!idA: idA, aa: aa})-[:REL_TYPE {*}]->(:LabelB {!idB: idB, bb: bb})"
     }
@@ -306,17 +333,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("idB", "idB")),
                   setOf(PropertyMapping("bb", "bb")),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelA"),
                   false,
                   setOf(PropertyMapping("idA", "idA")),
                   setOf(PropertyMapping("aa", "aa")),
-                  emptySet()),
+                  emptySet(),
+              ),
               true,
               emptySet(),
               emptySet(),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelB {!idB: idB, bb: bb})-[:REL_TYPE {*}]->(:LabelA {!idA: idA, aa: aa})"
     }
@@ -326,7 +356,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!idA})-[:REL_TYPE{foo, BAR}]->(:LabelB{!idB})",
-                "LabelA{!idA} REL_TYPE{foo, BAR} LabelB{!idB}"])
+                "LabelA{!idA} REL_TYPE{foo, BAR} LabelB{!idB}",
+            ]
+    )
     fun `should extract all fixed params`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -338,17 +370,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("idA", "idA")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("idB", "idB")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               false,
               emptySet(),
               setOf(PropertyMapping("foo", "foo"), PropertyMapping("BAR", "BAR")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!idA: idA})-[:REL_TYPE {foo: foo, BAR: BAR}]->(:LabelB {!idB: idB})"
     }
@@ -358,7 +393,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!idA})-[:REL_TYPE{foo.BAR, BAR.foo}]->(:LabelB{!idB})",
-                "LabelA{!idA} REL_TYPE{foo.BAR, BAR.foo} LabelB{!idB}"])
+                "LabelA{!idA} REL_TYPE{foo.BAR, BAR.foo} LabelB{!idB}",
+            ]
+    )
     fun `should extract complex params`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -370,17 +407,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("idA", "idA")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("idB", "idB")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               false,
               emptySet(),
               setOf(PropertyMapping("foo.BAR", "foo.BAR"), PropertyMapping("BAR.foo", "BAR.foo")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!idA: idA})-[:REL_TYPE {`foo.BAR`: `foo.BAR`, `BAR.foo`: `BAR.foo`}]->(:LabelB {!idB: idB})"
     }
@@ -390,7 +430,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!idA})-[:REL_TYPE{-foo, -BAR}]->(:LabelB{!idB})",
-                "LabelA{!idA} REL_TYPE{-foo, -BAR} LabelB{!idB}"])
+                "LabelA{!idA} REL_TYPE{-foo, -BAR} LabelB{!idB}",
+            ]
+    )
     fun `should extract all excluded params`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -402,17 +444,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("idA", "idA")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("idB", "idB")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               true,
               emptySet(),
               emptySet(),
-              setOf("foo", "BAR"))
+              setOf("foo", "BAR"),
+          )
       result.text shouldBe
           "(:LabelA {!idA: idA})-[:REL_TYPE {-foo, -BAR, *}]->(:LabelB {!idB: idB})"
     }
@@ -422,7 +467,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id:start.id,aa:start.aa})-[:REL_TYPE]->(:LabelB{!id:end.id,bb:end.bb})",
-                "LabelA{!id:start.id,aa:start.aa} REL_TYPE LabelB{!id:end.id,bb:end.bb}"])
+                "LabelA{!id:start.id,aa:start.aa} REL_TYPE LabelB{!id:end.id,bb:end.bb}",
+            ]
+    )
     fun `should extract all params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -434,17 +481,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("start.id", "id")),
                   setOf(PropertyMapping("start.aa", "aa")),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("end.id", "id")),
                   setOf(PropertyMapping("end.bb", "bb")),
-                  emptySet()),
+                  emptySet(),
+              ),
               true,
               emptySet(),
               emptySet(),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!id: `start.id`, aa: `start.aa`})-[:REL_TYPE {*}]->(:LabelB {!id: `end.id`, bb: `end.bb`})"
     }
@@ -464,17 +514,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("start.id", "id")),
                   setOf(PropertyMapping("start.bb", "bb")),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelA"),
                   false,
                   setOf(PropertyMapping("end.id", "id")),
                   setOf(PropertyMapping("end.aa", "aa")),
-                  emptySet()),
+                  emptySet(),
+              ),
               true,
               emptySet(),
               emptySet(),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelB {!id: `start.id`, bb: `start.bb`})-[:REL_TYPE {*}]->(:LabelA {!id: `end.id`, aa: `end.aa`})"
     }
@@ -484,7 +537,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id:start.id})-[:REL_TYPE{foo:rel.foo, BAR:rel.BAR}]->(:LabelB{!id:end.id})",
-                "LabelA{!id:start.id} REL_TYPE{foo:rel.foo, BAR:rel.BAR} LabelB{!id:end.id}"])
+                "LabelA{!id:start.id} REL_TYPE{foo:rel.foo, BAR:rel.BAR} LabelB{!id:end.id}",
+            ]
+    )
     fun `should extract all fixed params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -496,17 +551,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("start.id", "id")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("end.id", "id")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               false,
               emptySet(),
               setOf(PropertyMapping("rel.foo", "foo"), PropertyMapping("rel.BAR", "BAR")),
-              emptySet())
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!id: `start.id`})-[:REL_TYPE {foo: `rel.foo`, BAR: `rel.BAR`}]->(:LabelB {!id: `end.id`})"
     }
@@ -516,7 +574,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id:start.id})-[:REL_TYPE{foo.BAR:rel.foo.BAR, BAR.foo:rel.BAR.foo}]->(:LabelB{!id:end.id})",
-                "LabelA{!id:start.id} REL_TYPE{foo.BAR:rel.foo.BAR, BAR.foo:rel.BAR.foo} LabelB{!id:end.id}"])
+                "LabelA{!id:start.id} REL_TYPE{foo.BAR:rel.foo.BAR, BAR.foo:rel.BAR.foo} LabelB{!id:end.id}",
+            ]
+    )
     fun `should extract complex params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -528,19 +588,23 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("start.id", "id")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("end.id", "id")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               false,
               emptySet(),
               setOf(
                   PropertyMapping("rel.foo.BAR", "foo.BAR"),
-                  PropertyMapping("rel.BAR.foo", "BAR.foo")),
-              emptySet())
+                  PropertyMapping("rel.BAR.foo", "BAR.foo"),
+              ),
+              emptySet(),
+          )
       result.text shouldBe
           "(:LabelA {!id: `start.id`})-[:REL_TYPE {`foo.BAR`: `rel.foo.BAR`, `BAR.foo`: `rel.BAR.foo`}]->(:LabelB {!id: `end.id`})"
     }
@@ -550,7 +614,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id:start.id})-[:REL_TYPE{-foo, -BAR}]->(:LabelB{!id:end.id})",
-                "LabelA{!id:start.id} REL_TYPE{-foo, -BAR} LabelB{!id:end.id}"])
+                "LabelA{!id:start.id} REL_TYPE{-foo, -BAR} LabelB{!id:end.id}",
+            ]
+    )
     fun `should extract all excluded params aliased`(pattern: String) {
       val result = Pattern.parse(pattern)
 
@@ -562,17 +628,20 @@ class PatternTest {
                   false,
                   setOf(PropertyMapping("start.id", "id")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               NodePattern(
                   setOf("LabelB"),
                   false,
                   setOf(PropertyMapping("end.id", "id")),
                   emptySet(),
-                  emptySet()),
+                  emptySet(),
+              ),
               true,
               emptySet(),
               emptySet(),
-              setOf("foo", "BAR"))
+              setOf("foo", "BAR"),
+          )
       result.text shouldBe
           "(:LabelA {!id: `start.id`})-[:REL_TYPE {-foo, -BAR, *}]->(:LabelB {!id: `end.id`})"
     }
@@ -590,7 +659,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id})-[:REL_TYPE{foo}]->(:LabelB{!idB,-exclude})",
-                "LabelA{!id} REL_TYPE{foo} LabelB{!idB,-exclude}"])
+                "LabelA{!id} REL_TYPE{foo} LabelB{!idB,-exclude}",
+            ]
+    )
     fun `should throw an exception because of property exclusion`(pattern: String) {
       assertFailsWith(PatternException::class) { Pattern.parse(pattern) } shouldHaveMessage
           "Property exclusions are not allowed on start and end node patterns."
@@ -601,7 +672,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id})-[:REL_TYPE{foo}]->(:LabelB{!idB,*})",
-                "LabelA{!id} REL_TYPE{foo} LabelB{!idB,*}"])
+                "LabelA{!id} REL_TYPE{foo} LabelB{!idB,*}",
+            ]
+    )
     fun `should throw an exception because of wildcard property inclusion`(pattern: String) {
       assertFailsWith(PatternException::class) { Pattern.parse(pattern) } shouldHaveMessage
           "Wildcard property inclusion is not allowed on start and end node patterns."
@@ -612,7 +685,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id})-[:REL_TYPE{foo, -BAR}]->(:LabelB{!idB})",
-                "LabelA{!id} REL_TYPE{foo, -BAR} LabelB{!idB}"])
+                "LabelA{!id} REL_TYPE{foo, -BAR} LabelB{!idB}",
+            ]
+    )
     fun `should throw an exception because of mixed configuration`(pattern: String) {
       assertFailsWith(PatternException::class) { Pattern.parse(pattern) } shouldHaveMessage
           "Property inclusions and exclusions are mutually exclusive."
@@ -623,7 +698,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{id})-[:REL_TYPE{foo,BAR}]->(:LabelB{!idB})",
-                "LabelA{id} REL_TYPE{foo,BAR} LabelB{!idB}"])
+                "LabelA{id} REL_TYPE{foo,BAR} LabelB{!idB}",
+            ]
+    )
     fun `should throw an exception because the node pattern is missing a key`(pattern: String) {
       assertFailsWith(PatternException::class) { Pattern.parse(pattern) } shouldHaveMessage
           "At least one key selector must be specified in node patterns."
@@ -634,7 +711,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{})-[:REL_TYPE{foo,BAR}]->(:LabelB{!idB})",
-                "LabelA{} REL_TYPE{foo,BAR} LabelB{!idB}"])
+                "LabelA{} REL_TYPE{foo,BAR} LabelB{!idB}",
+            ]
+    )
     fun `should throw an exception because the node pattern is missing a key when selectors are empty`(
         pattern: String
     ) {
@@ -655,7 +734,9 @@ class PatternTest {
         strings =
             [
                 "(:LabelA{!id})-[REL_TYPE{foo,BAR}]->(:LabelB{!idB})",
-                "LabelA{id} :REL_TYPE{foo,BAR} LabelB{!idB}"])
+                "LabelA{id} :REL_TYPE{foo,BAR} LabelB{!idB}",
+            ]
+    )
     fun `should throw an exception because of invalid relationship pattern`(pattern: String) {
       assertFailsWith(PatternException::class) { Pattern.parse(pattern) }.message shouldStartWith
           "Invalid pattern:"
@@ -666,7 +747,9 @@ class PatternTest {
         strings =
             [
                 "(LabelA{!id})-[:REL_TYPE{-foo:abc}]->(:LabelB{!idB})",
-                "LabelA{id} :REL_TYPE{-bar:abc} LabelB{!idB}"])
+                "LabelA{id} :REL_TYPE{-bar:abc} LabelB{!idB}",
+            ]
+    )
     fun `should throw an exception because the pattern has aliased exclusion`(pattern: String) {
       assertFailsWith(PatternException::class) { Pattern.parse(pattern) }.message shouldStartWith
           "Invalid pattern:"
@@ -677,7 +760,9 @@ class PatternTest {
         strings =
             [
                 "(LabelA{!id})-[:REL_TYPE{-foo}]->(:LabelB{!idB,-prop: abc})",
-                "LabelA{id} :REL_TYPE{foo,BAR} LabelB{!idB,-bb:bb}"])
+                "LabelA{id} :REL_TYPE{foo,BAR} LabelB{!idB,-bb:bb}",
+            ]
+    )
     fun `should throw an exception because the pattern has aliased exclusion on node pattern`(
         pattern: String
     ) {

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceIT.kt
@@ -53,17 +53,22 @@ abstract class Neo4jCdcSourceIT {
                   arrayOf(
                       CdcSourceTopic(
                           topic = "neo4j-cdc-nodes-topic",
-                          patterns = arrayOf(CdcSourceParam("(:Person)"))),
+                          patterns = arrayOf(CdcSourceParam("(:Person)")),
+                      ),
                       CdcSourceTopic(
                           topic = "neo4j-cdc-rels-topic",
-                          patterns = arrayOf(CdcSourceParam("()-[:KNOWS]-()"))))))
+                          patterns = arrayOf(CdcSourceParam("()-[:KNOWS]-()")),
+                      ),
+                  )
+          ),
+  )
   @Test
   fun `should place cdc related information into headers`(
       @TopicConsumer(topic = "neo4j-cdc-nodes-topic", offset = "earliest")
       nodesConsumer: ConvertingKafkaConsumer,
       @TopicConsumer(topic = "neo4j-cdc-rels-topic", offset = "earliest")
       relsConsumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session
         .run(
@@ -79,13 +84,17 @@ abstract class Neo4jCdcSourceIT {
                         "id" to 1L,
                         "name" to "Jane",
                         "surname" to "Doe",
-                        "dob" to LocalDate.of(2000, 1, 1)),
+                        "dob" to LocalDate.of(2000, 1, 1),
+                    ),
                 "person2" to
                     mapOf(
                         "id" to 2L,
                         "name" to "John",
                         "surname" to "Doe",
-                        "dob" to LocalDate.of(1999, 1, 1))))
+                        "dob" to LocalDate.of(1999, 1, 1),
+                    ),
+            ),
+        )
         .consume()
 
     TopicVerifier.create<ChangeEvent, ChangeEvent>(nodesConsumer)
@@ -94,7 +103,9 @@ abstract class Neo4jCdcSourceIT {
               .headers()
               .map {
                 ConnectHeader(
-                    it.key(), SimpleHeaderConverter().toConnectHeader("", it.key(), it.value()))
+                    it.key(),
+                    SimpleHeaderConverter().toConnectHeader("", it.key(), it.value()),
+                )
               }
               .asIterable()
               .shouldHaveSize(3)
@@ -107,7 +118,8 @@ abstract class Neo4jCdcSourceIT {
                             Schema.INT8_SCHEMA,
                             Schema.INT16_SCHEMA,
                             Schema.INT32_SCHEMA,
-                            Schema.INT64_SCHEMA)
+                            Schema.INT64_SCHEMA,
+                        )
                         .contains(it.schema())
               }
               .shouldHaveSingleElement {
@@ -116,7 +128,8 @@ abstract class Neo4jCdcSourceIT {
                             Schema.INT8_SCHEMA,
                             Schema.INT16_SCHEMA,
                             Schema.INT32_SCHEMA,
-                            Schema.INT64_SCHEMA)
+                            Schema.INT64_SCHEMA,
+                        )
                         .contains(it.schema())
               }
         }
@@ -125,7 +138,9 @@ abstract class Neo4jCdcSourceIT {
               .headers()
               .map {
                 ConnectHeader(
-                    it.key(), SimpleHeaderConverter().toConnectHeader("", it.key(), it.value()))
+                    it.key(),
+                    SimpleHeaderConverter().toConnectHeader("", it.key(), it.value()),
+                )
               }
               .asIterable()
               .shouldHaveSize(3)
@@ -138,7 +153,8 @@ abstract class Neo4jCdcSourceIT {
                             Schema.INT8_SCHEMA,
                             Schema.INT16_SCHEMA,
                             Schema.INT32_SCHEMA,
-                            Schema.INT64_SCHEMA)
+                            Schema.INT64_SCHEMA,
+                        )
                         .contains(it.schema())
               }
               .shouldHaveSingleElement {
@@ -147,7 +163,8 @@ abstract class Neo4jCdcSourceIT {
                             Schema.INT8_SCHEMA,
                             Schema.INT16_SCHEMA,
                             Schema.INT32_SCHEMA,
-                            Schema.INT64_SCHEMA)
+                            Schema.INT64_SCHEMA,
+                        )
                         .contains(it.schema())
               }
         }
@@ -159,7 +176,9 @@ abstract class Neo4jCdcSourceIT {
               .headers()
               .map {
                 ConnectHeader(
-                    it.key(), SimpleHeaderConverter().toConnectHeader("", it.key(), it.value()))
+                    it.key(),
+                    SimpleHeaderConverter().toConnectHeader("", it.key(), it.value()),
+                )
               }
               .asIterable()
               .shouldHaveSize(3)
@@ -172,7 +191,8 @@ abstract class Neo4jCdcSourceIT {
                             Schema.INT8_SCHEMA,
                             Schema.INT16_SCHEMA,
                             Schema.INT32_SCHEMA,
-                            Schema.INT64_SCHEMA)
+                            Schema.INT64_SCHEMA,
+                        )
                         .contains(it.schema())
               }
               .shouldHaveSingleElement {
@@ -181,7 +201,8 @@ abstract class Neo4jCdcSourceIT {
                             Schema.INT8_SCHEMA,
                             Schema.INT16_SCHEMA,
                             Schema.INT32_SCHEMA,
-                            Schema.INT64_SCHEMA)
+                            Schema.INT64_SCHEMA,
+                        )
                         .contains(it.schema())
               }
         }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceKeyStrategyIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceKeyStrategyIT.kt
@@ -56,15 +56,16 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-none",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          keySerializationStrategy = "SKIP"),
-                  ),
+                          keySerializationStrategy = "SKIP",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports skipping serialization of keys`(
       @TopicConsumer(topic = "neo4j-cdc-topic-key-serialization-none", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
 
@@ -83,15 +84,16 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-whole",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          keySerializationStrategy = "WHOLE_VALUE"),
-                  ),
+                          keySerializationStrategy = "WHOLE_VALUE",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports serialization of keys as whole values`(
       @TopicConsumer(topic = "neo4j-cdc-topic-key-serialization-whole", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
 
@@ -118,15 +120,16 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-element-ids",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          keySerializationStrategy = "ELEMENT_ID"),
-                  ),
+                          keySerializationStrategy = "ELEMENT_ID",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports serialization of keys as element IDs`(
       @TopicConsumer(topic = "neo4j-cdc-topic-key-serialization-element-ids", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
 
@@ -145,16 +148,19 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-missing-node-keys",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          keySerializationStrategy = "ENTITY_KEYS"),
-                  ),
+                          keySerializationStrategy = "ENTITY_KEYS",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports serialization of keys as (missing) node keys`(
       @TopicConsumer(
-          topic = "neo4j-cdc-topic-key-serialization-missing-node-keys", offset = "earliest")
+          topic = "neo4j-cdc-topic-key-serialization-missing-node-keys",
+          offset = "earliest",
+      )
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
 
@@ -173,8 +179,9 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-node-keys",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          keySerializationStrategy = "ENTITY_KEYS"),
-                  ),
+                          keySerializationStrategy = "ENTITY_KEYS",
+                      )
+                  )
           ),
   )
   @Test
@@ -182,7 +189,7 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
       @TopicConsumer(topic = "neo4j-cdc-topic-key-serialization-node-keys", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) {
     session.createNodeKeyConstraint(neo4j, "test_id", "TestSource", "name")
     session.run("CALL db.awaitIndexes()").consume()
@@ -207,16 +214,19 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-missing-rel-keys",
                           patterns = arrayOf(CdcSourceParam("()-[:TO {name,+execId}]-()")),
-                          keySerializationStrategy = "ENTITY_KEYS"),
-                  ),
+                          keySerializationStrategy = "ENTITY_KEYS",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports serialization of keys as (missing) rel keys`(
       @TopicConsumer(
-          topic = "neo4j-cdc-topic-key-serialization-missing-rel-keys", offset = "earliest")
+          topic = "neo4j-cdc-topic-key-serialization-missing-rel-keys",
+          offset = "earliest",
+      )
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:Source)-[:TO {name: 'somewhere'}]->(:Destination)").consume()
 
@@ -235,8 +245,9 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-key-serialization-rel-keys",
                           patterns = arrayOf(CdcSourceParam("()-[:TO {name,+execId}]-()")),
-                          keySerializationStrategy = "ENTITY_KEYS"),
-                  ),
+                          keySerializationStrategy = "ENTITY_KEYS",
+                      )
+                  )
           ),
   )
   @Test
@@ -244,7 +255,7 @@ abstract class Neo4jCdcSourceKeyStrategyIT {
       @TopicConsumer(topic = "neo4j-cdc-topic-key-serialization-rel-keys", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) {
     session.createRelationshipKeyConstraint(neo4j, "to_id", "TO", "name")
     session.run("CALL db.awaitIndexes()").consume()

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceRelationshipsIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceRelationshipsIT.kt
@@ -59,12 +59,18 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                           patterns =
                               arrayOf(
                                   CdcSourceParam(
-                                      "(:TestSource)-[:RELIES_TO {weight,-rate}]->(:TestSource)"))))))
+                                      "(:TestSource)-[:RELIES_TO {weight,-rate}]->(:TestSource)"
+                                  )
+                              ),
+                      )
+                  )
+          ),
+  )
   @Test
   fun `should publish changes caught by patterns`(
       @TopicConsumer(topic = "neo4j-cdc-rels", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session
         .run(
@@ -72,7 +78,8 @@ abstract class Neo4jCdcSourceRelationshipsIT {
             |CREATE (t:TestSource {name: 'Alice'})
             |CREATE (s)-[:RELIES_TO {weight: 1, rate: 42}]->(t)
     """
-                .trimMargin())
+                .trimMargin()
+        )
         .consume()
     session.run("MATCH (:TestSource)-[r:RELIES_TO]-(:TestSource) SET r.weight = 2").consume()
     session.run("MATCH (:TestSource)-[r:RELIES_TO]-(:TestSource) DELETE r").consume()
@@ -120,12 +127,16 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                   arrayOf(
                       CdcSourceTopic(
                           topic = "neo4j-cdc-rels-prop-remove-add",
-                          patterns = arrayOf(CdcSourceParam("()-[:RELIES_TO {}]->()"))))))
+                          patterns = arrayOf(CdcSourceParam("()-[:RELIES_TO {}]->()")),
+                      )
+                  )
+          ),
+  )
   @Test
   fun `should publish property removal and additions`(
       @TopicConsumer(topic = "neo4j-cdc-rels-prop-remove-add", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session
         .run(
@@ -133,7 +144,8 @@ abstract class Neo4jCdcSourceRelationshipsIT {
             |CREATE (t:TestSource {name: 'Alice'})
             |CREATE (s)-[:RELIES_TO {weight: 1, rate: 42}]->(t)
     """
-                .trimMargin())
+                .trimMargin()
+        )
         .consume()
     session
         .run("MATCH (:TestSource)-[r:RELIES_TO]-(:TestSource) SET r.weight = 2, r.rate = NULL")
@@ -197,12 +209,16 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                           topic = "neo4j-cdc-update-rel",
                           patterns = arrayOf(CdcSourceParam(value = "(:A)-[:R {a,b,c,-d}]->(:B)")),
                           operations = arrayOf(CdcSourceParam(value = "UPDATE")),
-                          changesTo = arrayOf(CdcSourceParam(value = "a,c"))))))
+                          changesTo = arrayOf(CdcSourceParam(value = "a,c")),
+                      )
+                  ),
+          ),
+  )
   @Test
   fun `should publish only specified field changes on update`(
       @TopicConsumer(topic = "neo4j-cdc-update-rel", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:A)-[:R {a: 'foo', b: 'bar', c: 'abra', d: 'cadabra'}]->(:B)").consume()
     session.run("MATCH (:A)-[r:R {a: 'foo'}]->(:B) SET r.a = 'mini', r.b = 'midi'").consume()
@@ -244,15 +260,21 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                       CdcSourceTopic(
                           topic = "cdc-creates-rel",
                           patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
-                          operations = arrayOf(CdcSourceParam("CREATE"))),
+                          operations = arrayOf(CdcSourceParam("CREATE")),
+                      ),
                       CdcSourceTopic(
                           topic = "cdc-updates-rel",
                           patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
-                          operations = arrayOf(CdcSourceParam("UPDATE"))),
+                          operations = arrayOf(CdcSourceParam("UPDATE")),
+                      ),
                       CdcSourceTopic(
                           topic = "cdc-deletes-rel",
                           patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
-                          operations = arrayOf(CdcSourceParam("DELETE"))))))
+                          operations = arrayOf(CdcSourceParam("DELETE")),
+                      ),
+                  ),
+          ),
+  )
   @Test
   fun `should publish each operation to a separate topic`(
       @TopicConsumer(topic = "cdc-creates-rel", offset = "earliest")
@@ -261,7 +283,7 @@ abstract class Neo4jCdcSourceRelationshipsIT {
       updatesConsumer: ConvertingKafkaConsumer,
       @TopicConsumer(topic = "cdc-deletes-rel", offset = "earliest")
       deletesConsumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:Person)-[:EMPLOYED {role: 'SWE'}]->(:Company)").consume()
     session.run("MATCH (:Person)-[r:EMPLOYED]->(:Company) SET r.role = 'EM'").consume()
@@ -315,12 +337,15 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                   arrayOf(
                       CdcSourceTopic(
                           topic = "cdc",
-                          patterns =
-                              arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)"))))))
+                          patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
+                      )
+                  ),
+          ),
+  )
   @Test
   fun `should publish each operation to a single topic`(
       @TopicConsumer(topic = "cdc", offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:Person)-[:EMPLOYED {role: 'SWE'}]->(:Company)").consume()
     session.run("MATCH (:Person)-[r:EMPLOYED]->(:Company) SET r.role = 'EM'").consume()
@@ -371,23 +396,28 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-metadata-rel",
                           patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
-                          metadata =
-                              arrayOf(CdcMetadata(key = "txMetadata.testLabel", value = "B"))))))
+                          metadata = arrayOf(CdcMetadata(key = "txMetadata.testLabel", value = "B")),
+                      )
+                  ),
+          ),
+  )
   @Test
   fun `should publish changes marked with specific transaction metadata attribute`(
       @TopicConsumer(topic = "neo4j-cdc-metadata-rel", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     val transaction1 =
         session.beginTransaction(
-            TransactionConfig.builder().withMetadata(mapOf("testLabel" to "A")).build())
+            TransactionConfig.builder().withMetadata(mapOf("testLabel" to "A")).build()
+        )
     transaction1.run("CREATE (:Person)-[:EMPLOYED {role: 'SWE'}]->(:Company)").consume()
     transaction1.commit()
 
     val transaction2 =
         session.beginTransaction(
-            TransactionConfig.builder().withMetadata(mapOf("testLabel" to "B")).build())
+            TransactionConfig.builder().withMetadata(mapOf("testLabel" to "B")).build()
+        )
     transaction2.run("CREATE (:Person)-[:EMPLOYED {role: 'EM'}]->(:Company)").consume()
     transaction2.commit()
 
@@ -415,14 +445,17 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                   arrayOf(
                       CdcSourceTopic(
                           topic = "neo4j-cdc-keys-rel",
-                          patterns =
-                              arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)"))))))
+                          patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
+                      )
+                  )
+          ),
+  )
   @Test
   fun `should publish changes containing relationship keys`(
       @TopicConsumer(topic = "neo4j-cdc-keys-rel", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) {
     session.createRelationshipKeyConstraint(neo4j, "employedId", "EMPLOYED", "id")
     session.createRelationshipKeyConstraint(neo4j, "employedRole", "EMPLOYED", "role")
@@ -454,12 +487,15 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                   arrayOf(
                       CdcSourceTopic(
                           topic = "cdc",
-                          patterns =
-                              arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)"))))))
+                          patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
+                      )
+                  )
+          ),
+  )
   @Test
   fun `should publish changes with arrays`(
       @TopicConsumer(topic = "cdc", offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session
         .run(
@@ -471,7 +507,10 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                         "prop2" to arrayOf(LocalDate.of(1999, 1, 1), LocalDate.of(2000, 1, 1)),
                         "prop3" to listOf("a", "b", "c"),
                         "prop4" to arrayOf<Boolean>(),
-                        "prop5" to listOf<Double>())))
+                        "prop5" to listOf<Double>(),
+                    )
+            ),
+        )
         .consume()
 
     TopicVerifier.create<ChangeEvent, ChangeEvent>(consumer)
@@ -487,7 +526,9 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                       "prop2" to listOf(LocalDate.of(1999, 1, 1), LocalDate.of(2000, 1, 1)),
                       "prop3" to listOf("a", "b", "c"),
                       "prop4" to emptyList<Boolean>(),
-                      "prop5" to emptyList<Double>()))
+                      "prop5" to emptyList<Double>(),
+                  )
+              )
         }
         .verifyWithin(Duration.ofSeconds(30))
   }
@@ -501,14 +542,17 @@ abstract class Neo4jCdcSourceRelationshipsIT {
                   arrayOf(
                       CdcSourceTopic(
                           topic = "neo4j-cdc-keys-rel",
-                          patterns =
-                              arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)"))))))
+                          patterns = arrayOf(CdcSourceParam("(:Person)-[:EMPLOYED]->(:Company)")),
+                      )
+                  )
+          ),
+  )
   @Test
   fun `should publish with multiple keys on the same property`(
       @TopicConsumer(topic = "neo4j-cdc-keys-rel", offset = "earliest")
       consumer: ConvertingKafkaConsumer,
       session: Session,
-      neo4j: Neo4j
+      neo4j: Neo4j,
   ) {
     session.createRelationshipKeyConstraint(neo4j, "employedId", "EMPLOYED", "id", "role")
     session.createRelationshipKeyConstraint(neo4j, "employedRole", "EMPLOYED", "id")

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceValueStrategyIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcSourceValueStrategyIT.kt
@@ -52,16 +52,19 @@ abstract class Neo4jCdcSourceValueStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-value-serialization-change-event",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          valueSerializationStrategy = "CHANGE_EVENT"),
-                  ),
+                          valueSerializationStrategy = "CHANGE_EVENT",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports serialization of values as whole change event`(
       @TopicConsumer(
-          topic = "neo4j-cdc-topic-value-serialization-change-event", offset = "earliest")
+          topic = "neo4j-cdc-topic-value-serialization-change-event",
+          offset = "earliest",
+      )
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
 
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
@@ -88,16 +91,19 @@ abstract class Neo4jCdcSourceValueStrategyIT {
                       CdcSourceTopic(
                           topic = "neo4j-cdc-topic-value-serialization-entity-event",
                           patterns = arrayOf(CdcSourceParam("(:TestSource{name,+execId})")),
-                          valueSerializationStrategy = "ENTITY_EVENT"),
-                  ),
+                          valueSerializationStrategy = "ENTITY_EVENT",
+                      )
+                  )
           ),
   )
   @Test
   fun `supports serialization of values as only event entity`(
       @TopicConsumer(
-          topic = "neo4j-cdc-topic-value-serialization-entity-event", offset = "earliest")
+          topic = "neo4j-cdc-topic-value-serialization-entity-event",
+          offset = "earliest",
+      )
       consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) {
     session.run("CREATE (:TestSource {name: 'Jane'})").consume()
 
@@ -115,7 +121,10 @@ abstract class Neo4jCdcSourceValueStrategyIT {
                           "after" to
                               mapOf(
                                   "labels" to listOf("TestSource"),
-                                  "properties" to mapOf("name" to "Jane"))))
+                                  "properties" to mapOf("name" to "Jane"),
+                              )
+                      ),
+              )
         }
         .verifyWithin(Duration.ofSeconds(30))
   }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jConnectorTest.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jConnectorTest.kt
@@ -106,7 +106,9 @@ class Neo4jConnectorTest {
             mutableMapOf(
                 Neo4jConfiguration.URI to "neo4j://localhost",
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
-                SourceConfiguration.STRATEGY to "CDC"))
+                SourceConfiguration.STRATEGY to "CDC",
+            )
+        )
 
     config
         .configValues()
@@ -124,7 +126,9 @@ class Neo4jConnectorTest {
             mutableMapOf(
                 Neo4jConfiguration.URI to "neo4j://localhost",
                 SourceConfiguration.QUERY_TOPIC to "topic",
-                SourceConfiguration.STRATEGY to "QUERY"))
+                SourceConfiguration.STRATEGY to "QUERY",
+            )
+        )
         .apply {
           this.configValues()
               .first { it.name() == SourceConfiguration.QUERY }
@@ -137,7 +141,9 @@ class Neo4jConnectorTest {
             mutableMapOf(
                 Neo4jConfiguration.URI to "neo4j://localhost",
                 SourceConfiguration.QUERY to "MATCH (n) RETURN n",
-                SourceConfiguration.STRATEGY to "QUERY"))
+                SourceConfiguration.STRATEGY to "QUERY",
+            )
+        )
         .apply {
           this.configValues()
               .first { it.name() == SourceConfiguration.QUERY_TOPIC }
@@ -156,7 +162,9 @@ class Neo4jConnectorTest {
                 Neo4jConfiguration.URI to "neo4j://localhost",
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
                 SourceConfiguration.STRATEGY to "CDC",
-                "neo4j.cdc.topic.topic-1.patterns" to ""))
+                "neo4j.cdc.topic.topic-1.patterns" to "",
+            )
+        )
         .apply {
           this.configValues()
               .first { it.name() == SourceConfiguration.STRATEGY }
@@ -170,14 +178,17 @@ class Neo4jConnectorTest {
                 Neo4jConfiguration.URI to "neo4j://localhost",
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
                 SourceConfiguration.STRATEGY to "CDC",
-                "neo4j.cdc.topic.topic-1.patterns" to "(;ABC]"))
+                "neo4j.cdc.topic.topic-1.patterns" to "(;ABC]",
+            )
+        )
         .apply {
           this.configValues()
               .first { it.name() == SourceConfiguration.STRATEGY }
               .errorMessages() shouldHaveSingleElement
               {
                 it.startsWith(
-                    "Invalid value (;ABC] for configuration neo4j.cdc.topic.topic-1.patterns:")
+                    "Invalid value (;ABC] for configuration neo4j.cdc.topic.topic-1.patterns:"
+                )
               }
         }
 
@@ -188,7 +199,9 @@ class Neo4jConnectorTest {
                 Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
                 SourceConfiguration.STRATEGY to "CDC",
                 "neo4j.cdc.topic.topic-1.patterns" to "(:Person),()-[:KNOWS]-()",
-                "neo4j.cdc.topic.topic-2.patterns" to "(:Person),()-[:KNOWS]-(;Company)"))
+                "neo4j.cdc.topic.topic-2.patterns" to "(:Person),()-[:KNOWS]-(;Company)",
+            )
+        )
         .apply {
           this.configValues()
               .first { it.name() == SourceConfiguration.STRATEGY }
@@ -209,7 +222,9 @@ class Neo4jConnectorTest {
             Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
             SourceConfiguration.QUERY_TOPIC to "my-topic",
             SourceConfiguration.STRATEGY to "QUERY",
-            SourceConfiguration.QUERY to "MATCH (n) RETURN n.timestamp, n"))
+            SourceConfiguration.QUERY to "MATCH (n) RETURN n.timestamp, n",
+        )
+    )
 
     connector.taskClass() shouldBe Neo4jQueryTask::class.java
   }
@@ -223,7 +238,9 @@ class Neo4jConnectorTest {
             Neo4jConfiguration.URI to "neo4j://localhost",
             Neo4jConfiguration.AUTHENTICATION_TYPE to "NONE",
             SourceConfiguration.STRATEGY to "CDC",
-            "neo4j.cdc.topic.topic-1.patterns" to "(:Person)"))
+            "neo4j.cdc.topic.topic-1.patterns" to "(:Person)",
+        )
+    )
 
     connector.taskClass() shouldBe Neo4jCdcTask::class.java
   }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
@@ -49,20 +49,23 @@ abstract class Neo4jSourceQueryIT {
       streamingProperty = "timestamp",
       startFrom = "EARLIEST",
       query =
-          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp")
+          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
+  )
   @Test
   fun `reads latest changes from Neo4j source starting from EARLIEST`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) = runTest {
     session.run("CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: 0})").consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'john', surname: 'doe', timestamp: datetime().epochMillis})")
+            "CREATE (:TestSource {name: 'john', surname: 'doe', timestamp: datetime().epochMillis})"
+        )
         .consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: datetime().epochMillis})")
+            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: datetime().epochMillis})"
+        )
         .consume()
 
     TopicVerifier.createForMap(consumer)
@@ -86,11 +89,12 @@ abstract class Neo4jSourceQueryIT {
       query =
           "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck " +
               "RETURN ts.name as name, ts.surname as surname, ts.timestamp as timestamp, " +
-              "{key1: {subKey1: 'value', subKey2: 'value'}, key2: {subKey1: 'value', subKey2: true}} AS nested")
+              "{key1: {subKey1: 'value', subKey2: 'value'}, key2: {subKey1: 'value', subKey2: true}} AS nested",
+  )
   @Test
   fun `should return nested object`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) = runTest {
     session.run("CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: 0})").consume()
 
@@ -104,7 +108,9 @@ abstract class Neo4jSourceQueryIT {
                   "nested" to
                       mapOf(
                           "key1" to mapOf("subKey1" to "value", "subKey2" to "value"),
-                          "key2" to mapOf("subKey1" to "value", "subKey2" to true)))
+                          "key2" to mapOf("subKey1" to "value", "subKey2" to true),
+                      ),
+              )
         }
         .verifyWithin(Duration.ofSeconds(30))
   }
@@ -115,23 +121,27 @@ abstract class Neo4jSourceQueryIT {
       streamingProperty = "timestamp",
       startFrom = "NOW",
       query =
-          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp")
+          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
+  )
   @Test
   fun `reads latest changes from Neo4j source starting from NOW`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
-            "CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: (datetime() - duration('PT10S')).epochMillis})")
+            "CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: (datetime() - duration('PT10S')).epochMillis})"
+        )
         .consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'john', surname: 'doe', timestamp: (datetime() + duration('PT10S')).epochMillis})")
+            "CREATE (:TestSource {name: 'john', surname: 'doe', timestamp: (datetime() + duration('PT10S')).epochMillis})"
+        )
         .consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: (datetime() + duration('PT10S')).epochMillis})")
+            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: (datetime() + duration('PT10S')).epochMillis})"
+        )
         .consume()
 
     TopicVerifier.createForMap(consumer)
@@ -151,27 +161,32 @@ abstract class Neo4jSourceQueryIT {
       startFrom = "USER_PROVIDED",
       startFromValue = "1704067200000", // 2024-01-01T00:00:00
       query =
-          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp")
+          "MATCH (ts:TestSource) WHERE ts.timestamp > \$lastCheck RETURN ts.name AS name, ts.surname AS surname, ts.timestamp AS timestamp",
+  )
   @Test
   fun `reads latest changes from Neo4j source starting from USER_PROVIDED`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer,
-      session: Session
+      session: Session,
   ) = runTest {
     session
         .run(
-            "CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: datetime('2023-12-31T23:59:59Z').epochMillis})")
+            "CREATE (:TestSource {name: 'jane', surname: 'doe', timestamp: datetime('2023-12-31T23:59:59Z').epochMillis})"
+        )
         .consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'john', surname: 'doe', timestamp: datetime('2024-01-01T12:00:00Z').epochMillis})")
+            "CREATE (:TestSource {name: 'john', surname: 'doe', timestamp: datetime('2024-01-01T12:00:00Z').epochMillis})"
+        )
         .consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: datetime('2024-01-03T00:00:00Z').epochMillis})")
+            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: datetime('2024-01-03T00:00:00Z').epochMillis})"
+        )
         .consume()
     session
         .run(
-            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: datetime().epochMillis})")
+            "CREATE (:TestSource {name: 'mary', surname: 'doe', timestamp: datetime().epochMillis})"
+        )
         .consume()
 
     TopicVerifier.createForMap(consumer)
@@ -183,7 +198,8 @@ abstract class Neo4jSourceQueryIT {
                   "timestamp" to
                       OffsetDateTime.of(2024, 1, 1, 12, 0, 0, 0, ZoneOffset.UTC)
                           .toInstant()
-                          .toEpochMilli())
+                          .toEpochMilli(),
+              )
         }
         .assertMessageValue { value ->
           value shouldBe
@@ -193,7 +209,8 @@ abstract class Neo4jSourceQueryIT {
                   "timestamp" to
                       OffsetDateTime.of(2024, 1, 3, 0, 0, 0, 0, ZoneOffset.UTC)
                           .toInstant()
-                          .toEpochMilli())
+                          .toEpochMilli(),
+              )
         }
         .assertMessageValue { value ->
           value.excludingKeys("timestamp") shouldBe mapOf("name" to "mary", "surname" to "doe")
@@ -232,7 +249,8 @@ class Neo4jSourceJsonRawCompactIT : Neo4jSourceQueryIT() {
       startFrom = "USER_PROVIDED",
       startFromValue = "1704067200000", // 2024-01-01T00:00:00
       query =
-          "WITH {id: 'ROOT_ID', list: [{ property1: 'value1' }, { property2: 'value2' }]} AS data RETURN data, data.id AS guid, dateTime().epochMillis AS timestamp")
+          "WITH {id: 'ROOT_ID', list: [{ property1: 'value1' }, { property2: 'value2' }]} AS data RETURN data, data.id AS guid, dateTime().epochMillis AS timestamp",
+  )
   @Test
   fun `serializes list of heterogeneous objects as map by default`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer
@@ -254,7 +272,8 @@ class Neo4jSourceJsonRawCompactIT : Neo4jSourceQueryIT() {
       startFromValue = "1704067200000", // 2024-01-01T00:00:00
       forceMapsAsStruct = false,
       query =
-          "WITH {id: 'ROOT_ID', list: [{ property1: 'value1' }, { property2: 'value2' }]} AS data RETURN data, data.id AS guid, dateTime().epochMillis AS timestamp")
+          "WITH {id: 'ROOT_ID', list: [{ property1: 'value1' }, { property2: 'value2' }]} AS data RETURN data, data.id AS guid, dateTime().epochMillis AS timestamp",
+  )
   @Test
   fun `serializes list of heterogeneous objects as list when not forcing structs for map values with homogeneous value types`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer

--- a/source/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTask.kt
+++ b/source/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTask.kt
@@ -36,6 +36,7 @@ import org.neo4j.cdc.client.model.ChangeIdentifier
 import org.neo4j.connectors.kafka.configuration.helpers.VersionUtil
 import org.neo4j.connectors.kafka.data.ChangeEventConverter
 import org.neo4j.connectors.kafka.data.Headers
+import org.neo4j.connectors.kafka.data.ValueConverter
 import org.neo4j.driver.SessionConfig
 import org.neo4j.driver.TransactionConfig
 import org.slf4j.Logger
@@ -50,6 +51,7 @@ class Neo4jCdcTask : SourceTask() {
   private lateinit var transactionConfig: TransactionConfig
   private lateinit var cdc: CDCService
   private lateinit var offset: AtomicReference<String>
+  private lateinit var converter: ValueConverter
   private lateinit var changeEventConverter: ChangeEventConverter
 
   override fun version(): String = VersionUtil.version(this.javaClass as Class<*>)

--- a/source/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTask.kt
+++ b/source/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTask.kt
@@ -72,7 +72,8 @@ class Neo4jCdcTask : SourceTask() {
             { sessionConfig },
             { transactionConfig },
             config.cdcPollingInterval.toJavaDuration(),
-            *config.cdcSelectors.toTypedArray())
+            *config.cdcSelectors.toTypedArray(),
+        )
     log.debug("constructed cdc client")
 
     offset = AtomicReference(resumeFrom(config, cdc))
@@ -131,7 +132,9 @@ class Neo4jCdcTask : SourceTask() {
                   config.cdcTopicsToKeyStrategy.getOrDefault(topic, Neo4jCdcKeyStrategy.WHOLE_VALUE)
               val valueStrategy =
                   config.cdcTopicsToValueStrategy.getOrDefault(
-                      topic, Neo4jCdcValueStrategy.CHANGE_EVENT)
+                      topic,
+                      Neo4jCdcValueStrategy.CHANGE_EVENT,
+                  )
               SourceRecord(
                   config.partition,
                   mapOf("value" to changeEvent.id.id),
@@ -142,8 +145,10 @@ class Neo4jCdcTask : SourceTask() {
                   valueStrategy.schema(transformedValue),
                   valueStrategy.value(transformedValue),
                   changeEvent.metadata.txCommitTime.toInstant().toEpochMilli(),
-                  Headers.from(changeEvent))
-            })
+                  Headers.from(changeEvent),
+              )
+            }
+        )
       }
     }
 
@@ -169,7 +174,8 @@ class Neo4jCdcTask : SourceTask() {
         config.startFrom,
         SourceConfiguration.IGNORE_STORED_OFFSET,
         config.ignoreStoredOffset,
-        value)
+        value,
+    )
     return value
   }
 }

--- a/source/src/main/kotlin/org/neo4j/connectors/kafka/source/SourceConfiguration.kt
+++ b/source/src/main/kotlin/org/neo4j/connectors/kafka/source/SourceConfiguration.kt
@@ -46,13 +46,13 @@ import org.neo4j.driver.TransactionConfig
 
 enum class SourceType(val description: String) {
   QUERY("query"),
-  CDC("cdc")
+  CDC("cdc"),
 }
 
 enum class StartFrom {
   EARLIEST,
   NOW,
-  USER_PROVIDED
+  USER_PROVIDED,
 }
 
 class SourceConfiguration(originals: Map<*, *>) :
@@ -102,7 +102,11 @@ class SourceConfiguration(originals: Map<*, *>) :
       return when (strategy) {
         SourceType.QUERY ->
             mapOf(
-                "database" to this.database, "type" to "query", "query" to query, "partition" to 1)
+                "database" to this.database,
+                "type" to "query",
+                "query" to query,
+                "partition" to 1,
+            )
         SourceType.CDC -> mapOf("database" to this.database, "type" to "cdc", "partition" to 1)
       }
     }
@@ -196,18 +200,18 @@ class SourceConfiguration(originals: Map<*, *>) :
   private fun mapPositionalPattern(
       configEntry: CdcPatternConfigItem,
       nonPositionalConfigMode: MutableMap<String, Boolean>,
-      configMap: MutableMap<String, MutableList<Pattern>>
+      configMap: MutableMap<String, MutableList<Pattern>>,
   ) {
     val topicName = configEntry.topic
     if (nonPositionalConfigMode.getOrDefault(topicName, false)) {
       throw ConfigException(
-          "It's not allowed to mix positional and non-positional configuration for the same topic.",
+          "It's not allowed to mix positional and non-positional configuration for the same topic."
       )
     }
     val patterns = Pattern.parse(configEntry.value as String?)
     if (patterns.size > 1) {
       throw ConfigException(
-          "Too many patterns. Only one pattern allowed for positional pattern configuration.",
+          "Too many patterns. Only one pattern allowed for positional pattern configuration."
       )
     }
 
@@ -220,7 +224,7 @@ class SourceConfiguration(originals: Map<*, *>) :
     val list = configMap.getValue(topicName)
     if (index > list.size) {
       throw ConfigException(
-          "Index $index out of bounds. Please ensure that you started the definition with a 0-based index.",
+          "Index $index out of bounds. Please ensure that you started the definition with a 0-based index."
       )
     }
     list.add(pattern)
@@ -229,7 +233,7 @@ class SourceConfiguration(originals: Map<*, *>) :
   private fun mapOperation(
       configEntry: CdcPatternConfigItem,
       nonPositionalConfigMode: MutableMap<String, Boolean>,
-      configMap: MutableMap<String, MutableList<Pattern>>
+      configMap: MutableMap<String, MutableList<Pattern>>,
   ) {
     val (index, patterns) = retrieveIndexAndPattern(configEntry, nonPositionalConfigMode, configMap)
     val operation =
@@ -239,7 +243,8 @@ class SourceConfiguration(originals: Map<*, *>) :
           "delete" -> EntityOperation.DELETE
           else -> {
             throw ConfigException(
-                "Cannot parse $value as an operation. Allowed operations are create, delete or update.")
+                "Cannot parse $value as an operation. Allowed operations are create, delete or update."
+            )
           }
         }
     val pattern = patterns[index]
@@ -249,7 +254,7 @@ class SourceConfiguration(originals: Map<*, *>) :
   private fun mapChangesTo(
       configEntry: CdcPatternConfigItem,
       nonPositionalConfigMode: MutableMap<String, Boolean>,
-      configMap: MutableMap<String, MutableList<Pattern>>
+      configMap: MutableMap<String, MutableList<Pattern>>,
   ) {
     val (index, patterns) = retrieveIndexAndPattern(configEntry, nonPositionalConfigMode, configMap)
     val value = configEntry.value as String
@@ -262,7 +267,7 @@ class SourceConfiguration(originals: Map<*, *>) :
       configEntry: CdcPatternConfigItem,
       nonPositionalConfigMode: MutableMap<String, Boolean>,
       configMap: MutableMap<String, MutableList<Pattern>>,
-      patternTxMetadataMap: MutableMap<Pattern, MutableMap<String, Any>>
+      patternTxMetadataMap: MutableMap<Pattern, MutableMap<String, Any>>,
   ) {
     val (index, patterns) = retrieveIndexAndPattern(configEntry, nonPositionalConfigMode, configMap)
     val metadataKey = configEntry.metadata!!
@@ -285,20 +290,19 @@ class SourceConfiguration(originals: Map<*, *>) :
       throw ConfigException(
           "Unexpected metadata key: '$metadataKey' found in configuration property '${configEntry.key}'. " +
               "Valid keys are '$METADATA_KEY_AUTHENTICATED_USER', '$METADATA_KEY_EXECUTING_USER', " +
-              "or keys starting with '$METADATA_KEY_TX_METADATA.*'.")
+              "or keys starting with '$METADATA_KEY_TX_METADATA.*'."
+      )
     }
   }
 
-  private fun mapKeyStrategy(
-      configEntry: CdcPatternConfigItem,
-  ): Pair<String, Neo4jCdcKeyStrategy> {
+  private fun mapKeyStrategy(configEntry: CdcPatternConfigItem): Pair<String, Neo4jCdcKeyStrategy> {
     val topicName = configEntry.topic
     val value = configEntry.value
     return topicName to Neo4jCdcKeyStrategy.valueOf(value as String)
   }
 
   private fun mapValueStrategy(
-      configEntry: CdcPatternConfigItem,
+      configEntry: CdcPatternConfigItem
   ): Pair<String, Neo4jCdcValueStrategy> {
     val topicName = configEntry.topic
     val value = configEntry.value
@@ -308,24 +312,24 @@ class SourceConfiguration(originals: Map<*, *>) :
   private fun retrieveIndexAndPattern(
       configEntry: CdcPatternConfigItem,
       nonPositionalConfigMode: MutableMap<String, Boolean>,
-      configMap: MutableMap<String, MutableList<Pattern>>
+      configMap: MutableMap<String, MutableList<Pattern>>,
   ): Pair<Int, MutableList<Pattern>> {
     val topicName = configEntry.topic
     if (nonPositionalConfigMode.getOrDefault(topicName, false)) {
       throw ConfigException(
-          "It's not allowed to mix positional and non-positional configuration for the same topic.",
+          "It's not allowed to mix positional and non-positional configuration for the same topic."
       )
     }
     val index = configEntry.index!!
     if (!configMap.containsKey(topicName)) {
       throw ConfigException(
-          "Cannot assign config value because pattern is not defined for index $index.",
+          "Cannot assign config value because pattern is not defined for index $index."
       )
     }
     val patterns = configMap.getValue(topicName)
     if (index > patterns.size - 1) {
       throw ConfigException(
-          "Index $index out of bounds. Please ensure that you started the definition with a 0-based index.",
+          "Index $index out of bounds. Please ensure that you started the definition with a 0-based index."
       )
     }
     return Pair(index, patterns)
@@ -469,25 +473,25 @@ class SourceConfiguration(originals: Map<*, *>) :
     private val CDC_PATTERNS_REGEX =
         Regex("^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)$")
     private val CDC_KEY_STRATEGY_REGEX =
-        Regex(
-            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.key-strategy)$",
-        )
+        Regex("^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.key-strategy)$")
     private val CDC_VALUE_STRATEGY_REGEX =
-        Regex(
-            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.value-strategy)$",
-        )
+        Regex("^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.value-strategy)$")
     private val CDC_PATTERN_ARRAY_REGEX =
         Regex(
-            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.pattern)$")
+            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.pattern)$"
+        )
     private val CDC_PATTERN_ARRAY_OPERATION_REGEX =
         Regex(
-            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.operation)$")
+            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.operation)$"
+        )
     private val CDC_PATTERN_ARRAY_CHANGES_TO_REGEX =
         Regex(
-            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.changesTo)$")
+            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.changesTo)$"
+        )
     private val CDC_PATTERN_ARRAY_METADATA_REGEX =
         Regex(
-            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.metadata)\\.(?<$GROUP_NAME_METADATA>[a-zA-Z0-9._-]+)$")
+            "^neo4j\\.cdc\\.topic\\.(?<$GROUP_NAME_TOPIC>[a-zA-Z0-9._-]+)(\\.patterns)\\.(?<$GROUP_NAME_INDEX>[0-9]+)(\\.metadata)\\.(?<$GROUP_NAME_METADATA>[a-zA-Z0-9._-]+)$"
+        )
 
     private val DEFAULT_QUERY_POLL_INTERVAL = 1.seconds
     private val DEFAULT_QUERY_POLL_DURATION = 5.seconds
@@ -534,7 +538,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                 originals.entries.filter { CDC_VALUE_STRATEGY_REGEX.matches(it.key) }
         if (cdcTopics.isEmpty()) {
           strategy.addErrorMessage(
-              "At least one topic needs to be configured with pattern(s) describing the entities to query changes for. Please refer to documentation for more information.")
+              "At least one topic needs to be configured with pattern(s) describing the entities to query changes for. Please refer to documentation for more information."
+          )
         } else {
           cdcTopics.forEach {
             // parse & validate CDC patterns
@@ -571,7 +576,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR.title
                   validator = Validators.enum(SourceType::class.java)
                   recommender = Recommenders.enum(SourceType::class.java)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(START_FROM, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.HIGH
@@ -579,7 +585,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR.title
                   validator = Validators.enum(StartFrom::class.java)
                   recommender = Recommenders.enum(StartFrom::class.java)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(START_FROM_VALUE, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.HIGH
@@ -587,8 +594,11 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR.title
                   recommender =
                       Recommenders.visibleIf(
-                          START_FROM, Predicate.isEqual(StartFrom.USER_PROVIDED.name))
-                })
+                          START_FROM,
+                          Predicate.isEqual(StartFrom.USER_PROVIDED.name),
+                      )
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(IGNORE_STORED_OFFSET, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -596,7 +606,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = Validators.bool()
                   recommender = Recommenders.bool()
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.HIGH
@@ -604,7 +615,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR.title
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY_STREAMING_PROPERTY, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -613,7 +625,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
                   validator = Validators.notBlankOrEmpty()
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY_TOPIC, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.HIGH
@@ -621,7 +634,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR.title
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY_TIMEOUT, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.LOW
@@ -630,7 +644,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY_POLL_INTERVAL, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -639,7 +654,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY_POLL_DURATION, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -648,7 +664,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(QUERY_FORCE_MAPS_AS_STRUCT, ConfigDef.Type.BOOLEAN) {
                   importance = ConfigDef.Importance.LOW
@@ -656,7 +673,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR_ADVANCED.title
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(BATCH_SIZE, ConfigDef.Type.INT) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -665,7 +683,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.QUERY.name))
                   validator = Range.atLeast(1)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CDC_POLL_INTERVAL, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -674,7 +693,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.CDC.name))
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(CDC_POLL_DURATION, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -683,7 +703,8 @@ class SourceConfiguration(originals: Map<*, *>) :
                   recommender =
                       Recommenders.visibleIf(STRATEGY, Predicate.isEqual(SourceType.CDC.name))
                   validator = Validators.pattern(SIMPLE_DURATION_PATTERN)
-                })
+                }
+            )
             .define(
                 ConfigKeyBuilder.of(PAYLOAD_MODE, ConfigDef.Type.STRING) {
                   importance = ConfigDef.Importance.MEDIUM
@@ -691,6 +712,7 @@ class SourceConfiguration(originals: Map<*, *>) :
                   group = Groups.CONNECTOR_ADVANCED.title
                   validator = Validators.enum(PayloadMode::class.java)
                   recommender = Recommenders.enum(PayloadMode::class.java)
-                })
+                }
+            )
   }
 }

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcKeyStrategyTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcKeyStrategyTest.kt
@@ -39,6 +39,7 @@ import org.neo4j.cdc.client.model.NodeEvent
 import org.neo4j.cdc.client.model.NodeState
 import org.neo4j.cdc.client.model.RelationshipEvent
 import org.neo4j.cdc.client.model.RelationshipState
+import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.connectors.kafka.data.ChangeEventConverter
 import org.neo4j.connectors.kafka.data.PropertyType
 import org.neo4j.connectors.kafka.source.Neo4jCdcKeyStrategy.ELEMENT_ID
@@ -171,7 +172,7 @@ object TestData {
           )
 
   val nodeChange =
-      ChangeEventConverter()
+      ChangeEventConverter(PayloadMode.EXTENDED)
           .toConnectValue(
               ChangeEvent(
                   ChangeIdentifier("a-node-change-id"),
@@ -190,7 +191,7 @@ object TestData {
           )
 
   val relChange =
-      ChangeEventConverter()
+      ChangeEventConverter(PayloadMode.EXTENDED)
           .toConnectValue(
               ChangeEvent(
                   ChangeIdentifier("a-rel-change-id"),

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcKeyStrategyTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcKeyStrategyTest.kt
@@ -53,7 +53,7 @@ class Neo4jCdcKeyStrategyTest {
   fun `serializes key schema`(
       message: SchemaAndValue,
       strategy: Neo4jCdcKeyStrategy,
-      expectedKeySchema: Schema?
+      expectedKeySchema: Schema?,
   ) {
     val actualKeySchema = strategy.schema(message)
 
@@ -65,7 +65,7 @@ class Neo4jCdcKeyStrategyTest {
   fun `serializes key value`(
       message: SchemaAndValue,
       strategy: Neo4jCdcKeyStrategy,
-      expectedKeyValue: Any?
+      expectedKeyValue: Any?,
   ) {
     val actualKeyValue = strategy.value(message)
 
@@ -76,7 +76,7 @@ class Neo4jCdcKeyStrategyTest {
 class KeySchemaSerializationArgument : ArgumentsProvider {
   override fun provideArguments(
       parameters: ParameterDeclarations?,
-      context: ExtensionContext?
+      context: ExtensionContext?,
   ): Stream<out Arguments?>? {
     return Stream.of(
         Arguments.of(TestData.nodeChange, SKIP, null),
@@ -94,7 +94,7 @@ class KeySchemaSerializationArgument : ArgumentsProvider {
 class KeyValueSerializationArgument : ArgumentsProvider {
   override fun provideArguments(
       parameters: ParameterDeclarations?,
-      context: ExtensionContext?
+      context: ExtensionContext?,
   ): Stream<out Arguments?>? {
     return Stream.of(
         Arguments.of(TestData.nodeChange, SKIP, null),
@@ -133,7 +133,8 @@ object TestData {
               SchemaBuilder.struct()
                   .field(LABEL, SchemaBuilder.array(propertySchema).optional().build())
                   .optional()
-                  .build())
+                  .build(),
+          )
           .optional()
           .build()
 
@@ -147,9 +148,10 @@ object TestData {
                       listOf(
                           Struct(propertySchema)
                               .put("foo", PropertyType.toConnectValue("fighters"))
-                              .put("bar", PropertyType.toConnectValue(42L)),
+                              .put("bar", PropertyType.toConnectValue(42L))
                       ),
-                  ))
+                  ),
+          )
 
   val relKeysSchema: Schema =
       SchemaBuilder.struct()
@@ -164,8 +166,9 @@ object TestData {
               listOf(
                   Struct(propertySchema)
                       .put("foo", PropertyType.toConnectValue("fighters"))
-                      .put("bar", PropertyType.toConnectValue(42L)),
-              ))
+                      .put("bar", PropertyType.toConnectValue(42L))
+              ),
+          )
 
   val nodeChange =
       ChangeEventConverter()
@@ -181,7 +184,10 @@ object TestData {
                       listOf(LABEL),
                       mapOf(LABEL to listOf(mapOf("foo" to "fighters", "bar" to 42L))),
                       NodeState(listOf(LABEL), mapOf()),
-                      NodeState(listOf(LABEL), mapOf("foo" to "fighters", "bar" to 42L)))))
+                      NodeState(listOf(LABEL), mapOf("foo" to "fighters", "bar" to 42L)),
+                  ),
+              )
+          )
 
   val relChange =
       ChangeEventConverter()
@@ -199,7 +205,10 @@ object TestData {
                       listOf(mapOf("foo" to "fighters", "bar" to 42L)),
                       EntityOperation.CREATE,
                       RelationshipState(mapOf()),
-                      RelationshipState(mapOf("foo" to "fighters", "bar" to 42L)))))
+                      RelationshipState(mapOf("foo" to "fighters", "bar" to 42L)),
+                  ),
+              )
+          )
 
   private fun aTransactionId(): Long {
     return 42
@@ -224,7 +233,8 @@ object TestData {
         txStartTime,
         txCommitTime,
         mapOf("tx" to "metadata"),
-        mapOf("additional" to "entries"))
+        mapOf("additional" to "entries"),
+    )
   }
 
   private fun aRelationshipType() = "A_RELATION_TO"

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -101,7 +101,8 @@ class Neo4jCdcTaskTest {
     driver.session(SessionConfig.forDatabase("system")).use {
       it.run(
               "CREATE OR REPLACE DATABASE \$db OPTIONS { txLogEnrichment: \$mode } WAIT",
-              mapOf("db" to db, "mode" to "FULL"))
+              mapOf("db" to db, "mode" to "FULL"),
+          )
           .consume()
     }
     session = driver.session(SessionConfig.forDatabase(db))
@@ -124,7 +125,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.STRATEGY to SourceType.CDC.toString(),
             SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
             "neo4j.cdc.topic.nodes.patterns" to "()",
-            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()"))
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
 
     // poll for changes
     val changes = task.poll()
@@ -147,7 +150,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.STRATEGY to SourceType.CDC.toString(),
             SourceConfiguration.START_FROM to StartFrom.NOW.toString(),
             "neo4j.cdc.topic.nodes.patterns" to "()",
-            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()"))
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
 
     // create data (2)
     session.run("UNWIND RANGE(1, 75) AS x CREATE (n), (m), (n)-[:RELATED_TO]->(m)").consume()
@@ -180,7 +185,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.START_FROM to StartFrom.USER_PROVIDED.toString(),
             SourceConfiguration.START_FROM_VALUE to changeId,
             "neo4j.cdc.topic.nodes.patterns" to "()",
-            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()"))
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
 
     // poll for changes
     val changes = task.poll()
@@ -214,7 +221,8 @@ class Neo4jCdcTaskTest {
           }
           put("neo4j.cdc.topic.nodes.patterns", "()")
           put("neo4j.cdc.topic.relationships.patterns", "()-[]-()")
-        })
+        }
+    )
 
     // poll for changes
     val changes = task.poll()
@@ -244,7 +252,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
             SourceConfiguration.IGNORE_STORED_OFFSET to "true",
             "neo4j.cdc.topic.nodes.patterns" to "()",
-            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()"))
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
 
     // poll for changes
     val changes = task.poll()
@@ -271,7 +281,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.START_FROM to StartFrom.NOW.toString(),
             SourceConfiguration.IGNORE_STORED_OFFSET to "true",
             "neo4j.cdc.topic.nodes.patterns" to "()",
-            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()"))
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
 
     // create data (2), 100 nodes + 50 relationships
     session.run("UNWIND RANGE(1, 50) AS x CREATE (n), (m), (n)-[:RELATED_TO]->(m)").consume()
@@ -302,7 +314,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.START_FROM_VALUE to currentChangeId(),
             SourceConfiguration.IGNORE_STORED_OFFSET to "true",
             "neo4j.cdc.topic.nodes.patterns" to "()",
-            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()"))
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
 
     // create data (2), 100 nodes + 50 relationships
     session.run("UNWIND RANGE(1, 50) AS x CREATE (n), (m), (n)-[:RELATED_TO]->(m)").consume()
@@ -334,7 +348,8 @@ class Neo4jCdcTaskTest {
               MATCH (c:Company {id: n%25+1})
               CREATE (p)-[:WORKS_FOR {id: n, since: date()}]->(c)
             """
-                .trimIndent())
+                .trimIndent()
+        )
         .consume()
 
     task.start(
@@ -356,7 +371,8 @@ class Neo4jCdcTaskTest {
             "neo4j.cdc.topic.works_for-key.patterns" to
                 "(:Person)-[:WORKS_FOR{id: 11}]->(:Company)",
             "neo4j.cdc.topic.none.patterns" to "(:People),()-[:KNOWS]-()",
-        ))
+        )
+    )
 
     val changes = task.poll().toList()
 
@@ -382,7 +398,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.STRATEGY to SourceType.CDC.toString(),
             SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
             SourceConfiguration.BATCH_SIZE to "5",
-            "neo4j.cdc.topic.nodes.patterns" to "()"))
+            "neo4j.cdc.topic.nodes.patterns" to "()",
+        )
+    )
 
     session.run("UNWIND RANGE(1, 100) AS n CREATE ()").consume()
 
@@ -410,7 +428,9 @@ class Neo4jCdcTaskTest {
             SourceConfiguration.STRATEGY to SourceType.CDC.toString(),
             SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
             SourceConfiguration.CDC_POLL_DURATION to "5s",
-            "neo4j.cdc.topic.nodes.patterns" to "()"))
+            "neo4j.cdc.topic.nodes.patterns" to "()",
+        )
+    )
 
     // should block at most CDC_POLL_DURATION waiting for an event
     measureTime {

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
@@ -126,7 +126,10 @@ class Neo4jQueryTaskTest {
     // create data with timestamp set as NOW + 5m
     expected.addAll(
         insertRecords(
-            100, Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault())))
+            100,
+            Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+        )
+    )
 
     // start task with EARLIEST, previous changes should be visible
     task.start(
@@ -136,7 +139,9 @@ class Neo4jQueryTaskTest {
             SourceConfiguration.STRATEGY to SourceType.QUERY.toString(),
             SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
             SourceConfiguration.QUERY_TOPIC to UUID.randomUUID().toString(),
-            SourceConfiguration.QUERY to sourceQuery))
+            SourceConfiguration.QUERY to sourceQuery,
+        )
+    )
 
     // expect to see all data
     pollAndAssertReceived(expected)
@@ -146,12 +151,16 @@ class Neo4jQueryTaskTest {
   fun `should source data correctly when startFrom=now`() = runTest {
     // create data with timestamp set as NOW - 5m
     insertRecords(
-        100, Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+        100,
+        Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+    )
 
     // create data with timestamp set as NOW + 5m
     val expected =
         insertRecords(
-            75, Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+            75,
+            Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+        )
 
     // start task with NOW, previous changes should NOT be visible
     task.start(
@@ -161,7 +170,9 @@ class Neo4jQueryTaskTest {
             SourceConfiguration.STRATEGY to SourceType.QUERY.toString(),
             SourceConfiguration.START_FROM to StartFrom.NOW.toString(),
             SourceConfiguration.QUERY_TOPIC to UUID.randomUUID().toString(),
-            SourceConfiguration.QUERY to sourceQuery))
+            SourceConfiguration.QUERY to sourceQuery,
+        )
+    )
 
     // expect to see only the data created after task is started
     pollAndAssertReceived(expected)
@@ -171,16 +182,22 @@ class Neo4jQueryTaskTest {
   fun `should source data correctly when startFrom=user provided`() = runTest {
     // create data with timestamp set as NOW - 5m
     insertRecords(
-        10, Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+        10,
+        Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+    )
 
     // create data with timestamp set as NOW + 5m
     insertRecords(
-        25, Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+        25,
+        Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+    )
 
     // create data with timestamp set as NOW + 10m
     val expected =
         insertRecords(
-            75, Clock.fixed(Instant.now().plus(Duration.ofMinutes(10)), ZoneId.systemDefault()))
+            75,
+            Clock.fixed(Instant.now().plus(Duration.ofMinutes(10)), ZoneId.systemDefault()),
+        )
 
     // start task with NOW + 7m, previous changes should NOT be visible
     task.start(
@@ -192,7 +209,9 @@ class Neo4jQueryTaskTest {
             SourceConfiguration.START_FROM_VALUE to
                 Instant.now().plus(Duration.ofMinutes(7)).toEpochMilli().toString(),
             SourceConfiguration.QUERY_TOPIC to UUID.randomUUID().toString(),
-            SourceConfiguration.QUERY to sourceQuery))
+            SourceConfiguration.QUERY to sourceQuery,
+        )
+    )
 
     // expect to see only the data created after the provided timestamp
     pollAndAssertReceived(expected)
@@ -203,19 +222,28 @@ class Neo4jQueryTaskTest {
   fun `should use stored offset regardless of provided startFrom`(startFrom: StartFrom) = runTest {
     // create data with timestamp set as NOW - 5m
     insertRecords(
-        25, Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+        25,
+        Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+    )
 
     val expected =
         // create data with timestamp set as NOW - 2m and NOW + 2m
         insertRecords(
-            25, Clock.fixed(Instant.now().minus(Duration.ofMinutes(2)), ZoneId.systemDefault())) +
+            25,
+            Clock.fixed(Instant.now().minus(Duration.ofMinutes(2)), ZoneId.systemDefault()),
+        ) +
             insertRecords(
-                25, Clock.fixed(Instant.now().plus(Duration.ofMinutes(2)), ZoneId.systemDefault()))
+                25,
+                Clock.fixed(Instant.now().plus(Duration.ofMinutes(2)), ZoneId.systemDefault()),
+            )
 
     // set an offset of NOW - 3m
     task.initialize(
         newTaskContextWithOffset(
-            "timestamp", Instant.now().minus(Duration.ofMinutes(3)).toEpochMilli()))
+            "timestamp",
+            Instant.now().minus(Duration.ofMinutes(3)).toEpochMilli(),
+        )
+    )
 
     // start task with provided START_FROM, with the mocked task context
     task.start(
@@ -231,7 +259,8 @@ class Neo4jQueryTaskTest {
           if (startFrom == StartFrom.USER_PROVIDED) {
             put(SourceConfiguration.START_FROM_VALUE, "-1")
           }
-        })
+        }
+    )
 
     // expect to see only the data created after the stored offset
     pollAndAssertReceived(expected)
@@ -245,7 +274,9 @@ class Neo4jQueryTaskTest {
 
         // create data with timestamp set as NOW + 5m
         insertRecords(
-            100, Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+            100,
+            Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+        )
 
         task.initialize(newTaskContextWithOffset("", Instant.now().toEpochMilli()))
 
@@ -258,7 +289,9 @@ class Neo4jQueryTaskTest {
                 SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
                 SourceConfiguration.QUERY_TOPIC to UUID.randomUUID().toString(),
                 SourceConfiguration.QUERY to sourceQuery,
-                SourceConfiguration.IGNORE_STORED_OFFSET to "true"))
+                SourceConfiguration.IGNORE_STORED_OFFSET to "true",
+            )
+        )
 
         // expect to see all data
         pollAndAssertReceivedSize(150)
@@ -268,11 +301,15 @@ class Neo4jQueryTaskTest {
   fun `should ignore stored offset when startFrom=now and ignore-stored-offset=true`() = runTest {
     // create data with timestamp set as NOW - 5m
     insertRecords(
-        100, Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+        100,
+        Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+    )
 
     // create data with timestamp set as NOW + 5m
     insertRecords(
-        75, Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+        75,
+        Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+    )
 
     task.initialize(newTaskContextWithOffset("", Instant.EPOCH.toEpochMilli()))
 
@@ -285,7 +322,9 @@ class Neo4jQueryTaskTest {
             SourceConfiguration.START_FROM to StartFrom.NOW.toString(),
             SourceConfiguration.QUERY_TOPIC to UUID.randomUUID().toString(),
             SourceConfiguration.QUERY to sourceQuery,
-            SourceConfiguration.IGNORE_STORED_OFFSET to "true"))
+            SourceConfiguration.IGNORE_STORED_OFFSET to "true",
+        )
+    )
 
     // expect to see only the data created after task is started
     pollAndAssertReceivedSize(75)
@@ -296,15 +335,21 @@ class Neo4jQueryTaskTest {
       runTest {
         // create data with timestamp set as NOW - 5m
         insertRecords(
-            10, Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+            10,
+            Clock.fixed(Instant.now().minus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+        )
 
         // create data with timestamp set as NOW + 5m
         insertRecords(
-            25, Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()))
+            25,
+            Clock.fixed(Instant.now().plus(Duration.ofMinutes(5)), ZoneId.systemDefault()),
+        )
 
         // create data with timestamp set as NOW + 10m
         insertRecords(
-            75, Clock.fixed(Instant.now().plus(Duration.ofMinutes(10)), ZoneId.systemDefault()))
+            75,
+            Clock.fixed(Instant.now().plus(Duration.ofMinutes(10)), ZoneId.systemDefault()),
+        )
 
         task.initialize(newTaskContextWithOffset("", Instant.EPOCH.toEpochMilli()))
 
@@ -319,7 +364,9 @@ class Neo4jQueryTaskTest {
                     Instant.now().plus(Duration.ofMinutes(7)).toEpochMilli().toString(),
                 SourceConfiguration.QUERY_TOPIC to UUID.randomUUID().toString(),
                 SourceConfiguration.QUERY to sourceQuery,
-                SourceConfiguration.IGNORE_STORED_OFFSET to "true"))
+                SourceConfiguration.IGNORE_STORED_OFFSET to "true",
+            )
+        )
 
         // expect to see only the data created after the provided timestamp
         pollAndAssertReceivedSize(75)
@@ -360,8 +407,10 @@ class Neo4jQueryTaskTest {
                     "prop4" to null,
                     "prop5" to mapOf("prop" to null),
                     "prop6" to listOf(1L),
-                    "prop7" to listOf<Any?>(null)),
-            "timestamp" to 1717773205L)
+                    "prop7" to listOf<Any?>(null),
+                ),
+            "timestamp" to 1717773205L,
+        )
 
     eventually(30.seconds) {
       val first =
@@ -408,7 +457,10 @@ class Neo4jQueryTaskTest {
                     "root" to
                         listOf(
                             mapOf("children" to emptyList<Map<String, Any>>()),
-                            mapOf("children" to listOf(mapOf("name" to "child"))))))
+                            mapOf("children" to listOf(mapOf("name" to "child"))),
+                        ),
+                ),
+        )
 
     val list = mutableListOf<SourceRecord>()
 
@@ -469,7 +521,8 @@ class Neo4jQueryTaskTest {
                                 |   n AS node
                             """
                           .trimMargin(),
-                      mapOf("timestamp" to ts + it))
+                      mapOf("timestamp" to ts + it),
+                  )
               result.next().asMap().mapValues { (_, v) ->
                 when (v) {
                   is Node ->

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
@@ -38,6 +38,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.neo4j.connectors.kafka.configuration.AuthenticationType
 import org.neo4j.connectors.kafka.configuration.Neo4jConfiguration
+import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.connectors.kafka.data.DynamicTypes
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.neo4jImage
@@ -473,6 +474,60 @@ class Neo4jQueryTaskTest {
   }
 
   @Test
+  fun `should source data with complex type 2 with custom QUERY`() = runTest {
+    val props = mutableMapOf<String, String>()
+    props[Neo4jConfiguration.URI] = neo4j.boltUrl
+    props[SourceConfiguration.QUERY_TOPIC] = UUID.randomUUID().toString()
+    props[SourceConfiguration.QUERY_POLL_INTERVAL] = "10ms"
+    props[SourceConfiguration.QUERY_FORCE_MAPS_AS_STRUCT] = "false"
+    props[SourceConfiguration.PAYLOAD_MODE] = PayloadMode.COMPACT.toString()
+    props[SourceConfiguration.QUERY] =
+        """
+          |WITH {
+          |id: 'ROOT_ID', 
+          |list: [
+          |      {property1: 'property1', subList: [{subListProperty1: 'subListProperty1'}]}, 
+          |      {property1: 'property2', subList: [{subListProperty1: 'subListProperty2'}]}
+          |]} AS data 
+          |RETURN data, data.id AS guid, 123456789 AS timestamp
+            """
+            .trimMargin()
+    props[Neo4jConfiguration.AUTHENTICATION_TYPE] = AuthenticationType.NONE.toString()
+
+    task.start(props)
+
+    val expected =
+        mapOf(
+            "timestamp" to 123456789L,
+            "guid" to "ROOT_ID",
+            "data" to
+                mapOf(
+                    "id" to "ROOT_ID",
+                    "list" to
+                        listOf(
+                            mapOf(
+                                "property1" to "property1",
+                                "subList" to listOf(mapOf("subListProperty1" to "subListProperty1")),
+                            ),
+                            mapOf(
+                                "property1" to "property2",
+                                "subList" to listOf(mapOf("subListProperty1" to "subListProperty2")),
+                            ),
+                        ),
+                ),
+        )
+
+    val list = mutableListOf<SourceRecord>()
+
+    eventually(30.seconds) {
+      task.poll()?.let { list.addAll(it) }
+      val actualList = list.map { DynamicTypes.fromConnectValue(it.valueSchema(), it.value()) }
+
+      actualList.firstOrNull()!! shouldBe expected
+    }
+  }
+
+  @Test
   fun `should throw exception if provided with an invalid query`() {
     assertFailsWith(ClientException::class) {
       val props = mutableMapOf<String, String>()
@@ -531,6 +586,7 @@ class Neo4jQueryTaskTest {
                         this["<labels>"] = v.labels()
                         this.putAll(v.asMap())
                       }
+
                   else -> v
                 }
               }

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/SourceConfigurationTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/SourceConfigurationTest.kt
@@ -49,7 +49,9 @@ class SourceConfigurationTest {
           SourceConfiguration(
               mapOf(
                   Neo4jConfiguration.URI to "neo4j://localhost",
-                  SourceConfiguration.STRATEGY to "none"))
+                  SourceConfiguration.STRATEGY to "none",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -60,7 +62,9 @@ class SourceConfigurationTest {
           SourceConfiguration(
               mapOf(
                   Neo4jConfiguration.URI to "neo4j://localhost",
-                  SourceConfiguration.STRATEGY to "none"))
+                  SourceConfiguration.STRATEGY to "none",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -74,7 +78,9 @@ class SourceConfigurationTest {
                   SourceConfiguration.STRATEGY to "QUERY",
                   SourceConfiguration.QUERY to "MATCH (n) RETURN n",
                   SourceConfiguration.QUERY_TOPIC to "my-topic",
-                  SourceConfiguration.START_FROM to "none"))
+                  SourceConfiguration.START_FROM to "none",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -89,7 +95,9 @@ class SourceConfigurationTest {
                   SourceConfiguration.QUERY to "MATCH (n) RETURN n",
                   SourceConfiguration.QUERY_TOPIC to "my-topic",
                   SourceConfiguration.START_FROM to "EARLIEST",
-                  SourceConfiguration.QUERY_POLL_INTERVAL to "1k"))
+                  SourceConfiguration.QUERY_POLL_INTERVAL to "1k",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -105,7 +113,9 @@ class SourceConfigurationTest {
                   SourceConfiguration.QUERY_TOPIC to "my-topic",
                   SourceConfiguration.START_FROM to "EARLIEST",
                   SourceConfiguration.QUERY_POLL_INTERVAL to "1m",
-                  SourceConfiguration.QUERY_TIMEOUT to "1k"))
+                  SourceConfiguration.QUERY_TIMEOUT to "1k",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -122,7 +132,9 @@ class SourceConfigurationTest {
                   SourceConfiguration.START_FROM to "EARLIEST",
                   SourceConfiguration.QUERY_POLL_INTERVAL to "1m",
                   SourceConfiguration.QUERY_TIMEOUT to "5m",
-                  SourceConfiguration.BATCH_SIZE to "-1"))
+                  SourceConfiguration.BATCH_SIZE to "-1",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -140,7 +152,9 @@ class SourceConfigurationTest {
                   SourceConfiguration.QUERY_POLL_INTERVAL to "1m",
                   SourceConfiguration.QUERY_STREAMING_PROPERTY to "",
                   SourceConfiguration.QUERY_TIMEOUT to "5m",
-                  SourceConfiguration.BATCH_SIZE to "50"))
+                  SourceConfiguration.BATCH_SIZE to "50",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -161,7 +175,9 @@ class SourceConfigurationTest {
                 SourceConfiguration.START_FROM to "EARLIEST",
                 SourceConfiguration.QUERY_POLL_INTERVAL to "1m",
                 SourceConfiguration.QUERY_TIMEOUT to "5m",
-                SourceConfiguration.BATCH_SIZE to "50"))
+                SourceConfiguration.BATCH_SIZE to "50",
+            )
+        )
 
     assertEquals(SourceType.QUERY, config.strategy)
     assertEquals("MATCH (n) RETURN n", config.query)
@@ -183,7 +199,9 @@ class SourceConfigurationTest {
                 SourceConfiguration.START_FROM to "EARLIEST",
                 SourceConfiguration.BATCH_SIZE to "10000",
                 SourceConfiguration.CDC_POLL_INTERVAL to "5s",
-                "neo4j.cdc.topic.topic-1.patterns" to "(),()-[]-()"))
+                "neo4j.cdc.topic.topic-1.patterns" to "(),()-[]-()",
+            )
+        )
 
     config.strategy shouldBe SourceType.CDC
     config.startFrom shouldBe StartFrom.EARLIEST
@@ -192,7 +210,8 @@ class SourceConfigurationTest {
     config.cdcSelectorsToTopics shouldContainExactly
         mapOf(
             NodeSelector.builder().build() to listOf("topic-1"),
-            RelationshipSelector.builder().build() to listOf("topic-1"))
+            RelationshipSelector.builder().build() to listOf("topic-1"),
+        )
   }
 
   @Test
@@ -216,7 +235,8 @@ class SourceConfigurationTest {
                 "neo4j.cdc.topic.topic-3.patterns.0.metadata.authenticatedUser" to "someone",
                 "neo4j.cdc.topic.topic-3.patterns.0.metadata.executingUser" to "someoneElse",
                 "neo4j.cdc.topic.topic-3.patterns.0.metadata.txMetadata.app" to "neo4j-browser",
-            ))
+            )
+        )
 
     config.strategy shouldBe SourceType.CDC
     config.startFrom shouldBe StartFrom.EARLIEST
@@ -243,7 +263,8 @@ class SourceConfigurationTest {
                 .withTxMetadata(mapOf("app" to "neo4j-browser"))
                 .withExecutingUser("someoneElse")
                 .withAuthenticatedUser("someone")
-                .build() to listOf("topic-3"))
+                .build() to listOf("topic-3"),
+        )
   }
 
   @Test
@@ -259,7 +280,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns" to "(:Person)",
                       "neo4j.cdc.topic.people.patterns.0.pattern" to "(:User)",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -281,7 +303,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns" to "(:Person)",
                       "neo4j.cdc.topic.people.patterns.0.operation" to "create",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -303,7 +326,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns" to "(:Person)",
                       "neo4j.cdc.topic.people.patterns.0.changesTo" to "name",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -325,7 +349,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns" to "(:Person)",
                       "neo4j.cdc.topic.people.patterns.0.metadata.authenticatedUser" to "neo4j",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -347,7 +372,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns.0.pattern" to "(:User)-[]-(),()",
                       "neo4j.cdc.topic.people.patterns.0.operation" to "create",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -368,7 +394,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.BATCH_SIZE to "10000",
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns.1.pattern" to "(:User)",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -389,7 +416,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.BATCH_SIZE to "10000",
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns.1.changesTo" to "name",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -410,7 +438,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.BATCH_SIZE to "10000",
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns.1.operation" to "create",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -431,7 +460,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.BATCH_SIZE to "10000",
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns.1.metadata.authenticatedUser" to "neo4j",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -453,7 +483,8 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.people.patterns.0.pattern" to "(:User)",
                       "neo4j.cdc.topic.people.patterns.0.operation" to "wurstsalat",
-                  ))
+                  )
+              )
               .cdcSelectors
         }
         .also {
@@ -480,7 +511,9 @@ class SourceConfigurationTest {
                   "neo4j.cdc.topic.updates.patterns.0.pattern" to "(:TestSource)",
                   "neo4j.cdc.topic.updates.patterns.0.operation" to "UPDATE",
                   "neo4j.cdc.topic.deletes.patterns.0.pattern" to "(:TestSource)",
-                  "neo4j.cdc.topic.deletes.patterns.0.operation" to "DELETE"))
+                  "neo4j.cdc.topic.deletes.patterns.0.operation" to "DELETE",
+              )
+          )
 
       config.validate()
     }
@@ -519,7 +552,7 @@ class SourceConfigurationTest {
                       "pattern1-value0",
                   "neo4j.cdc.topic.my-topic.patterns.1.metadata.txMetadata.key1" to
                       "pattern1-value1",
-              ),
+              )
           )
 
       configuration.validate()
@@ -543,7 +576,8 @@ class SourceConfigurationTest {
                   .withTxMetadata(mapOf("key0" to "pattern1-value0", "key1" to "pattern1-value1"))
                   .withExecutingUser("pattern1-execUser")
                   .withAuthenticatedUser("pattern1-authUser")
-                  .build())
+                  .build(),
+          )
       configuration.cdcSelectorsToTopics shouldBe
           mapOf(
               NodeSelector.builder()
@@ -584,8 +618,9 @@ class SourceConfigurationTest {
                 "neo4j.cdc.topic.myTopic.patterns.0.operation" to "CREATE",
                 "neo4j.cdc.topic.myTopic.patterns.0.metadata.txMetadata.app" to
                     "something-AI-something",
-                "neo4j.cdc.topic.myTopic.patterns.0.metadata.txMetadataButNotReally.key" to
-                    "value"))
+                "neo4j.cdc.topic.myTopic.patterns.0.metadata.txMetadataButNotReally.key" to "value",
+            )
+        )
 
     assertFailsWith(ConfigException::class) { config.cdcSelectorsToTopics }
         .also {
@@ -607,7 +642,7 @@ class SourceConfigurationTest {
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.topic-1.patterns" to "(),()-[]-()",
                       "neo4j.cdc.topic.topic-1.key-strategy" to "INVALID",
-                  ),
+                  )
               )
               .validate()
         }
@@ -629,7 +664,9 @@ class SourceConfigurationTest {
                       SourceConfiguration.BATCH_SIZE to "10000",
                       SourceConfiguration.CDC_POLL_INTERVAL to "5s",
                       "neo4j.cdc.topic.topic-1.patterns" to "(),()-[]-()",
-                      "neo4j.cdc.topic.topic-1.value-strategy" to "INVALID"))
+                      "neo4j.cdc.topic.topic-1.value-strategy" to "INVALID",
+                  )
+              )
               .validate()
         }
         .also {
@@ -648,7 +685,9 @@ class SourceConfigurationTest {
                   SourceConfiguration.QUERY to "MATCH (n) RETURN n",
                   SourceConfiguration.QUERY_TOPIC to "my-topic",
                   SourceConfiguration.START_FROM to "EARLIEST",
-                  SourceConfiguration.PAYLOAD_MODE to "invalid"))
+                  SourceConfiguration.PAYLOAD_MODE to "invalid",
+              )
+          )
         }
         .also {
           it shouldHaveMessage
@@ -672,7 +711,8 @@ class SourceConfigurationTest {
             "neo4j.cdc.topic.updates.patterns.0.pattern" to "(:TestSource)",
             "neo4j.cdc.topic.updates.patterns.0.operation" to "UPDATE",
             "neo4j.cdc.topic.deletes.patterns.0.pattern" to "(:TestSource)",
-            "neo4j.cdc.topic.deletes.patterns.0.operation" to "DELETE")
+            "neo4j.cdc.topic.deletes.patterns.0.operation" to "DELETE",
+        )
     val config = SourceConfiguration(originals)
 
     config.userAgentComment() shouldBe "cdc"
@@ -691,7 +731,8 @@ class SourceConfigurationTest {
             "neo4j.source-strategy" to "QUERY",
             "neo4j.query" to "RETURN 1",
             "neo4j.start-from" to "NOW",
-            "neo4j.topic" to "my-topic")
+            "neo4j.topic" to "my-topic",
+        )
     val config = SourceConfiguration(originals)
 
     config.userAgentComment() shouldBe "query"

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/AnnotationSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/AnnotationSupport.kt
@@ -27,10 +27,7 @@ internal object AnnotationSupport {
     while (current != null) {
       if (current.testMethod.isPresent) {
         val methodAnnotation =
-            AnnotationSupport.findAnnotation(
-                current.testMethod.get(),
-                T::class.java,
-            )
+            AnnotationSupport.findAnnotation(current.testMethod.get(), T::class.java)
         if (methodAnnotation.isPresent) {
           return methodAnnotation.get()
         }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DatabaseSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DatabaseSupport.kt
@@ -29,7 +29,8 @@ object DatabaseSupport {
     if (withCdc) {
       this.run(
           "CREATE DATABASE \$db_name OPTIONS { txLogEnrichment: 'FULL' } WAIT 30 SECONDS",
-          mapOf("db_name" to database))
+          mapOf("db_name" to database),
+      )
     } else {
       this.run("CREATE DATABASE \$db_name WAIT 30 SECONDS", mapOf("db_name" to database))
     }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DateSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DateSupport.kt
@@ -44,7 +44,7 @@ object DateSupport {
       hour: Int,
       minute: Int,
       second: Int,
-      millis: Int
+      millis: Int,
   ): Date {
     val calendar = Calendar.getInstance(UTC)
     calendar.set(year, month - 1, day, hour, minute, second)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/MapSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/MapSupport.kt
@@ -23,7 +23,7 @@ object MapSupport {
   @Suppress("UNCHECKED_CAST")
   internal fun <K, Any> MutableMap<K, Any>.nestUnder(
       key: K,
-      values: Map<K, Any>
+      values: Map<K, Any>,
   ): MutableMap<K, Any> {
     val map = this[key]
     if (map !is Map<*, *>) {
@@ -43,7 +43,8 @@ object MapSupport {
     val missing = keys.filter { !this.keys.contains(it) }
     if (missing.isNotEmpty()) {
       throw IllegalArgumentException(
-          "Cannot exclude keys ${missing.joinToString()}: they are missing from map $this")
+          "Cannot exclude keys ${missing.joinToString()}: they are missing from map $this"
+      )
     }
     val exclusions = setOf(*keys)
     return this.filterKeys { !exclusions.contains(it) }
@@ -52,7 +53,7 @@ object MapSupport {
   fun <T : Any> MutableMap<String, Any>.putConditionally(
       key: String,
       value: T,
-      condition: (T) -> Boolean
+      condition: (T) -> Boolean,
   ): MutableMap<String, Any> {
     if (!condition(value)) {
       return this

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/Neo4jSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/Neo4jSupport.kt
@@ -33,11 +33,12 @@ fun Session.createNodeKeyConstraint(
     neo4j: Neo4j,
     name: String,
     label: String,
-    vararg properties: String
+    vararg properties: String,
 ) {
   if (canIUse(Schema.nodeKeyConstraints()).withNeo4j(neo4j)) {
     this.run(
-            "CREATE CONSTRAINT $name FOR (n:$label) REQUIRE ${properties.joinToString(", ", "(", ")") { "n.$it"}} IS NODE KEY")
+            "CREATE CONSTRAINT $name FOR (n:$label) REQUIRE ${properties.joinToString(", ", "(", ")") { "n.$it"}} IS NODE KEY"
+        )
         .consume()
   } else {
     if (canIUse(Schema.nodePropertyUniquenessConstraints()).withNeo4j(neo4j)) {
@@ -46,9 +47,10 @@ fun Session.createNodeKeyConstraint(
             properties.joinToString(
                 ", ",
                 "(",
-                ")"
+                ")",
             ) { "n.$it" }
-          } IS UNIQUE")
+          } IS UNIQUE"
+          )
           .consume()
     }
 
@@ -65,11 +67,12 @@ fun Session.createRelationshipKeyConstraint(
     neo4j: Neo4j,
     name: String,
     type: String,
-    vararg properties: String
+    vararg properties: String,
 ) {
   if (canIUse(Schema.relationshipKeyConstraints()).withNeo4j(neo4j)) {
     this.run(
-            "CREATE CONSTRAINT $name FOR ()-[r:$type]->() REQUIRE ${properties.joinToString(", ", "(", ")") { "r.$it" } } IS RELATIONSHIP KEY")
+            "CREATE CONSTRAINT $name FOR ()-[r:$type]->() REQUIRE ${properties.joinToString(", ", "(", ")") { "r.$it" } } IS RELATIONSHIP KEY"
+        )
         .consume()
   } else {
     if (canIUse(Schema.relationshipPropertyUniquenessConstraints()).withNeo4j(neo4j)) {
@@ -78,9 +81,10 @@ fun Session.createRelationshipKeyConstraint(
             properties.joinToString(
                 ", ",
                 "(",
-                ")"
+                ")",
             ) { "r.$it"} 
-          } IS UNIQUE")
+          } IS UNIQUE"
+          )
           .consume()
     }
 

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/ParameterSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/ParameterSupport.kt
@@ -26,14 +26,14 @@ internal class ParameterResolvers(
 
   override fun supportsParameter(
       parameterContext: ParameterContext?,
-      ignored: ExtensionContext?
+      ignored: ExtensionContext?,
   ): Boolean {
     return parameterResolvers.containsKey(parameterContext!!.parameter.type)
   }
 
   override fun resolveParameter(
       parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): Any {
     val resolver = parameterResolvers[parameterContext!!.parameter.type]!!
     return resolver(parameterContext, extensionContext)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/SchemaRegistrySupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/SchemaRegistrySupport.kt
@@ -34,7 +34,9 @@ internal object SchemaRegistrySupport {
             .header("Accept", "application/json")
             .PUT(
                 HttpRequest.BodyPublishers.ofString(
-                    convertToJson(mapOf("compatibility" to mode.name))))
+                    convertToJson(mapOf("compatibility" to mode.name))
+                )
+            )
             .build()
     val response = HttpClient.newHttpClient().send(update, HttpResponse.BodyHandlers.ofString())
     if (response.statusCode() != 200) {

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/TestSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/TestSupport.kt
@@ -39,7 +39,7 @@ object TestSupport {
    */
   fun runTest(
       context: CoroutineContext = EmptyCoroutineContext,
-      block: suspend CoroutineScope.() -> Any
+      block: suspend CoroutineScope.() -> Any,
   ): Unit {
     runBlocking(context, block)
     Unit

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/assertions/ChangeEventAssert.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/assertions/ChangeEventAssert.kt
@@ -32,7 +32,8 @@ class ChangeEventAssert(actual: ChangeEvent?) :
     isNotNull
     if (event().eventType != eventType) {
       failWithMessage(
-          "Expected event type to be <${eventType.name}> but was <${event().eventType}>")
+          "Expected event type to be <${eventType.name}> but was <${event().eventType}>"
+      )
     }
     return this
   }
@@ -73,27 +74,29 @@ class ChangeEventAssert(actual: ChangeEvent?) :
 
   fun hasBeforeStateProperties(
       properties: Map<String, Any>,
-      vararg excludingKeys: String
+      vararg excludingKeys: String,
   ): ChangeEventAssert {
     isNotNull
     val actualProperties = event().before?.properties?.excludingKeys(*excludingKeys) ?: emptyMap()
     if (actualProperties != properties) {
       failWithMessage(
-          "Expected before state's properties to be <$properties> but was <$actualProperties>")
+          "Expected before state's properties to be <$properties> but was <$actualProperties>"
+      )
     }
     return this
   }
 
   fun hasAfterStateProperties(
       properties: Map<String, Any>,
-      vararg excludingKeys: String
+      vararg excludingKeys: String,
   ): ChangeEventAssert {
 
     isNotNull
     val actualProperties = event().after?.properties?.excludingKeys(*excludingKeys) ?: emptyMap()
     if (actualProperties != properties) {
       failWithMessage(
-          "Expected after state's properties to be <$properties> but was <$actualProperties>")
+          "Expected after state's properties to be <$properties> but was <$actualProperties>"
+      )
     }
     return this
   }
@@ -102,7 +105,7 @@ class ChangeEventAssert(actual: ChangeEvent?) :
     isNotNull
     if (actual.metadata.txMetadata != txMetadata) {
       failWithMessage(
-          "Expect txMetadata to be <$txMetadata> but was <${actual.metadata.txMetadata}>",
+          "Expect txMetadata to be <$txMetadata> but was <${actual.metadata.txMetadata}>"
       )
     }
     return this
@@ -124,7 +127,8 @@ class ChangeEventAssert(actual: ChangeEvent?) :
     isNotNull
     if (relationshipEvent().start.labels.toSet() != labels) {
       failWithMessage(
-          "Expected start labels to be <${labels}> but was <${relationshipEvent().start.labels}>")
+          "Expected start labels to be <${labels}> but was <${relationshipEvent().start.labels}>"
+      )
     }
     return this
   }
@@ -137,7 +141,8 @@ class ChangeEventAssert(actual: ChangeEvent?) :
     isNotNull
     if (relationshipEvent().end.labels.toSet() != labels) {
       failWithMessage(
-          "Expected end labels to be <${labels}> but was <${relationshipEvent().end.labels}>")
+          "Expected end labels to be <${labels}> but was <${relationshipEvent().end.labels}>"
+      )
     }
     return this
   }
@@ -154,7 +159,8 @@ class ChangeEventAssert(actual: ChangeEvent?) :
     isNotNull
     if (relationshipEvent().keys != keys) {
       failWithMessage(
-          "Expected relationship keys to be <$keys> but was <${relationshipEvent().keys}>")
+          "Expected relationship keys to be <$keys> but was <${relationshipEvent().keys}>"
+      )
     }
     return this
   }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/assertions/TopicVerifier.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/assertions/TopicVerifier.kt
@@ -58,7 +58,7 @@ class TopicVerifier<K, V>(
   @Suppress("UNCHECKED_CAST")
   fun assertMessage(
       schemaTopic: String? = null,
-      assertion: (GenericRecord<K, V>) -> Unit
+      assertion: (GenericRecord<K, V>) -> Unit,
   ): TopicVerifier<K, V> {
     messagePredicates.add { record ->
       try {
@@ -147,7 +147,7 @@ class TopicVerifier<K, V>(
       }
     } catch (e: ConditionTimeoutException) {
       throw AssertionError(
-          "Timeout of ${timeout.toMillis()}s reached: could not verify all ${predicates.size} predicate(s) on received messages",
+          "Timeout of ${timeout.toMillis()}s reached: could not verify all ${predicates.size} predicate(s) on received messages"
       )
     }
   }
@@ -182,7 +182,7 @@ class TopicVerifier<K, V>(
 
   companion object {
     inline fun <reified K, reified V> create(
-        consumer: ConvertingKafkaConsumer,
+        consumer: ConvertingKafkaConsumer
     ): TopicVerifier<K, V> {
       val keyConverter = consumer.keyConverter.converterProvider()
       when (consumer.keyConverter) {
@@ -193,7 +193,7 @@ class TopicVerifier<K, V>(
             keyConverter.configure(
                 mapOf(
                     AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG to
-                        consumer.schemaRegistryUrlProvider(),
+                        consumer.schemaRegistryUrlProvider()
                 ),
                 true,
             )
@@ -208,7 +208,7 @@ class TopicVerifier<K, V>(
             valueConverter.configure(
                 mapOf(
                     AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG to
-                        consumer.schemaRegistryUrlProvider(),
+                        consumer.schemaRegistryUrlProvider()
                 ),
                 false,
             )

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/format/KafkaConverter.kt
@@ -91,7 +91,7 @@ enum class KafkaConverter(
       converterProvider = { StringConverter() },
       serializerClass = org.apache.kafka.common.serialization.StringSerializer::class.java,
       testShimSerializer = StringSerializer,
-  )
+  ),
 }
 
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
@@ -99,7 +99,7 @@ enum class KafkaConverter(
 annotation class KeyValueConverter(
     val key: KafkaConverter,
     val value: KafkaConverter,
-    val payloadMode: PayloadMode = PayloadMode.EXTENDED
+    val payloadMode: PayloadMode = PayloadMode.EXTENDED,
 )
 
 class KeyValueConverterResolver {

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConsumerResolver.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConsumerResolver.kt
@@ -30,32 +30,30 @@ internal class ConsumerResolver(
     private val topicRegistry: TopicRegistry,
     private val brokerExternalHostProvider: () -> String,
     private val schemaControlRegistryExternalUriProvider: () -> String,
-    private val consumerFactory: (Properties, String) -> KafkaConsumer<ByteArray, ByteArray>
+    private val consumerFactory: (Properties, String) -> KafkaConsumer<ByteArray, ByteArray>,
 ) {
 
   fun resolveGenericConsumer(
       parameterContext: ParameterContext?,
-      context: ExtensionContext?
+      context: ExtensionContext?,
   ): ConvertingKafkaConsumer {
     val kafkaConsumer = resolveConsumer(parameterContext, context)
     return ConvertingKafkaConsumer(
         keyConverter = keyValueConverterResolver.resolveKeyConverter(context),
         valueConverter = keyValueConverterResolver.resolveValueConverter(context),
         schemaRegistryUrlProvider = schemaControlRegistryExternalUriProvider,
-        kafkaConsumer = kafkaConsumer)
+        kafkaConsumer = kafkaConsumer,
+    )
   }
 
   private fun resolveConsumer(
       parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): KafkaConsumer<ByteArray, ByteArray> {
     val consumerAnnotation = parameterContext?.parameter?.getAnnotation(TopicConsumer::class.java)!!
     val topic = topicRegistry.resolveTopic(consumerAnnotation.topic)
     val properties = Properties()
-    properties.setProperty(
-        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-        brokerExternalHostProvider(),
-    )
+    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerExternalHostProvider())
 
     properties.setProperty(
         ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
@@ -79,7 +77,7 @@ internal class ConsumerResolver(
   companion object {
     internal fun getSubscribedConsumer(
         properties: Properties,
-        topic: String
+        topic: String,
     ): KafkaConsumer<ByteArray, ByteArray> {
       val consumer = KafkaConsumer<ByteArray, ByteArray>(properties)
       consumer.subscribe(listOf(topic))

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaConsumer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaConsumer.kt
@@ -24,7 +24,7 @@ data class ConvertingKafkaConsumer(
     val keyConverter: KafkaConverter,
     val valueConverter: KafkaConverter,
     val schemaRegistryUrlProvider: () -> String,
-    val kafkaConsumer: KafkaConsumer<ByteArray, ByteArray>
+    val kafkaConsumer: KafkaConsumer<ByteArray, ByteArray>,
 )
 
 data class GenericRecord<K, V>(val key: K?, val value: V, val raw: ConsumerRecord<*, *>)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaProducer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaProducer.kt
@@ -39,7 +39,7 @@ data class KafkaMessage(
     val valueSchema: Schema? = null,
     val value: Any? = null,
     val timestamp: Instant? = null,
-    val headers: Map<String, Any> = emptyMap()
+    val headers: Map<String, Any> = emptyMap(),
 )
 
 data class ConvertingKafkaProducer(
@@ -49,7 +49,7 @@ data class ConvertingKafkaProducer(
     val valueCompatibilityMode: SchemaCompatibilityMode,
     val valueConverter: KafkaConverter,
     val kafkaProducer: KafkaProducer<Any, Any>,
-    val topic: String
+    val topic: String,
 ) {
 
   init {
@@ -69,7 +69,8 @@ data class ConvertingKafkaProducer(
                   keyConverter.testShimSerializer.serialize(
                       it.key,
                       it.keySchema ?: throw IllegalArgumentException("null key schema"),
-                      true)
+                      true,
+                  )
             }
         val serializedValue =
             when (it.value) {
@@ -78,7 +79,8 @@ data class ConvertingKafkaProducer(
                   valueConverter.testShimSerializer.serialize(
                       it.value,
                       it.valueSchema ?: throw IllegalArgumentException("null value schema"),
-                      false)
+                      false,
+                  )
             }
         val converter = SimpleHeaderConverter()
         val recordHeaders =
@@ -88,7 +90,11 @@ data class ConvertingKafkaProducer(
 
                 override fun value(): ByteArray {
                   return converter.fromConnectHeader(
-                      "", e.key, Values.inferSchema(e.value), e.value)
+                      "",
+                      e.key,
+                      Values.inferSchema(e.value),
+                      e.value,
+                  )
                 }
               }
             }
@@ -100,7 +106,8 @@ data class ConvertingKafkaProducer(
                 it.timestamp?.toEpochMilli(),
                 serializedKey,
                 serializedValue,
-                recordHeaders)
+                recordHeaders,
+            )
         kafkaProducer.send(record).get()
       }
       kafkaProducer.commitTransaction()
@@ -116,7 +123,7 @@ data class ConvertingKafkaProducer(
       valueSchema: Schema? = null,
       value: Any? = null,
       timestamp: Instant? = null,
-      headers: Map<String, Any> = emptyMap()
+      headers: Map<String, Any> = emptyMap(),
   ) {
     publish(KafkaMessage(keySchema, key, valueSchema, value, timestamp, headers))
   }
@@ -130,7 +137,8 @@ data class ConvertingKafkaProducer(
         valueSchema = connectValue.schema(),
         value = connectValue.value(),
         timestamp = event.metadata.txCommitTime.toInstant(),
-        headers = Headers.from(event).associate { it.key() to it.value() })
+        headers = Headers.from(event).associate { it.key() to it.value() },
+    )
   }
 
   fun publish(vararg events: ChangeEvent) {
@@ -145,7 +153,9 @@ data class ConvertingKafkaProducer(
               valueSchema = connectValue.schema(),
               value = connectValue.value(),
               timestamp = it.metadata.txCommitTime.toInstant(),
-              headers = Headers.from(it).associate { header -> header.key() to header.value() }))
+              headers = Headers.from(it).associate { header -> header.key() to header.value() },
+          )
+      )
     }
 
     publish(*kafkaMessages.toTypedArray())
@@ -157,8 +167,14 @@ data class ConvertingKafkaProducer(
 
   private fun ensureSchemaCompatibility(topic: String) {
     SchemaRegistrySupport.setCompatibilityMode(
-        schemaRegistryURI, "$topic-key", keyCompatibilityMode)
+        schemaRegistryURI,
+        "$topic-key",
+        keyCompatibilityMode,
+    )
     SchemaRegistrySupport.setCompatibilityMode(
-        schemaRegistryURI, "$topic-value", valueCompatibilityMode)
+        schemaRegistryURI,
+        "$topic-value",
+        valueCompatibilityMode,
+    )
   }
 }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaProducer.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ConvertingKafkaProducer.kt
@@ -25,6 +25,7 @@ import org.apache.kafka.connect.data.Schema
 import org.apache.kafka.connect.data.Values
 import org.apache.kafka.connect.storage.SimpleHeaderConverter
 import org.neo4j.cdc.client.model.ChangeEvent
+import org.neo4j.connectors.kafka.configuration.PayloadMode
 import org.neo4j.connectors.kafka.data.ChangeEventConverter
 import org.neo4j.connectors.kafka.data.Headers
 import org.neo4j.connectors.kafka.events.StreamsTransactionEvent
@@ -56,7 +57,7 @@ data class ConvertingKafkaProducer(
     ensureSchemaCompatibility(topic)
   }
 
-  private val changeEventConverter = ChangeEventConverter()
+  private val changeEventConverter = ChangeEventConverter(PayloadMode.EXTENDED)
 
   fun publish(vararg kafkaMessages: KafkaMessage) {
     kafkaProducer.beginTransaction()

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ProducerResolver.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/ProducerResolver.kt
@@ -34,12 +34,12 @@ class ProducerResolver(
     private val brokerExternalHostProvider: () -> String,
     private val schemaControlRegistryExternalUriProvider: () -> String,
     private val schemaControlKeyCompatibilityProvider: () -> SchemaCompatibilityMode,
-    private val schemaControlValueCompatibilityProvider: () -> SchemaCompatibilityMode
+    private val schemaControlValueCompatibilityProvider: () -> SchemaCompatibilityMode,
 ) {
 
   fun resolveGenericProducer(
       parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): Any {
     val producerAnnotation = parameterContext?.parameter?.getAnnotation(TopicProducer::class.java)!!
     return ConvertingKafkaProducer(
@@ -49,18 +49,16 @@ class ProducerResolver(
         valueConverter = keyValueConverterResolver.resolveValueConverter(extensionContext),
         valueCompatibilityMode = schemaControlValueCompatibilityProvider(),
         kafkaProducer = resolveProducer(parameterContext, extensionContext),
-        topic = topicRegistry.resolveTopic(producerAnnotation.topic))
+        topic = topicRegistry.resolveTopic(producerAnnotation.topic),
+    )
   }
 
   private fun resolveProducer(
       @Suppress("UNUSED_PARAMETER") parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): KafkaProducer<Any, Any> {
     val properties = Properties()
-    properties.setProperty(
-        ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-        brokerExternalHostProvider(),
-    )
+    properties.setProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, brokerExternalHostProvider())
     val keyConverter = keyValueConverterResolver.resolveKeyConverter(extensionContext)
     val valueConverter = keyValueConverterResolver.resolveValueConverter(extensionContext)
     if (keyConverter.supportsSchemaRegistry || valueConverter.supportsSchemaRegistry) {

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/TopicRegistry.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/kafka/TopicRegistry.kt
@@ -37,7 +37,8 @@ class TopicRegistry {
     log.info(
         "Using the following topic mapping:\n${aliases.entries.joinToString("\n") { 
           " * '${it.key}' -> '${it.value}'" 
-        }}")
+        }}"
+    )
   }
 
   fun clear() {

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSink.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSink.kt
@@ -54,7 +54,7 @@ enum class SchemaCompatibilityMode {
   FORWARD_TRANSITIVE,
   FULL,
   FULL_TRANSITIVE,
-  NONE
+  NONE,
 }
 
 annotation class CypherStrategy(
@@ -64,30 +64,28 @@ annotation class CypherStrategy(
     val bindHeaderAs: String = "__header",
     val bindKeyAs: String = "__key",
     val bindValueAs: String = "__value",
-    val bindValueAsEvent: Boolean = true
+    val bindValueAsEvent: Boolean = true,
 )
 
 annotation class CdcSourceIdStrategy(
     val topic: String,
     val labelName: String = "",
-    val propertyName: String = ""
+    val propertyName: String = "",
 )
 
-annotation class CdcSchemaStrategy(
-    val topic: String,
-)
+annotation class CdcSchemaStrategy(val topic: String)
 
 annotation class NodePatternStrategy(
     val topic: String,
     val pattern: String,
-    val mergeNodeProperties: Boolean
+    val mergeNodeProperties: Boolean,
 )
 
 annotation class RelationshipPatternStrategy(
     val topic: String,
     val pattern: String,
     val mergeNodeProperties: Boolean,
-    val mergeRelationshipProperties: Boolean
+    val mergeRelationshipProperties: Boolean,
 )
 
 annotation class CudStrategy(val topic: String)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistration.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistration.kt
@@ -45,7 +45,7 @@ class Neo4jSinkRegistration(
     keyConverter: KafkaConverter,
     valueConverter: KafkaConverter,
     topics: List<String>,
-    strategies: Map<String, Any>
+    strategies: Map<String, Any>,
 ) {
 
   private val name: String = randomizedName("Neo4jSinkConnector")
@@ -73,7 +73,8 @@ class Neo4jSinkRegistration(
                           put("errors.deadletterqueue.topic.name", errorDlqTopic)
                           put(
                               "errors.deadletterqueue.topic.replication.factor",
-                              DLQ_TOPIC_REPLICATION_FACTOR)
+                              DLQ_TOPIC_REPLICATION_FACTOR,
+                          )
                         }
                         put("errors.deadletterqueue.context.headers.enable", enableErrorHeaders)
                         put("errors.log.enable", enableErrorLog)
@@ -89,7 +90,8 @@ class Neo4jSinkRegistration(
                         put("key.converter.schema.registry.url", schemaControlRegistryUri)
                       }
                       putAll(
-                          keyConverter.additionalProperties.mapKeys { "key.converter.${it.key}" })
+                          keyConverter.additionalProperties.mapKeys { "key.converter.${it.key}" }
+                      )
 
                       if (valueConverter.supportsSchemaRegistry) {
                         put("value.converter.schema.registry.url", schemaControlRegistryUri)
@@ -97,10 +99,12 @@ class Neo4jSinkRegistration(
                       putAll(
                           valueConverter.additionalProperties.mapKeys {
                             "value.converter.${it.key}"
-                          })
+                          }
+                      )
 
                       putAll(strategies)
-                    })
+                    },
+            )
             .toMap()
   }
 
@@ -126,7 +130,8 @@ class Neo4jSinkRegistration(
     val response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString())
     if (response.statusCode() != 200) {
       throw RuntimeException(
-          "Could not get connector status, response code: ${response.statusCode()}")
+          "Could not get connector status, response code: ${response.statusCode()}"
+      )
     }
 
     val connectorTasks = ObjectMapper().readTree(response.body()).get("tasks")

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSource.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSource.kt
@@ -43,17 +43,17 @@ annotation class Neo4jSource(
     val forceMapsAsStruct: Boolean = true,
 
     // CDC strategy
-    val cdc: CdcSource = CdcSource()
+    val cdc: CdcSource = CdcSource(),
 )
 
 enum class SourceStrategy {
   QUERY,
-  CDC
+  CDC,
 }
 
 annotation class CdcSource(
     val patternsIndexed: Boolean = false,
-    val topics: Array<CdcSourceTopic> = []
+    val topics: Array<CdcSourceTopic> = [],
 )
 
 annotation class CdcSourceTopic(
@@ -63,7 +63,7 @@ annotation class CdcSourceTopic(
     val changesTo: Array<CdcSourceParam> = [],
     val metadata: Array<CdcMetadata> = [],
     val keySerializationStrategy: String = "WHOLE_VALUE",
-    val valueSerializationStrategy: String = "CHANGE_EVENT"
+    val valueSerializationStrategy: String = "CHANGE_EVENT",
 )
 
 annotation class CdcSourceParam(val value: String, val index: Int = 0)

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtension.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtension.kt
@@ -78,7 +78,7 @@ internal class Neo4jSourceExtension(
               Session::class.java to ::resolveSession,
               ConvertingKafkaConsumer::class.java to ::resolveTopicConsumer,
               Neo4j::class.java to ::resolveNeo4j,
-          ),
+          )
       )
 
   private lateinit var sourceAnnotation: Neo4jSource
@@ -114,13 +114,7 @@ internal class Neo4jSourceExtension(
   private val neo4jPassword = AnnotationValueResolver(Neo4jSource::neo4jPassword, envAccessor)
 
   private val mandatorySettings =
-      listOf(
-          brokerExternalHost,
-          schemaRegistryUri,
-          neo4jUri,
-          neo4jUser,
-          neo4jPassword,
-      )
+      listOf(brokerExternalHost, schemaRegistryUri, neo4jUri, neo4jUser, neo4jPassword)
 
   private val topicRegistry = TopicRegistry()
 
@@ -134,7 +128,8 @@ internal class Neo4jSourceExtension(
           schemaControlRegistryExternalUriProvider = {
             schemaControlRegistryExternalUri.resolve(sourceAnnotation)
           },
-          consumerFactory)
+          consumerFactory,
+      )
 
   override fun evaluateExecutionCondition(context: ExtensionContext?): ConditionEvaluationResult {
     val metadata =
@@ -149,7 +144,7 @@ internal class Neo4jSourceExtension(
     }
     if (errors.isNotEmpty()) {
       throw ExtensionConfigurationException(
-          "\nMissing settings, see details below:\n\t${errors.joinToString("\n\t")}",
+          "\nMissing settings, see details below:\n\t${errors.joinToString("\n\t")}"
       )
     }
 
@@ -160,7 +155,7 @@ internal class Neo4jSourceExtension(
         var version = Neo4jDetector.detect(it)
         if (!canIUse(Dbms.changeDataCapture()).withNeo4j(version)) {
           return ConditionEvaluationResult.disabled(
-              "CDC is not available with this version of Neo4j: $version",
+              "CDC is not available with this version of Neo4j: $version"
           )
         }
       }
@@ -195,7 +190,8 @@ internal class Neo4jSourceExtension(
             cdcMetadata = sourceAnnotation.cdc.metadataAsMap(),
             cdcKeySerializations = sourceAnnotation.cdc.keySerializationsAsMap(),
             cdcValueSerializations = sourceAnnotation.cdc.valueSerializationsAsMap(),
-            payloadMode = keyValueConverterResolver.resolvePayloadMode(context))
+            payloadMode = keyValueConverterResolver.resolvePayloadMode(context),
+        )
 
     source.register(kafkaConnectExternalUri.resolve(sourceAnnotation))
     log.info("registered source connector with name {}", source.name)
@@ -230,7 +226,7 @@ internal class Neo4jSourceExtension(
 
   private fun resolveSession(
       @Suppress("UNUSED_PARAMETER") parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): Any {
     ensureDatabase(extensionContext)
     driver = createDriver()
@@ -259,7 +255,9 @@ internal class Neo4jSourceExtension(
     createDriver().use { driver ->
       driver.session(SessionConfig.forDatabase("system")).use { session ->
         session.createDatabase(
-            neo4jDatabase, withCdc = sourceAnnotation.strategy == SourceStrategy.CDC)
+            neo4jDatabase,
+            withCdc = sourceAnnotation.strategy == SourceStrategy.CDC,
+        )
       }
 
       // want to make sure that CDC is functional before running the test
@@ -290,7 +288,7 @@ internal class Neo4jSourceExtension(
 
   private fun resolveTopicConsumer(
       parameterContext: ParameterContext?,
-      context: ExtensionContext?
+      context: ExtensionContext?,
   ): ConvertingKafkaConsumer {
     return consumerResolver.resolveGenericConsumer(parameterContext, context)
   }
@@ -347,14 +345,14 @@ internal class Neo4jSourceExtension(
 
   override fun supportsParameter(
       parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): Boolean {
     return paramResolvers.supportsParameter(parameterContext, extensionContext)
   }
 
   override fun resolveParameter(
       parameterContext: ParameterContext?,
-      extensionContext: ExtensionContext?
+      extensionContext: ExtensionContext?,
   ): Any {
     return paramResolvers.resolveParameter(parameterContext, extensionContext)
   }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceRegistration.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceRegistration.kt
@@ -50,7 +50,7 @@ internal class Neo4jSourceRegistration(
     cdcKeySerializations: Map<String, String>,
     cdcValueSerializations: Map<String, String>,
     payloadMode: PayloadMode,
-    forceMapsAsStruct: Boolean
+    forceMapsAsStruct: Boolean,
 ) {
 
   val name: String = randomizedName("Neo4jSourceConnector")
@@ -129,7 +129,7 @@ internal class Neo4jSourceRegistration(
 
     fun MutableMap<String, Any>.putCdcParameters(
         keyPattern: String,
-        values: Map<String, List<String>>
+        values: Map<String, List<String>>,
     ): MutableMap<String, Any> {
       if (values.isEmpty()) {
         return this
@@ -146,7 +146,7 @@ internal class Neo4jSourceRegistration(
 
     fun MutableMap<String, Any>.putCdcPatterns(
         patterns: Map<String, List<String>>,
-        indexed: Boolean
+        indexed: Boolean,
     ): MutableMap<String, Any> {
       if (patterns.isEmpty()) {
         return this
@@ -181,7 +181,7 @@ internal class Neo4jSourceRegistration(
 
     fun MutableMap<String, Any>.putCdcKeyValueSerializations(
         pattern: String,
-        strategies: Map<String, String>
+        strategies: Map<String, String>,
     ): MutableMap<String, Any> {
       strategies.forEach { (topic, strategy) -> this[pattern.format(topic)] = strategy }
       return this

--- a/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/JUnitSupport.kt
+++ b/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/JUnitSupport.kt
@@ -35,7 +35,7 @@ internal object JUnitSupport {
 
   inline fun <reified T : Annotation> annotatedParameterContextForType(
       parameterType: KClass<*>,
-      paramAnnotation: T
+      paramAnnotation: T,
   ): ParameterContext {
     val param =
         mock<Parameter> {

--- a/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/KafkaConnectServer.kt
+++ b/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/KafkaConnectServer.kt
@@ -46,7 +46,7 @@ class KafkaConnectServer : AutoCloseable {
       unregistrationHandler: (HttpExchange) -> Boolean = {
         it.sendResponseHeaders(204, -1)
         true
-      }
+      },
   ) {
 
     httpServer.createContext("/connectors") { exchange ->
@@ -80,9 +80,9 @@ class KafkaConnectServer : AutoCloseable {
   }
 
   private fun handleRegistration(exchange: HttpExchange, handler: (HttpExchange) -> Boolean) {
-    if (!validateMethod(exchange, "POST") ||
-        !validateJsonIn(exchange) ||
-        !validateJsonOut(exchange)) {
+    if (
+        !validateMethod(exchange, "POST") || !validateJsonIn(exchange) || !validateJsonOut(exchange)
+    ) {
       return
     }
     if (!handler(exchange)) {
@@ -123,8 +123,9 @@ class KafkaConnectServer : AutoCloseable {
 
   private fun validateJsonOut(exchange: HttpExchange): Boolean {
     val acceptedMedia = exchange.requestHeaders["Accept"]!!
-    if (acceptedMedia.isNotEmpty() &&
-        acceptedMedia.none { CANDIDATE_ACCEPT_HEADERS.contains(it) }) {
+    if (
+        acceptedMedia.isNotEmpty() && acceptedMedia.none { CANDIDATE_ACCEPT_HEADERS.contains(it) }
+    ) {
       exchange.sendResponseHeaders(406, -1)
       return false
     }

--- a/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkExtensionTest.kt
+++ b/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkExtensionTest.kt
@@ -69,16 +69,15 @@ class Neo4jSinkExtensionTest {
         registrationHandler = { exchange ->
           if (!handlerCalled.compareAndSet(false, true)) {
             kafkaConnectServer.internalServerError(
-                exchange, "expected handler flag to be initially false")
+                exchange,
+                "expected handler flag to be initially false",
+            )
             return@start true
           }
           return@start false
-        },
+        }
     )
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val session = mock<Session>()
     val driver =
         mock<Driver> {
@@ -101,16 +100,15 @@ class Neo4jSinkExtensionTest {
         unregistrationHandler = { exchange ->
           if (!handlerCalled.compareAndSet(false, true)) {
             kafkaConnectServer.internalServerError(
-                exchange, "expected handler flag to be initially false")
+                exchange,
+                "expected handler flag to be initially false",
+            )
             return@start true
           }
           return@start false
-        },
+        }
     )
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val session = mock<Session>()
     val driver =
         mock<Driver> {
@@ -168,10 +166,7 @@ class Neo4jSinkExtensionTest {
   fun `verifies connectivity if driver is initialized before each test`() {
     kafkaConnectServer.start()
     val session = mock<Session>()
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val driver =
         mock<Driver> {
           on { session() } doReturn session
@@ -179,10 +174,7 @@ class Neo4jSinkExtensionTest {
           on { verifyConnectivity() } doAnswer {}
         }
     val extension =
-        Neo4jSinkExtension(
-            envAccessor = environment::get,
-            driverFactory = { _, _ -> driver },
-        )
+        Neo4jSinkExtension(envAccessor = environment::get, driverFactory = { _, _ -> driver })
     val extensionContext = extensionContextFor(::onlyKafkaConnectExternalUriFromEnvMethod)
     extension.evaluateExecutionCondition(extensionContext)
     extension.resolveParameter(parameterContextForType(Session::class), extensionContext)
@@ -196,20 +188,14 @@ class Neo4jSinkExtensionTest {
   fun `closes Driver and Session after each test`() {
     kafkaConnectServer.start()
     val session = mock<Session>()
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val driver =
         mock<Driver> {
           on { session() } doReturn session
           on { session(any(SessionConfig::class.java)) } doReturn session
         }
     val extension =
-        Neo4jSinkExtension(
-            envAccessor = environment::get,
-            driverFactory = { _, _ -> driver },
-        )
+        Neo4jSinkExtension(envAccessor = environment::get, driverFactory = { _, _ -> driver })
     val extensionContext = extensionContextFor(::onlyKafkaConnectExternalUriFromEnvMethod)
     extension.evaluateExecutionCondition(extensionContext)
     extension.resolveParameter(parameterContextForType(Session::class), extensionContext)
@@ -335,7 +321,8 @@ class Neo4jSinkExtensionTest {
       neo4jUser = "user",
       neo4jPassword = "password",
       cypher = [CypherStrategy("topic1", "MERGE ()")],
-      schemaControlRegistryUri = "http://example.com")
+      schemaControlRegistryUri = "http://example.com",
+  )
   @Suppress("UNUSED")
   fun validMethod() {}
 
@@ -345,7 +332,8 @@ class Neo4jSinkExtensionTest {
       neo4jUser = "user",
       neo4jPassword = "password",
       cypher = [CypherStrategy("topic1", "MERGE ()")],
-      schemaControlRegistryUri = "http://example.com")
+      schemaControlRegistryUri = "http://example.com",
+  )
   @Suppress("UNUSED")
   fun onlyKafkaConnectExternalUriFromEnvMethod() {}
 
@@ -370,7 +358,8 @@ class Neo4jSinkExtensionTest {
       neo4jUser = "user",
       neo4jPassword = "password",
       cypher = [CypherStrategy("topic1", "MERGE ()")],
-      cud = [CudStrategy("topic1")])
+      cud = [CudStrategy("topic1")],
+  )
   @Suppress("UNUSED")
   fun duplicateTopicMethod() {}
 }

--- a/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistrationTest.kt
+++ b/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/sink/Neo4jSinkRegistrationTest.kt
@@ -44,7 +44,8 @@ class Neo4jSinkRegistrationTest {
             "neo4j.authentication.type" to "BASIC",
             "neo4j.authentication.basic.username" to "user",
             "neo4j.authentication.basic.password" to "password",
-            "neo4j.cypher.topic.my-topic" to "MERGE ()")
+            "neo4j.cypher.topic.my-topic" to "MERGE ()",
+        )
     val registration =
         Neo4jSinkRegistration(
             neo4jUri = "neo4j://example.com",
@@ -55,7 +56,8 @@ class Neo4jSinkRegistrationTest {
             keyConverter = KafkaConverter.AVRO,
             valueConverter = KafkaConverter.AVRO,
             topics = listOf("my-topic"),
-            strategies = mapOf("neo4j.cypher.topic.my-topic" to "MERGE ()"))
+            strategies = mapOf("neo4j.cypher.topic.my-topic" to "MERGE ()"),
+        )
 
     val payload = registration.getPayload()
 
@@ -86,7 +88,8 @@ class Neo4jSinkRegistrationTest {
             "neo4j.authentication.type" to "BASIC",
             "neo4j.authentication.basic.username" to "user",
             "neo4j.authentication.basic.password" to "password",
-            "neo4j.cypher.topic.my-topic" to "MERGE ()")
+            "neo4j.cypher.topic.my-topic" to "MERGE ()",
+        )
     val registration =
         Neo4jSinkRegistration(
             neo4jUri = "neo4j://example.com",
@@ -98,7 +101,8 @@ class Neo4jSinkRegistrationTest {
             valueConverter = KafkaConverter.AVRO,
             errorDlqTopic = "dlq-topic",
             topics = listOf("my-topic"),
-            strategies = mapOf("neo4j.cypher.topic.my-topic" to "MERGE ()"))
+            strategies = mapOf("neo4j.cypher.topic.my-topic" to "MERGE ()"),
+        )
 
     val payload = registration.getPayload()
 
@@ -119,7 +123,8 @@ class Neo4jSinkRegistrationTest {
             valueConverter = KafkaConverter.AVRO,
             topics = listOf("topic1", "topic2"),
             strategies =
-                mapOf("neo4j.cypher.topic.topic1" to "MERGE ()", "neo4j.cud.topics" to "topic2"))
+                mapOf("neo4j.cypher.topic.topic1" to "MERGE ()", "neo4j.cud.topics" to "topic2"),
+        )
 
     val payload = registration.getPayload()
 

--- a/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtensionTest.kt
+++ b/testing/src/test/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtensionTest.kt
@@ -81,16 +81,15 @@ class Neo4jSourceExtensionTest {
         registrationHandler = { exchange ->
           if (!handlerCalled.compareAndSet(false, true)) {
             kafkaConnectServer.internalServerError(
-                exchange, "expected handler flag to be initially false")
+                exchange,
+                "expected handler flag to be initially false",
+            )
             return@start true
           }
           return@start false
-        },
+        }
     )
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val session = mock<Session>()
     val driver =
         mock<Driver> {
@@ -113,16 +112,15 @@ class Neo4jSourceExtensionTest {
         unregistrationHandler = { exchange ->
           if (!handlerCalled.compareAndSet(false, true)) {
             kafkaConnectServer.internalServerError(
-                exchange, "expected handler flag to be initially false")
+                exchange,
+                "expected handler flag to be initially false",
+            )
             return@start true
           }
           return@start false
-        },
+        }
     )
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val (driver, _) = setupDetectableDriver()
     val extension = Neo4jSourceExtension(environment::get, driverFactory = { _, _ -> driver })
     val extensionContext = extensionContextFor(::onlyKafkaConnectExternalUriFromEnvMethod)
@@ -183,7 +181,9 @@ class Neo4jSourceExtensionTest {
     val (driver, _) = setupDetectableDriver()
     val extension =
         Neo4jSourceExtension(
-            consumerFactory = { _, _ -> consumer }, driverFactory = { _, _ -> driver })
+            consumerFactory = { _, _ -> consumer },
+            driverFactory = { _, _ -> driver },
+        )
     val extensionContext = extensionContextFor(method)
     extension.evaluateExecutionCondition(extensionContext)
     val consumerAnnotation = TopicConsumer(topic = "topic", offset = "earliest")
@@ -191,7 +191,8 @@ class Neo4jSourceExtensionTest {
     val convertingKafkaConsumer =
         extension.resolveParameter(
             annotatedParameterContextForType(ConvertingKafkaConsumer::class, consumerAnnotation),
-            extensionContext)
+            extensionContext,
+        )
 
     assertIs<ConvertingKafkaConsumer>(convertingKafkaConsumer)
     assertSame(consumer, convertingKafkaConsumer.kafkaConsumer)
@@ -211,7 +212,8 @@ class Neo4jSourceExtensionTest {
     assertIs<Neo4j>(neo4j)
     assertEquals(
         Neo4j(Neo4jVersion(5, 26, 0), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED),
-        neo4j)
+        neo4j,
+    )
   }
 
   private fun setupDetectableDriver(): Pair<Driver, Session> {
@@ -237,10 +239,7 @@ class Neo4jSourceExtensionTest {
   fun `closes Driver and Session after each test`() {
     kafkaConnectServer.start()
     val session = mock<Session>()
-    val environment =
-        mapOf(
-            "KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address(),
-        )
+    val environment = mapOf("KAFKA_CONNECT_EXTERNAL_URI" to kafkaConnectServer.address())
     val driver =
         mock<Driver> {
           on { session() } doReturn session
@@ -248,10 +247,7 @@ class Neo4jSourceExtensionTest {
         }
 
     val extension =
-        Neo4jSourceExtension(
-            envAccessor = environment::get,
-            driverFactory = { _, _ -> driver },
-        )
+        Neo4jSourceExtension(envAccessor = environment::get, driverFactory = { _, _ -> driver })
     val extensionContext = extensionContextFor(::onlyKafkaConnectExternalUriFromEnvMethod)
     extension.evaluateExecutionCondition(extensionContext)
     extension.resolveParameter(parameterContextForType(Session::class), extensionContext)
@@ -396,7 +392,8 @@ class Neo4jSourceExtensionTest {
       topic = "topic",
       streamingProperty = "prop",
       startFrom = "ALL",
-      query = "MERGE (:Example)")
+      query = "MERGE (:Example)",
+  )
   @Suppress("UNUSED")
   fun validMethod() {}
 
@@ -420,7 +417,12 @@ class Neo4jSourceExtensionTest {
                           patterns =
                               arrayOf(
                                   CdcSourceParam("(:Person {+name})"),
-                                  CdcSourceParam("(:Person)-[:WORKS_FOR]→(:Company)"))))))
+                                  CdcSourceParam("(:Person)-[:WORKS_FOR]→(:Company)"),
+                              ),
+                      )
+                  )
+          ),
+  )
   @Suppress("UNUSED")
   fun validCdcMethod() {}
 
@@ -435,12 +437,17 @@ class Neo4jSourceExtensionTest {
       topic = "topic",
       streamingProperty = "prop",
       startFrom = "ALL",
-      query = "MERGE (:Example)")
+      query = "MERGE (:Example)",
+  )
   @Suppress("UNUSED")
   fun onlyKafkaConnectExternalUriFromEnvMethod() {}
 
   @Neo4jSource(
-      topic = "topic", streamingProperty = "prop", startFrom = "ALL", query = "MERGE (:Example)")
+      topic = "topic",
+      streamingProperty = "prop",
+      startFrom = "ALL",
+      query = "MERGE (:Example)",
+  )
   @Suppress("UNUSED")
   fun envBackedMethod() {}
 
@@ -451,6 +458,7 @@ class Neo4jSourceExtensionTest {
     fun validMethods(): Array<Array<Any>> =
         arrayOf(
             arrayOf("valid query settings", Neo4jSourceExtensionTest::validMethod),
-            arrayOf("valid cdc settings", Neo4jSourceExtensionTest::validCdcMethod))
+            arrayOf("valid cdc settings", Neo4jSourceExtensionTest::validCdcMethod),
+        )
   }
 }


### PR DESCRIPTION
This PR refactors `DynamicTypes` class into two parts where `PayloadMode` becomes the owner for corresponding schema generation & value conversion.