### PR TITLE
fix: use new cdc.query overload to find out last known id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <build-resources.version>2024-12.1</build-resources.version>
         <byte-buddy.version>1.17.8</byte-buddy.version>
         <caniuse-neo4j-detection.version>1.3.0</caniuse-neo4j-detection.version>
-        <cdc.version>1.0.17</cdc.version>
+        <cdc.version>1.1.0</cdc.version>
         <commons-collections4.version>4.5.0</commons-collections4.version>
         <commons-lang3.version>3.19.0</commons-lang3.version>
         <hamcrest.version>3.0</hamcrest.version>


### PR DESCRIPTION
This PR fixes an issue where current change id lookup occurs in one member of the cluster whereas the change query happening on another which both has different views of changes. The fix ensures that we lookup the current change identifier on the same member as the change query will be executed (in the same transaction) and will prevent skipped changes in those scenarios.

This bug only applies to 5.1.17 version of the connector.