### PR TITLE
feat: support exactlyOnceSupport capability for cdc sources

### DIFF
--- a/source-connector/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jConnector.kt
+++ b/source-connector/src/main/kotlin/org/neo4j/connectors/kafka/source/Neo4jConnector.kt
@@ -19,8 +19,10 @@ package org.neo4j.connectors.kafka.source
 import org.apache.kafka.common.config.Config
 import org.apache.kafka.common.config.ConfigDef
 import org.apache.kafka.connect.connector.Task
+import org.apache.kafka.connect.source.ExactlyOnceSupport
 import org.apache.kafka.connect.source.SourceConnector
 import org.neo4j.connectors.kafka.configuration.helpers.VersionUtil
+import org.neo4j.connectors.kafka.source.SourceConfiguration.Companion.STRATEGY
 
 class Neo4jConnector : SourceConnector() {
   private lateinit var props: Map<String, String>
@@ -55,5 +57,14 @@ class Neo4jConnector : SourceConnector() {
     SourceConfiguration.validate(result, originals)
 
     return result
+  }
+
+  override fun exactlyOnceSupport(connectorConfig: Map<String?, String?>?): ExactlyOnceSupport? {
+    val strategy = connectorConfig?.get(STRATEGY)?.let { SourceType.valueOf(it) }
+    return when (strategy) {
+      SourceType.CDC -> ExactlyOnceSupport.SUPPORTED
+      SourceType.QUERY -> ExactlyOnceSupport.UNSUPPORTED
+      else -> super.exactlyOnceSupport(connectorConfig)
+    }
   }
 }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jConnectorTest.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jConnectorTest.kt
@@ -19,6 +19,7 @@ package org.neo4j.connectors.kafka.source
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSingleElement
 import io.kotest.matchers.shouldBe
+import org.apache.kafka.connect.source.ExactlyOnceSupport
 import org.junit.jupiter.api.Test
 import org.neo4j.connectors.kafka.configuration.Neo4jConfiguration
 
@@ -243,5 +244,19 @@ class Neo4jConnectorTest {
     )
 
     connector.taskClass() shouldBe Neo4jCdcTask::class.java
+  }
+
+  @Test
+  fun `should return correct exactlyOnceSupport based on strategy`() {
+    val connector = Neo4jConnector()
+
+    connector.exactlyOnceSupport(mapOf(SourceConfiguration.STRATEGY to "CDC")) shouldBe
+        ExactlyOnceSupport.SUPPORTED
+
+    connector.exactlyOnceSupport(mapOf(SourceConfiguration.STRATEGY to "QUERY")) shouldBe
+        ExactlyOnceSupport.UNSUPPORTED
+
+    connector.exactlyOnceSupport(emptyMap()) shouldBe null
+    connector.exactlyOnceSupport(null) shouldBe null
   }
 }


### PR DESCRIPTION
This PR adds `exactlyOnceSupport` pre-flight function to the source connector, which returns supported for `CDC` strategy and unsupported for `QUERY`.