### PR TITLE
fix: security findings to apply group by topic and partition

### DIFF
--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
@@ -63,9 +63,10 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
     val duration = measureTime {
       records
           ?.map { SinkMessage(it) }
-          ?.groupBy { it.topic }
-          ?.mapKeys { topicHandlers.getValue(it.key) }
-          ?.forEach { (handler, messages) -> processMessages(handler, messages) }
+          ?.groupBy { it.topic to it.record.kafkaPartition() }
+          ?.forEach { (topicPartition, messages) ->
+            processMessages(topicHandlers.getValue(topicPartition.first), messages)
+          }
     }
     log.info("processed {} records in {} ms", records?.size ?: 0, duration.inWholeMilliseconds)
   }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/ApocBatchStrategy.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/ApocBatchStrategy.kt
@@ -39,6 +39,9 @@ class ApocBatchStrategy(
       messages: Iterable<SinkMessage>,
       eventTransformer: (SinkMessage) -> SinkAction,
   ): Iterable<Iterable<ChangeQuery>> {
+    val partitions = messages.map { it.record.kafkaPartition() }.distinct()
+    require(partitions.size <= 1) { "batch must not span partitions, got $partitions" }
+
     val (topic, partition) =
         messages.firstOrNull()?.let { it.record.topic() to it.record.kafkaPartition() }
             ?: return emptyList()

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/NativeBatchStrategy.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/NativeBatchStrategy.kt
@@ -40,6 +40,9 @@ class NativeBatchStrategy(
       messages: Iterable<SinkMessage>,
       eventTransformer: (SinkMessage) -> SinkAction,
   ): Iterable<Iterable<ChangeQuery>> {
+    val partitions = messages.map { it.record.kafkaPartition() }.distinct()
+    require(partitions.size <= 1) { "batch must not span partitions, got $partitions" }
+
     val (topic, partition) =
         messages.firstOrNull()?.let { it.record.topic() to it.record.kafkaPartition() }
             ?: return emptyList()

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/HandlerTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/HandlerTest.kt
@@ -31,16 +31,19 @@ open class HandlerTest {
       keySchema: Schema? = null,
       key: Any? = null,
       headers: Iterable<Header> = emptyList(),
+      topic: String = "my-topic",
+      partition: Int = 0,
+      offset: Long = 0,
   ): SinkMessage {
     return SinkMessage(
         SinkRecord(
-            "my-topic",
-            0,
+            topic,
+            partition,
             keySchema,
             key,
             valueSchema,
             value,
-            0,
+            offset,
             TIMESTAMP,
             TimestampType.CREATE_TIME,
             headers,

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/TestUtils.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/TestUtils.kt
@@ -164,4 +164,38 @@ object TestUtils {
           )
     }
   }
+
+  /**
+   * Verifies one offset node per partition. Each partition must have its own independently tracked
+   * watermark.
+   *
+   * @param expectedOffsets partition number to expected offset
+   */
+  fun verifyEosOffsetsPerPartitionIfEnabled(
+      session: Session,
+      strategy: SinkStrategy,
+      offsetLabel: String,
+      expectedOffsets: Map<Int, Long>,
+  ) {
+    if (offsetLabel.isEmpty()) {
+      return
+    }
+
+    val actual =
+        session.run("MATCH (n:$offsetLabel) RETURN n{.*} AS n ORDER BY n.partition").list().map {
+          it.get("n").asMap()
+        }
+
+    actual shouldBe
+        expectedOffsets.entries
+            .sortedBy { it.key }
+            .map {
+              mapOf(
+                  "strategy" to strategy.name,
+                  "topic" to "my-topic",
+                  "partition" to it.key.toLong(),
+                  "offset" to it.value,
+              )
+            }
+  }
 }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cypher/CypherHandlerIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cypher/CypherHandlerIT.kt
@@ -38,6 +38,7 @@ import org.neo4j.connectors.kafka.sink.SinkStrategyHandler
 import org.neo4j.connectors.kafka.sink.strategy.SinkBatchStrategy
 import org.neo4j.connectors.kafka.sink.strategy.SinkHandler
 import org.neo4j.connectors.kafka.sink.strategy.TestUtils.verifyEosOffsetIfEnabled
+import org.neo4j.connectors.kafka.sink.strategy.TestUtils.verifyEosOffsetsPerPartitionIfEnabled
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.createDatabase
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.dropDatabase
 import org.neo4j.connectors.kafka.testing.createNodeKeyConstraint
@@ -187,16 +188,68 @@ abstract class CypherHandlerIT(
     verifyEosOffsetIfEnabled(session, SinkStrategy.CYPHER, eosOffsetLabel, 3)
   }
 
+  @Test
+  fun `should track offsets independently per partition`() {
+    session.createNodeKeyConstraint(neo4j(), "user_key", "User", "userId")
+    startTask("MERGE (u:User {userId: event.userId}) SET u.name = event.name")
+
+    val partition0 =
+        (100L..102L).map { offset ->
+          newMessage(mapOf("userId" to "p0-$offset", "name" to "P0-$offset"), offset, partition = 0)
+        }
+    val partition1 =
+        (3L..5L).map { offset ->
+          newMessage(mapOf("userId" to "p1-$offset", "name" to "P1-$offset"), offset, partition = 1)
+        }
+
+    task.put(partition0 + partition1)
+
+    session.run("MATCH (a:User) RETURN count(a)").single().get(0).asInt() shouldBe 6
+    session
+        .run("MATCH (a:User) WHERE a.userId STARTS WITH 'p1-' RETURN count(a)")
+        .single()
+        .get(0)
+        .asInt() shouldBe 3
+
+    verifyEosOffsetsPerPartitionIfEnabled(
+        session,
+        SinkStrategy.CYPHER,
+        eosOffsetLabel,
+        mapOf(0 to 102L, 1 to 5L),
+    )
+
+    // Now that watermarks exist, send the next messages for partition 1 only.
+    task.put(
+        (6L..8L).map { offset ->
+          newMessage(mapOf("userId" to "p1-$offset", "name" to "P1-$offset"), offset, partition = 1)
+        }
+    )
+
+    session.run("MATCH (a:User) RETURN count(a)").single().get(0).asInt() shouldBe 9
+    session
+        .run("MATCH (a:User) WHERE a.userId STARTS WITH 'p1-' RETURN count(a)")
+        .single()
+        .get(0)
+        .asInt() shouldBe 6
+
+    verifyEosOffsetsPerPartitionIfEnabled(
+        session,
+        SinkStrategy.CYPHER,
+        eosOffsetLabel,
+        mapOf(0 to 102L, 1 to 8L),
+    )
+  }
+
   protected fun newTaskContext(): SinkTaskContext {
     return mock<SinkTaskContext> {
       on { errantRecordReporter() } doReturn ErrantRecordReporter { _, error -> throw error }
     }
   }
 
-  private fun newMessage(value: Map<String, Any?>, offset: Long): SinkRecord {
+  private fun newMessage(value: Map<String, Any?>, offset: Long, partition: Int = 0): SinkRecord {
     return SinkRecord(
         "my-topic",
-        0,
+        partition,
         null,
         null,
         null,


### PR DESCRIPTION
 ## Problem                                                                                                                                                                                               
                                                                                                                                                                                                           
  For exactly-once semantic  records grouped by topic only.                                                                                                                                                
                                                                                                                                                                                                          
  Kafka Connect sends records from several partitions of the same topic in                                                                                                                           
  one `put()`. So all offsets were saved under the first record's partition. After a restart,                                                                                                                         
  records could be skipped or written twice. Exactly-once only worked when a task                                                                                                                          
  owned a single partition.                                                                                                                                                                                
                                                                                                                                                                                                           
  ## Changes                                                                                                                                                                                               
  - `Neo4jSinkTask` — group by `(topic, partition)`, so a batch never mixes                                                                                                                                
    partitions.                                                                                                                                                                                            
  - `NativeBatchStrategy`, `ApocBatchStrategy` — add                                                                                                                                                       
    `require(partitions.size <= 1)` so this cannot happen again unnoticed.                                                                                                                                 
                                                                                                                                                                                                           
  ## Tests                                                                                                                                                                                                 
                                                                                                                                                                                                           
  - New IT `should track offsets independently per partition`: one `put()` with                                                                                                                            
    offsets 100–102 on partition 0 and 3–5 on partition 1. Checks all 6 rows are                                                                                                                           
    written and offsets are `{0: 102, 1: 5}`. A second `put()` on partition 1                                                                                                                              
    (offsets 6–8) checks partition 0 stays at 102.                                                                                                                                                         
  - New helper `verifyEosOffsetsPerPartitionIfEnabled` checks one offset node per                                                                                                                          
    partition.                                                                                                                                                                                             
  - `HandlerTest.newMessage` now takes `topic`, `partition` and `offset`, with the                                                                                                                         
    old values as defaults.   