### PR TITLE
fix: merge collection element schemas with differing key sets

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
@@ -129,7 +129,19 @@ class CompactValueConverter : ValueConverter {
                   .apply { if (optional) optional() }
                   .build()
 
-          else ->
+          else -> {
+            val nonEmptyElements = value.filter { it.notNullOrEmpty() }
+            val merged =
+                if (nonEmptyElements.all { it is Map<*, *> }) {
+                  @Suppress("UNCHECKED_CAST")
+                  mergeMapElementSchemas(nonEmptyElements as List<Map<*, *>>, optional)
+                } else null
+
+            if (merged != null) {
+              SchemaBuilder.array(if (optional) makeOptional(merged) else merged)
+                  .apply { if (optional) optional() }
+                  .build()
+            } else {
               SchemaBuilder.struct()
                   .apply {
                     value.forEachIndexed { i, v ->
@@ -138,6 +150,8 @@ class CompactValueConverter : ValueConverter {
                   }
                   .apply { if (optional) optional() }
                   .build()
+            }
+          }
         }
       }
 
@@ -302,6 +316,68 @@ class CompactValueConverter : ValueConverter {
           }
 
       else -> value
+    }
+  }
+
+  /**
+   * Builds a merged STRUCT schema covering the union of keys across all element Maps. Keys absent
+   * (or null/empty) in some elements are marked optional. Element values are re-inferred with
+   * [forceMapsAsStruct] = true so a key whose value is a homogeneously-typed nested Map (which
+   * would otherwise be inferred as MAP) is rendered as a STRUCT, comparable field-by-field with
+   * sibling elements that already produced a STRUCT for the same key.
+   *
+   * Returns null when any key has multiple incompatible non-null value types across elements, so
+   * the caller falls back to the indexed `{e0, e1, ...}` representation.
+   */
+  private fun mergeMapElementSchemas(elements: List<Map<*, *>>, optional: Boolean): Schema? {
+    val allKeys = linkedSetOf<String>()
+    for (element in elements) {
+      for (key in element.keys) {
+        if (key !is String) return null
+        allKeys.add(key)
+      }
+    }
+
+    val builder = SchemaBuilder.struct()
+    for (key in allKeys) {
+      val fieldValues =
+          elements.filter { it.containsKey(key) && it[key].notNullOrEmpty() }.map { it[key] }
+
+      val resolvedSchema =
+          if (fieldValues.isEmpty()) {
+            SimpleTypes.NULL.schema(true)
+          } else {
+            val fieldSchemas = fieldValues.map { schema(it, optional, true) }.toSet()
+            when {
+              fieldSchemas.size == 1 -> fieldSchemas.first()
+              fieldValues.all { it is Map<*, *> } -> {
+                @Suppress("UNCHECKED_CAST")
+                mergeMapElementSchemas(fieldValues as List<Map<*, *>>, optional) ?: return null
+              }
+              else -> return null
+            }
+          }
+
+      val presentInAll = elements.all { it.containsKey(key) && it[key].notNullOrEmpty() }
+      builder.field(key, if (presentInAll) resolvedSchema else makeOptional(resolvedSchema))
+    }
+    return builder.build()
+  }
+
+  private fun makeOptional(schema: Schema): Schema {
+    if (schema.isOptional) return schema
+    return when (schema.type()) {
+      Schema.Type.STRUCT ->
+          SchemaBuilder.struct()
+              .apply {
+                schema.fields().forEach { field(it.name(), it.schema()) }
+                optional()
+              }
+              .build()
+      Schema.Type.ARRAY -> SchemaBuilder.array(schema.valueSchema()).optional().build()
+      Schema.Type.MAP ->
+          SchemaBuilder.map(schema.keySchema(), schema.valueSchema()).optional().build()
+      else -> SchemaBuilder.type(schema.type()).optional().build()
     }
   }
 }

