### PR TITLE
fix: bump netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <mockito.version>5.23.0</mockito.version>
         <neo4j-cypher-dsl.version>2022.11.0</neo4j-cypher-dsl.version>
         <neo4j-java-driver.version>4.4.23</neo4j-java-driver.version>
-        <netty.version>4.1.133.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- to match what is shipped with the Kafka Connect version used in our integration test environment -->
         <protobuf.version>3.25.5</protobuf.version>


### PR DESCRIPTION
Bumps netty version to address CVE-2026-42583 reported by Confluent.