### PR TITLE
feat: time delta in cdc metrics

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
@@ -44,7 +44,7 @@ class CdcMetricsData(
         "The time (in seconds) since the last committed ${connectorType.descriptionActionVerb()} CDC message",
         tags,
     ) {
-      if (lastTxCommitTs.get() == 0L) 0L // no tx to compare to
+      if (lastTxCommitTs.get() == 0L) -1L // no tx to compare to
       else Clock.System.now().epochSeconds - lastTxCommitTs.get()
     }
     metrics.addGauge(

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
@@ -40,7 +40,7 @@ class CdcMetricsData(
       lastTxCommitTs.get()
     }
     metrics.addGauge(
-        "last_cdc_tx_commit_time_delta",
+        "last_cdc_tx_commit_age_to_now",
         "The time (in seconds) since the last committed ${connectorType.descriptionActionVerb()} CDC message",
         tags,
     ) {

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
@@ -41,7 +41,7 @@ class CdcMetricsData(
     }
     metrics.addGauge(
         "last_cdc_tx_commit_time_delta",
-        "The time (in seconds) since the last commited ${connectorType.descriptionActionVerb()} CDC message",
+        "The time (in seconds) since the last committed ${connectorType.descriptionActionVerb()} CDC message",
         tags,
     ) {
       if (lastTxCommitTs.get() == 0L) 0L // no tx to compare to

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
@@ -17,6 +17,7 @@
 package org.neo4j.connectors.kafka.metrics
 
 import java.util.concurrent.atomic.AtomicLong
+import kotlin.time.Clock
 import org.neo4j.cdc.client.model.ChangeEvent
 import org.neo4j.connectors.kafka.configuration.ConnectorType
 
@@ -26,9 +27,9 @@ class CdcMetricsData(
     tags: LinkedHashMap<String, String> = linkedMapOf(),
 ) {
 
-  private var lastTxCommitTs: AtomicLong = AtomicLong(0L)
-  private var lastTxStartTs: AtomicLong = AtomicLong(0L)
-  private var lastTxId: AtomicLong = AtomicLong(0L)
+  private val lastTxCommitTs: AtomicLong = AtomicLong(0L)
+  private val lastTxStartTs: AtomicLong = AtomicLong(0L)
+  private val lastTxId: AtomicLong = AtomicLong(0L)
 
   init {
     metrics.addGauge(
@@ -37,6 +38,14 @@ class CdcMetricsData(
         tags,
     ) {
       lastTxCommitTs.get()
+    }
+    metrics.addGauge(
+        "last_cdc_tx_commit_time_delta",
+        "The time (in seconds) since the last commited ${connectorType.descriptionActionVerb()} CDC message",
+        tags,
+    ) {
+      if (lastTxCommitTs.get() == 0L) 0L // no tx to compare to
+      else Clock.System.now().epochSeconds - lastTxCommitTs.get()
     }
     metrics.addGauge(
         "last_cdc_tx_start_timestamp",

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/metrics/CdcMetricsData.kt
@@ -40,12 +40,13 @@ class CdcMetricsData(
       lastTxCommitTs.get()
     }
     metrics.addGauge(
-        "last_cdc_tx_commit_age_to_now",
+        "last_cdc_tx_commit_age",
         "The time (in seconds) since the last committed ${connectorType.descriptionActionVerb()} CDC message",
         tags,
     ) {
-      if (lastTxCommitTs.get() == 0L) -1L // no tx to compare to
-      else Clock.System.now().epochSeconds - lastTxCommitTs.get()
+      val timeStamp = lastTxCommitTs.get()
+      if (timeStamp == 0L) -1L // no tx to compare to
+      else Clock.System.now().epochSeconds - timeStamp
     }
     metrics.addGauge(
         "last_cdc_tx_start_timestamp",

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -16,13 +16,12 @@
  */
 package org.neo4j.connectors.kafka.source
 
-import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeLessThan
-import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import java.lang.management.ManagementFactory
 import java.util.UUID
@@ -30,6 +29,7 @@ import javax.management.MBeanServer
 import javax.management.ObjectName
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
+import kotlinx.coroutines.delay
 import org.apache.kafka.connect.source.SourceTaskContext
 import org.apache.kafka.connect.storage.OffsetStorageReader
 import org.assertj.core.api.SoftAssertions.assertSoftly
@@ -52,6 +52,7 @@ import org.neo4j.connectors.kafka.configuration.AuthenticationType
 import org.neo4j.connectors.kafka.configuration.Neo4jConfiguration
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.createDatabase
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.dropDatabase
+import org.neo4j.connectors.kafka.testing.TestSupport.runTest
 import org.neo4j.connectors.kafka.testing.createNodeKeyConstraint
 import org.neo4j.connectors.kafka.testing.createRelationshipKeyConstraint
 import org.neo4j.connectors.kafka.testing.neo4jDatabase
@@ -528,7 +529,7 @@ class Neo4jCdcTaskTest {
   }
 
   @Test
-  fun `should expose cdc time delta metrics`() {
+  fun `should expose cdc time delta metrics`() = runTest {
     val sleepSeconds = 1L
 
     // start a task with a set connector name and task ID so we can re-fetch it
@@ -557,11 +558,11 @@ class Neo4jCdcTaskTest {
     // run a transaction and then delay to increase commit age
     session.run("UNWIND RANGE(1, 10) AS n CREATE (:Person {id: n, name: 'person ' + n})").consume()
 
-    shouldNotThrow<InterruptedException> { Thread.sleep(sleepSeconds * 1000) }
+    delay(sleepSeconds.seconds)
 
     task.poll()
     val newDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age") as Long
-    newDelta shouldBeEqual sleepSeconds
+    newDelta shouldBeGreaterThanOrEqual sleepSeconds
   }
 
   private fun newTaskContextWithCurrentChangeId(): SourceTaskContext {

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -508,7 +508,7 @@ class Neo4jCdcTaskTest {
     val objectName = ObjectName("kafka.connect:type=plugins,connector=my-connector,task=0")
 
     val firstCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp") as Long
-    val firstDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta") as Long
+    val firstDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age_to_now") as Long
     val firstStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp") as Long
     val firstId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
 
@@ -517,7 +517,7 @@ class Neo4jCdcTaskTest {
     task.poll()
 
     val lastCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp") as Long
-    val lastDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta") as Long
+    val lastDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age_to_now") as Long
     val lastStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp") as Long
     val lastId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
 

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -16,12 +16,10 @@
  */
 package org.neo4j.connectors.kafka.source
 
-import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.equals.shouldNotBeEqual
-import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import java.lang.management.ManagementFactory
 import java.util.UUID
@@ -522,9 +520,8 @@ class Neo4jCdcTaskTest {
     val lastId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
 
     assertSoftly {
-      lastDelta shouldBeGreaterThanOrEqual firstDelta
-
       lastCommit shouldBeGreaterThan firstCommit
+      lastDelta shouldBeGreaterThan firstDelta
       lastStart shouldBeGreaterThan firstStart
       lastId shouldBeGreaterThan firstId
     }

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -16,12 +16,17 @@
  */
 package org.neo4j.connectors.kafka.source
 
+import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.shouldBe
+import java.lang.management.ManagementFactory
 import java.util.UUID
+import javax.management.MBeanServer
+import javax.management.ObjectName
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 import org.apache.kafka.connect.source.SourceTaskContext
@@ -341,7 +346,7 @@ class Neo4jCdcTaskTest {
     session
         .run(
             """
-            UNWIND RANGE(1, 100, 2) AS n 
+            UNWIND RANGE(1, 100, 2) AS n
             MATCH (p:Person {id: n})
             MATCH (c:Company {id: n%25+1})
             CREATE (p)-[:WORKS_FOR {id: n, since: date()}]->(c)
@@ -477,6 +482,51 @@ class Neo4jCdcTaskTest {
     task.poll() shouldBe emptyList()
     val finishedWith = task.latestOffset()
     finishedWith shouldNotBeEqual afterFirstPoll
+  }
+
+  @Test
+  fun `should expose cdc metrics`() {
+    // start a task with a set connector name and task ID so we can re-fetch it
+    task.start(
+        mapOf(
+            Neo4jConfiguration.URI to container.boltUrl,
+            Neo4jConfiguration.AUTHENTICATION_TYPE to AuthenticationType.NONE.toString(),
+            Neo4jConfiguration.DATABASE to db,
+            Neo4jConfiguration.CONNECTOR_NAME to "my-connector",
+            Neo4jConfiguration.TASK_ID to "0",
+            SourceConfiguration.STRATEGY to SourceType.CDC.toString(),
+            SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
+            "neo4j.cdc.topic.nodes.patterns" to "()",
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
+
+    // poll for initial state before any CDC event
+    task.poll()
+    val mbs: MBeanServer = ManagementFactory.getPlatformMBeanServer()
+    val objectName = ObjectName("kafka.connect:type=plugins,connector=my-connector,task=0")
+
+    val firstCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp")
+    val firstDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta")
+    val firstStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp")
+    val firstId = mbs.getAttribute(objectName, "last_cdc_tx_id")
+
+    // run a transaction and poll for CDC events
+    session.run("UNWIND RANGE(1, 10) AS n CREATE (:Person {id: n, name: 'person ' + n})").consume()
+    task.poll()
+
+    val lastCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp")
+    val lastDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta")
+    val lastStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp")
+    val lastId = mbs.getAttribute(objectName, "last_cdc_tx_id")
+
+    assertSoftly {
+      firstDelta shouldBeEqual lastDelta
+
+      firstCommit shouldNotBeEqual lastCommit
+      firstStart shouldNotBeEqual lastStart
+      firstId shouldNotBeEqual lastId
+    }
   }
 
   private fun newTaskContextWithCurrentChangeId(): SourceTaskContext {

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -16,9 +16,12 @@
  */
 package org.neo4j.connectors.kafka.source
 
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.shouldBe
 import java.lang.management.ManagementFactory
@@ -484,7 +487,10 @@ class Neo4jCdcTaskTest {
   }
 
   @Test
-  fun `should expose cdc metrics`() {
+  fun `should expose cdc timestamp and id metrics`() {
+    val metricsUnderTest =
+        listOf("last_cdc_tx_commit_timestamp", "last_cdc_tx_start_timestamp", "last_cdc_tx_id")
+
     // start a task with a set connector name and task ID so we can re-fetch it
     task.start(
         mapOf(
@@ -505,26 +511,57 @@ class Neo4jCdcTaskTest {
     val mbs: MBeanServer = ManagementFactory.getPlatformMBeanServer()
     val objectName = ObjectName("kafka.connect:type=plugins,connector=my-connector,task=0")
 
-    val firstCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp") as Long
-    val firstDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age_to_now") as Long
-    val firstStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp") as Long
-    val firstId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
+    val initial = metricsUnderTest.map { mbs.getAttribute(objectName, it) as Long }
 
     // run a transaction and poll for CDC events
     session.run("UNWIND RANGE(1, 10) AS n CREATE (:Person {id: n, name: 'person ' + n})").consume()
     task.poll()
 
-    val lastCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp") as Long
-    val lastDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age_to_now") as Long
-    val lastStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp") as Long
-    val lastId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
-
     assertSoftly {
-      lastCommit shouldBeGreaterThan firstCommit
-      lastDelta shouldBeGreaterThan firstDelta
-      lastStart shouldBeGreaterThan firstStart
-      lastId shouldBeGreaterThan firstId
+      metricsUnderTest.forEachIndexed { i, metricName ->
+        withClue("metric=$metricName") {
+          val metricValue = mbs.getAttribute(objectName, metricName) as Long
+          metricValue shouldBeGreaterThan initial[i]
+        }
+      }
     }
+  }
+
+  @Test
+  fun `should expose cdc time delta metrics`() {
+    val sleepSeconds = 1L
+
+    // start a task with a set connector name and task ID so we can re-fetch it
+    task.start(
+        mapOf(
+            Neo4jConfiguration.URI to container.boltUrl,
+            Neo4jConfiguration.AUTHENTICATION_TYPE to AuthenticationType.NONE.toString(),
+            Neo4jConfiguration.DATABASE to db,
+            Neo4jConfiguration.CONNECTOR_NAME to "my-connector",
+            Neo4jConfiguration.TASK_ID to "0",
+            SourceConfiguration.STRATEGY to SourceType.CDC.toString(),
+            SourceConfiguration.START_FROM to StartFrom.EARLIEST.toString(),
+            "neo4j.cdc.topic.nodes.patterns" to "()",
+            "neo4j.cdc.topic.relationships.patterns" to "()-[]-()",
+        )
+    )
+
+    // poll for initial state before any CDC event
+    task.poll()
+    val mbs: MBeanServer = ManagementFactory.getPlatformMBeanServer()
+    val objectName = ObjectName("kafka.connect:type=plugins,connector=my-connector,task=0")
+    val initialDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age") as Long
+
+    initialDelta shouldBe -1L
+
+    // run a transaction and then delay to increase commit age
+    session.run("UNWIND RANGE(1, 10) AS n CREATE (:Person {id: n, name: 'person ' + n})").consume()
+
+    shouldNotThrow<InterruptedException> { Thread.sleep(sleepSeconds * 1000) }
+
+    task.poll()
+    val newDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_age") as Long
+    newDelta shouldBeEqual sleepSeconds
   }
 
   private fun newTaskContextWithCurrentChangeId(): SourceTaskContext {

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -20,8 +20,8 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.comparables.shouldBeLessThan
-import io.kotest.matchers.equals.shouldBeEqual
 import io.kotest.matchers.equals.shouldNotBeEqual
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
 import java.lang.management.ManagementFactory
 import java.util.UUID
@@ -31,6 +31,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.measureTime
 import org.apache.kafka.connect.source.SourceTaskContext
 import org.apache.kafka.connect.storage.OffsetStorageReader
+import org.assertj.core.api.SoftAssertions.assertSoftly
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assumptions
@@ -506,26 +507,26 @@ class Neo4jCdcTaskTest {
     val mbs: MBeanServer = ManagementFactory.getPlatformMBeanServer()
     val objectName = ObjectName("kafka.connect:type=plugins,connector=my-connector,task=0")
 
-    val firstCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp")
-    val firstDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta")
-    val firstStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp")
-    val firstId = mbs.getAttribute(objectName, "last_cdc_tx_id")
+    val firstCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp") as Long
+    val firstDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta") as Long
+    val firstStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp") as Long
+    val firstId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
 
     // run a transaction and poll for CDC events
     session.run("UNWIND RANGE(1, 10) AS n CREATE (:Person {id: n, name: 'person ' + n})").consume()
     task.poll()
 
-    val lastCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp")
-    val lastDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta")
-    val lastStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp")
-    val lastId = mbs.getAttribute(objectName, "last_cdc_tx_id")
+    val lastCommit = mbs.getAttribute(objectName, "last_cdc_tx_commit_timestamp") as Long
+    val lastDelta = mbs.getAttribute(objectName, "last_cdc_tx_commit_time_delta") as Long
+    val lastStart = mbs.getAttribute(objectName, "last_cdc_tx_start_timestamp") as Long
+    val lastId = mbs.getAttribute(objectName, "last_cdc_tx_id") as Long
 
     assertSoftly {
-      firstDelta shouldBeEqual lastDelta
+      lastDelta shouldBeGreaterThanOrEqual firstDelta
 
-      firstCommit shouldNotBeEqual lastCommit
-      firstStart shouldNotBeEqual lastStart
-      firstId shouldNotBeEqual lastId
+      lastCommit shouldBeGreaterThan firstCommit
+      lastStart shouldBeGreaterThan firstStart
+      lastId shouldBeGreaterThan firstId
     }
   }
 


### PR DESCRIPTION
This commit adds a new cdc metric that will calculate the time delta
between now and the last cdc transaction commit. Time unit is number of
seconds since.

Metric is registered as `last_cdc_tx_commit_age`.