### PR TITLE
Remove ids constraint on delete relationship via CUD

### DIFF
--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteRelationship.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/DeleteRelationship.kt
@@ -40,12 +40,6 @@ data class DeleteRelationship(
       )
     }
 
-    if (start.ids.isEmpty() || end.ids.isEmpty()) {
-      throw InvalidDataException(
-          "'${Keys.FROM}' and '${Keys.TO}' must contain at least one ID property."
-      )
-    }
-
     val startParam = Cypher.parameter("start")
     val endParam = Cypher.parameter("end")
     val keysParam = Cypher.parameter("keys")


### PR DESCRIPTION
Deletions no longer require specifying the relationship IDs on "from" and "to"  enabling the possibility to remove all relationships from or to nodes with specific labels.
