### PR TITLE
build: fix package name for confluence compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ mvn verify
 ```
 
 You'll find the connector archive
-at `packaging/target/neo4j-kafka-connect-{version}.zip`.
+at `packaging/target/neo4j-kafka-connect-neo4j-{version}.zip`.
 
 ### Code Format
 

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -44,7 +44,7 @@ release:
           - GitHub
 
 checksum:
-  name: 'neo4j-kafka-connect-{{projectVersion}}-checksums.txt'
+  name: 'neo4j-kafka-connect-neo4j-{{projectVersion}}-checksums.txt'
   algorithms:
     - SHA_256
   files: true
@@ -53,8 +53,8 @@ checksum:
 
 files:
   globs:
-    - pattern: packaging/target/neo4j-kafka-connect-*.jar
-    - pattern: packaging/target/neo4j-kafka-connect-*.zip
+    - pattern: packaging/target/neo4j-kafka-connect-neo4j-*.jar
+    - pattern: packaging/target/neo4j-kafka-connect-neo4j-*.zip
 
 hooks:
   script:

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -114,7 +114,7 @@
                                 <descriptor>src/main/assemblies/confluent-zip.xml</descriptor>
                             </descriptors>
                             <appendAssemblyId>false</appendAssemblyId>
-                            <finalName>neo4j-kafka-connect-${project.version}</finalName>
+                            <finalName>neo4j-kafka-connect-neo4j-${project.version}</finalName>
                         </configuration>
                     </execution>
                     <execution>
@@ -128,7 +128,7 @@
                                 <descriptor>src/main/assemblies/jar.xml</descriptor>
                             </descriptors>
                             <appendAssemblyId>false</appendAssemblyId>
-                            <finalName>neo4j-kafka-connect-${project.version}</finalName>
+                            <finalName>neo4j-kafka-connect-neo4j-${project.version}</finalName>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
## Issue
Confluent upload compliance requires us to suffix the connector name with neo4j to align with: https://docs.confluent.io/platform/current/connect/confluent-hub/component-archive.html#component-archive-format.


