### PR TITLE
chore: git rev-parese to find repo root in hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-./mvnw sortpom:sort spotless:apply -f .teamcity
-./mvnw sortpom:sort spotless:apply
+$(git rev-parse --show-toplevel)/mvnw sortpom:sort spotless:apply -f .teamcity
+$(git rev-parse --show-toplevel)/mvnw spotless:apply
 
 git update-index --again


### PR DESCRIPTION
Updates our hooks to have git resolve the absolute path of the repository root.
Then we execute hook binaries from an absolute path instead of relative.