--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
@@ -134,13 +134,15 @@ class CompactValueConverter : ValueConverter {
             val merged =
                 if (nonEmptyElements.all { it is Map<*, *> }) {
                   @Suppress("UNCHECKED_CAST")
-                  mergeMapElementSchemas(nonEmptyElements as List<Map<*, *>>, optional)
+                  mergeMapElementSchemas(
+                      nonEmptyElements as List<Map<*, *>>,
+                      optional,
+                      forceMapsAsStruct,
+                  )
                 } else null
 
             if (merged != null) {
-              SchemaBuilder.array(if (optional) makeOptional(merged) else merged)
-                  .apply { if (optional) optional() }
-                  .build()
+              SchemaBuilder.array(merged).apply { if (optional) optional() }.build()
             } else {
               SchemaBuilder.struct()
                   .apply {
@@ -320,64 +322,54 @@ class CompactValueConverter : ValueConverter {
   }
 
   /**
-   * Builds a merged STRUCT schema covering the union of keys across all element Maps. Keys absent
-   * (or null/empty) in some elements are marked optional. Element values are re-inferred with
-   * [forceMapsAsStruct] = true so a key whose value is a homogeneously-typed nested Map (which
-   * would otherwise be inferred as MAP) is rendered as a STRUCT, comparable field-by-field with
-   * sibling elements that already produced a STRUCT for the same key.
+   * Builds a merged STRUCT schema covering the union of keys across all element Maps.
+   *
+   * Every field of the merged schema is marked optional, regardless of whether it is present in all
+   * elements, so that subsequent messages missing a value for any of these fields remain compatible
+   * with the merged schema. The merged STRUCT itself is optional only when [optional] is set,
+   * mirroring how single-typed collection elements are handled.
+   *
+   * Field schemas are re-inferred from the raw values rather than from the already computed element
+   * schemas, so a key that is inferred as MAP in one element (homogeneously typed values) and as
+   * STRUCT in another (mixed value types) still contributes all of its keys to the merged result.
+   * Nested Maps whose key sets differ across elements are merged recursively.
    *
    * Returns null when any key has multiple incompatible non-null value types across elements, so
    * the caller falls back to the indexed `{e0, e1, ...}` representation.
+   *
+   * Callers must have already validated the elements through [schema], which rejects non-String map
+   * keys.
    */
-  private fun mergeMapElementSchemas(elements: List<Map<*, *>>, optional: Boolean): Schema? {
+  private fun mergeMapElementSchemas(
+      elements: List<Map<*, *>>,
+      optional: Boolean,
+      forceMapsAsStruct: Boolean,
+  ): Schema? {
     val allKeys = linkedSetOf<String>()
-    for (element in elements) {
-      for (key in element.keys) {
-        if (key !is String) return null
-        allKeys.add(key)
-      }
-    }
+    elements.forEach { element -> element.keys.forEach { allKeys.add(it as String) } }
 
     val builder = SchemaBuilder.struct()
     for (key in allKeys) {
-      val fieldValues =
-          elements.filter { it.containsKey(key) && it[key].notNullOrEmpty() }.map { it[key] }
+      val fieldValues = elements.map { it[key] }.filter { it.notNullOrEmpty() }
 
-      val resolvedSchema =
+      val fieldSchema =
           if (fieldValues.isEmpty()) {
             SimpleTypes.NULL.schema(true)
           } else {
-            val fieldSchemas = fieldValues.map { schema(it, optional, true) }.toSet()
+            val fieldSchemas = fieldValues.map { schema(it, true, forceMapsAsStruct) }.toSet()
             when {
               fieldSchemas.size == 1 -> fieldSchemas.first()
               fieldValues.all { it is Map<*, *> } -> {
                 @Suppress("UNCHECKED_CAST")
-                mergeMapElementSchemas(fieldValues as List<Map<*, *>>, optional) ?: return null
+                mergeMapElementSchemas(fieldValues as List<Map<*, *>>, true, forceMapsAsStruct)
+                    ?: return null
               }
               else -> return null
             }
           }
 
-      val presentInAll = elements.all { it.containsKey(key) && it[key].notNullOrEmpty() }
-      builder.field(key, if (presentInAll) resolvedSchema else makeOptional(resolvedSchema))
+      builder.field(key, fieldSchema)
     }
-    return builder.build()
-  }
-
-  private fun makeOptional(schema: Schema): Schema {
-    if (schema.isOptional) return schema
-    return when (schema.type()) {
-      Schema.Type.STRUCT ->
-          SchemaBuilder.struct()
-              .apply {
-                schema.fields().forEach { field(it.name(), it.schema()) }
-                optional()
-              }
-              .build()
-      Schema.Type.ARRAY -> SchemaBuilder.array(schema.valueSchema()).optional().build()
-      Schema.Type.MAP ->
-          SchemaBuilder.map(schema.keySchema(), schema.valueSchema()).optional().build()
-      else -> SchemaBuilder.type(schema.type()).optional().build()
-    }
+    return builder.apply { if (optional) optional() }.build()
   }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverterTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverterTest.kt
@@ -703,4 +703,162 @@ class DynamicTypesCompactTest {
                 mapOf("2000" to "birth", "2005" to "school", "2017" to "college"),
         )
   }
+
+  @Test
+  fun `collection of maps with differing key sets should merge into array of struct`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "age" to 21),
+            mapOf(
+                "name" to "jane",
+                "age" to 25,
+                "address" to mapOf("city" to "london", "zip" to 10001),
+            ),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    val element = schema.valueSchema()
+    element.type() shouldBe Schema.Type.STRUCT
+    element.fields().map { it.name() }.toSet() shouldBe setOf("name", "age", "address")
+    element.field("name").schema().isOptional shouldBe false
+    element.field("age").schema().isOptional shouldBe false
+    element.field("address").schema().isOptional shouldBe true
+
+    val addressSchema = element.field("address").schema()
+    converted shouldBe
+        listOf(
+            Struct(element).put("name", "john").put("age", 21L).put("address", null),
+            Struct(element)
+                .put("name", "jane")
+                .put("age", 25L)
+                .put("address", Struct(addressSchema).put("city", "london").put("zip", 10001L)),
+        )
+  }
+
+  @Test
+  fun `collection mixing homogeneous map and heterogeneous map should not drop keys`() {
+    // Element A produces MAP<String,String> (all values strings); element B produces a
+    // STRUCT<x,z> (mixed value types). Earlier merge logic dropped MAP-typed schemas and
+    // therefore lost A's `y` key entirely. After the fix, every key from every element is
+    // preserved and round-trips through value().
+    val a = mapOf("x" to "s1", "y" to "s2")
+    val b = mapOf("x" to "s", "z" to 123)
+    val coll = listOf(a, b)
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    val element = schema.valueSchema()
+    element.fields().map { it.name() }.toSet() shouldBe setOf("x", "y", "z")
+    element.field("x").schema().isOptional shouldBe false
+    element.field("y").schema().isOptional shouldBe true
+    element.field("z").schema().isOptional shouldBe true
+
+    converted shouldBe
+        listOf(
+            Struct(element).put("x", "s1").put("y", "s2").put("z", null),
+            Struct(element).put("x", "s").put("y", null).put("z", 123L),
+        )
+  }
+
+  @Test
+  fun `collection of three maps with varying key sets should merge and round-trip`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "age" to 21),
+            mapOf("name" to "jane", "employed" to true),
+            mapOf("name" to "bob", "age" to 30, "employed" to false),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    val element = schema.valueSchema()
+    element.field("name").schema().isOptional shouldBe false
+    element.field("age").schema().isOptional shouldBe true
+    element.field("employed").schema().isOptional shouldBe true
+
+    converted shouldBe
+        listOf(
+            Struct(element).put("name", "john").put("age", 21L).put("employed", null),
+            Struct(element).put("name", "jane").put("age", null).put("employed", true),
+            Struct(element).put("name", "bob").put("age", 30L).put("employed", false),
+        )
+  }
+
+  @Test
+  fun `collection of maps with conflicting non-null types should fall back to indexed struct`() {
+    val coll = listOf(mapOf("name" to "john"), mapOf("name" to 42))
+    val schema = converter.schema(coll, false)
+
+    schema.type() shouldBe Schema.Type.STRUCT
+    schema.fields().map { it.name() } shouldBe listOf("e0", "e1")
+  }
+
+  @Test
+  fun `collection mixing maps and non-maps should fall back to indexed struct`() {
+    val coll = listOf(mapOf("name" to "john"), "a string")
+    val schema = converter.schema(coll, false)
+
+    schema.type() shouldBe Schema.Type.STRUCT
+    schema.fields().map { it.name() } shouldBe listOf("e0", "e1")
+  }
+
+  @Test
+  fun `nested map field with differing key sets across elements should merge recursively`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "address" to mapOf("city" to "london", "zip" to 10001)),
+            mapOf(
+                "name" to "jane",
+                "address" to mapOf("city" to "paris", "zip" to 75001, "country" to "fr"),
+            ),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    val element = schema.valueSchema()
+    val addressSchema = element.field("address").schema()
+    addressSchema.type() shouldBe Schema.Type.STRUCT
+    addressSchema.field("country").schema().isOptional shouldBe true
+
+    converted shouldBe
+        listOf(
+            Struct(element)
+                .put("name", "john")
+                .put(
+                    "address",
+                    Struct(addressSchema)
+                        .put("city", "london")
+                        .put("zip", 10001L)
+                        .put("country", null),
+                ),
+            Struct(element)
+                .put("name", "jane")
+                .put(
+                    "address",
+                    Struct(addressSchema)
+                        .put("city", "paris")
+                        .put("zip", 75001L)
+                        .put("country", "fr"),
+                ),
+        )
+  }
+
+  @Test
+  fun `merged collection with optional flag set should mark element schema optional`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "age" to 21),
+            mapOf("name" to "jane", "age" to 25, "address" to mapOf("city" to "london")),
+        )
+    val schema = converter.schema(coll, true)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    schema.isOptional shouldBe true
+    schema.valueSchema().isOptional shouldBe true
+  }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverterTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverterTest.kt
@@ -705,7 +705,7 @@ class DynamicTypesCompactTest {
   }
 
   @Test
-  fun `collection of maps with differing key sets should merge into array of struct`() {
+  fun `collection of maps where one key set is a superset of the other should merge into array of struct`() {
     val coll =
         listOf(
             mapOf("name" to "john", "age" to 21),
@@ -718,19 +718,24 @@ class DynamicTypesCompactTest {
     val schema = converter.schema(coll, false)
     val converted = converter.value(schema, coll)
 
-    schema.type() shouldBe Schema.Type.ARRAY
-    val element = schema.valueSchema()
-    element.type() shouldBe Schema.Type.STRUCT
-    element.fields().map { it.name() }.toSet() shouldBe setOf("name", "age", "address")
-    element.field("name").schema().isOptional shouldBe false
-    element.field("age").schema().isOptional shouldBe false
-    element.field("address").schema().isOptional shouldBe true
+    val addressSchema =
+        SchemaBuilder.struct()
+            .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("zip", Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build()
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("address", addressSchema)
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
 
-    val addressSchema = element.field("address").schema()
     converted shouldBe
         listOf(
-            Struct(element).put("name", "john").put("age", 21L).put("address", null),
-            Struct(element)
+            Struct(elementSchema).put("name", "john").put("age", 21L).put("address", null),
+            Struct(elementSchema)
                 .put("name", "jane")
                 .put("age", 25L)
                 .put("address", Struct(addressSchema).put("city", "london").put("zip", 10001L)),
@@ -738,28 +743,48 @@ class DynamicTypesCompactTest {
   }
 
   @Test
-  fun `collection mixing homogeneous map and heterogeneous map should not drop keys`() {
-    // Element A produces MAP<String,String> (all values strings); element B produces a
-    // STRUCT<x,z> (mixed value types). Earlier merge logic dropped MAP-typed schemas and
-    // therefore lost A's `y` key entirely. After the fix, every key from every element is
-    // preserved and round-trips through value().
+  fun `collection of maps with no common keys should merge into array of struct`() {
+    val coll = listOf(mapOf("name" to "john"), mapOf("age" to 21))
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema).put("name", "john").put("age", null),
+            Struct(elementSchema).put("name", null).put("age", 21L),
+        )
+  }
+
+  @Test
+  fun `collection of a map inferred as MAP schema and a map inferred as STRUCT schema should keep all keys`() {
+    // On its own, `a` is inferred as MAP<STRING, STRING> (all values share a type) whereas `b` is
+    // inferred as a STRUCT (mixed value types). Merging must work from the raw keys of both
+    // elements so that `y`, which only exists in the MAP-typed element, is not dropped.
     val a = mapOf("x" to "s1", "y" to "s2")
     val b = mapOf("x" to "s", "z" to 123)
     val coll = listOf(a, b)
     val schema = converter.schema(coll, false)
     val converted = converter.value(schema, coll)
 
-    schema.type() shouldBe Schema.Type.ARRAY
-    val element = schema.valueSchema()
-    element.fields().map { it.name() }.toSet() shouldBe setOf("x", "y", "z")
-    element.field("x").schema().isOptional shouldBe false
-    element.field("y").schema().isOptional shouldBe true
-    element.field("z").schema().isOptional shouldBe true
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("x", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("y", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("z", Schema.OPTIONAL_INT64_SCHEMA)
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
 
     converted shouldBe
         listOf(
-            Struct(element).put("x", "s1").put("y", "s2").put("z", null),
-            Struct(element).put("x", "s").put("y", null).put("z", 123L),
+            Struct(elementSchema).put("x", "s1").put("y", "s2").put("z", null),
+            Struct(elementSchema).put("x", "s").put("y", null).put("z", 123L),
         )
   }
 
@@ -774,17 +799,19 @@ class DynamicTypesCompactTest {
     val schema = converter.schema(coll, false)
     val converted = converter.value(schema, coll)
 
-    schema.type() shouldBe Schema.Type.ARRAY
-    val element = schema.valueSchema()
-    element.field("name").schema().isOptional shouldBe false
-    element.field("age").schema().isOptional shouldBe true
-    element.field("employed").schema().isOptional shouldBe true
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("employed", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
 
     converted shouldBe
         listOf(
-            Struct(element).put("name", "john").put("age", 21L).put("employed", null),
-            Struct(element).put("name", "jane").put("age", null).put("employed", true),
-            Struct(element).put("name", "bob").put("age", 30L).put("employed", false),
+            Struct(elementSchema).put("name", "john").put("age", 21L).put("employed", null),
+            Struct(elementSchema).put("name", "jane").put("age", null).put("employed", true),
+            Struct(elementSchema).put("name", "bob").put("age", 30L).put("employed", false),
         )
   }
 
@@ -793,8 +820,11 @@ class DynamicTypesCompactTest {
     val coll = listOf(mapOf("name" to "john"), mapOf("name" to 42))
     val schema = converter.schema(coll, false)
 
-    schema.type() shouldBe Schema.Type.STRUCT
-    schema.fields().map { it.name() } shouldBe listOf("e0", "e1")
+    schema shouldBe
+        SchemaBuilder.struct()
+            .field("e0", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+            .field("e1", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT64_SCHEMA).build())
+            .build()
   }
 
   @Test
@@ -802,8 +832,18 @@ class DynamicTypesCompactTest {
     val coll = listOf(mapOf("name" to "john"), "a string")
     val schema = converter.schema(coll, false)
 
-    schema.type() shouldBe Schema.Type.STRUCT
-    schema.fields().map { it.name() } shouldBe listOf("e0", "e1")
+    schema shouldBe
+        SchemaBuilder.struct()
+            .field("e0", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+            .field("e1", Schema.STRING_SCHEMA)
+            .build()
+  }
+
+  @Test
+  fun `collection of maps with differing key sets should still enforce string map keys`() {
+    shouldThrow<IllegalArgumentException> {
+      converter.schema(listOf(mapOf("name" to "john"), mapOf(1 to 5, "a" to "b")), false)
+    } shouldHaveMessage ("unsupported map key type java.lang.Integer")
   }
 
   @Test
@@ -819,15 +859,23 @@ class DynamicTypesCompactTest {
     val schema = converter.schema(coll, false)
     val converted = converter.value(schema, coll)
 
-    schema.type() shouldBe Schema.Type.ARRAY
-    val element = schema.valueSchema()
-    val addressSchema = element.field("address").schema()
-    addressSchema.type() shouldBe Schema.Type.STRUCT
-    addressSchema.field("country").schema().isOptional shouldBe true
+    val addressSchema =
+        SchemaBuilder.struct()
+            .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("zip", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("country", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build()
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("address", addressSchema)
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
 
     converted shouldBe
         listOf(
-            Struct(element)
+            Struct(elementSchema)
                 .put("name", "john")
                 .put(
                     "address",
@@ -836,7 +884,7 @@ class DynamicTypesCompactTest {
                         .put("zip", 10001L)
                         .put("country", null),
                 ),
-            Struct(element)
+            Struct(elementSchema)
                 .put("name", "jane")
                 .put(
                     "address",
@@ -849,6 +897,39 @@ class DynamicTypesCompactTest {
   }
 
   @Test
+  fun `nested maps with single typed values should keep their map schema when merging`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "tags" to mapOf("a" to "x")),
+            mapOf("name" to "jane", "tags" to mapOf("a" to "y"), "age" to 21),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field(
+                "tags",
+                SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+                    .optional()
+                    .build(),
+            )
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema)
+                .put("name", "john")
+                .put("tags", mapOf("a" to "x"))
+                .put("age", null),
+            Struct(elementSchema).put("name", "jane").put("tags", mapOf("a" to "y")).put("age", 21L),
+        )
+  }
+
+  @Test
   fun `merged collection with optional flag set should mark element schema optional`() {
     val coll =
         listOf(
@@ -856,9 +937,29 @@ class DynamicTypesCompactTest {
             mapOf("name" to "jane", "age" to 25, "address" to mapOf("city" to "london")),
         )
     val schema = converter.schema(coll, true)
+    val converted = converter.value(schema, coll)
 
-    schema.type() shouldBe Schema.Type.ARRAY
-    schema.isOptional shouldBe true
-    schema.valueSchema().isOptional shouldBe true
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field(
+                "address",
+                SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+                    .optional()
+                    .build(),
+            )
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).optional().build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema).put("name", "john").put("age", 21L).put("address", null),
+            Struct(elementSchema)
+                .put("name", "jane")
+                .put("age", 25L)
+                .put("address", mapOf("city" to "london")),
+        )
   }
 }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
@@ -317,14 +317,17 @@ class Neo4jSourceJsonRawCompactIT : Neo4jSourceQueryIT() {
           "WITH {id: 'ROOT_ID', list: [{ property1: 'value1' }, { property2: 'value2' }]} AS data RETURN data, data.id AS guid, dateTime().epochMillis AS timestamp",
   )
   @Test
-  fun `serializes list of heterogeneous objects as map by default`(
+  fun `serializes list of heterogeneous objects as merged list by default`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer
   ) = runTest {
     TopicVerifier.createForMap(consumer)
         .assertMessageValue { value ->
           val list = (value["data"] as Map<*, *>)["list"]
           list shouldBe
-              mapOf("e0" to mapOf("property1" to "value1"), "e1" to mapOf("property2" to "value2"))
+              listOf(
+                  mapOf("property1" to "value1", "property2" to null),
+                  mapOf("property1" to null, "property2" to "value2"),
+              )
         }
         .verifyWithin(Duration.ofSeconds(30))
   }


### PR DESCRIPTION
## Summary

Fixes a `DataException` raised by `CompactValueConverter.value()` when a Cypher `collect()` produces Maps with different key sets across elements (issue [#527](https://github.com/neo4j/neo4j-kafka-connector/issues/527)).

When the Collection branch sees multiple distinct element Schemas, `CompactValueConverter.schema()` previously fell back to the indexed-struct `{e0, e1, ...}` representation, but `value()` then could not coerce the elements and threw. This change merges those element schemas into a single STRUCT covering the union of keys; keys absent (or null/empty) in some elements become optional fields. Conflicting non-null types still fall back to the indexed-struct representation.

This is the **Case 1** fix referred to in the discussion on [#528](https://github.com/neo4j/neo4j-kafka-connector/pull/528). Per @fbiville's request, Case 1 (different key sets) and Case 2 (same key, null vs concrete value) have been split. Case 2 lives in [#528](https://github.com/neo4j/neo4j-kafka-connector/pull/528); this PR is Case 1 only.

## Addressing the "skipping keys" feedback

@fbiville pointed out on [#528](https://github.com/neo4j/neo4j-kafka-connector/pull/528) that an earlier Case 1 implementation silently dropped keys: tests that schema-shape-asserted but didn't call `converter.value(schema, coll)` masked the bug. The earlier `mergeMapAndStructSchemas` filtered `Set<Schema>` down to STRUCT schemas only and discarded MAP schemas, losing any key that lived exclusively under a MAP-typed element.

This rewrite avoids that class of bug by working from the **raw Map values**, not from previously-computed Schemas:

```kotlin
private fun mergeMapElementSchemas(elements: List<Map<*, *>>, optional: Boolean): Schema? {
  // walk every key from every element, re-inferring value schemas with
  // forceMapsAsStruct=true so MAP and STRUCT element shapes are comparable
}
```

Every new test in `CompactValueConverterTest` calls `converter.value(schema, coll)` and asserts on the resulting `List<Struct>`, so a key-dropping regression cannot pass. Specifically, `collection mixing homogeneous map and heterogeneous map should not drop keys` exercises the exact scenario that broke earlier (one element produces a `MAP<String,String>` schema, the other a STRUCT) and asserts that all three keys (`x`, `y`, `z`) round-trip.

## Scope notes

- The merge only runs when **all** non-empty Collection elements are Maps. Anything else (mixed types, conflicting non-null field types) still falls back to the existing indexed-struct schema. No behavior change for non-Map collections.
- Nested Maps with differing key sets are merged recursively (also driven by raw values, so the same safety property holds).
- @fbiville also noted the team is cautious about scanning all data for schema inference and may defer broader changes to the next major version. This PR is intentionally minimal — it scans only the immediate elements of a Collection that already hit the `else`-branch fallback (i.e. `schema()` was already iterating them anyway). If that's still beyond what should land before the next major, please feel free to defer this PR.

## Test plan

- [x] `./mvnw -pl common -am test -Dtest='DynamicTypesCompactTest'` — 28 tests pass (21 pre-existing + 7 new)
- [x] Updated `Neo4jSourceQueryIT.serializes list of heterogeneous objects as merged list by default` to reflect the new merged-list output
- [ ] Reviewer to run full source-connector ITs locally