### PR TITLE
ci: make build more resilient

### DIFF
--- a/.teamcity/builds/IntegrationTests.kt
+++ b/.teamcity/builds/IntegrationTests.kt
@@ -2,7 +2,9 @@ package builds
 
 import jetbrains.buildServer.configs.kotlin.BuildStep
 import jetbrains.buildServer.configs.kotlin.BuildType
+import jetbrains.buildServer.configs.kotlin.buildSteps.ExecBuildStep
 import jetbrains.buildServer.configs.kotlin.buildSteps.ScriptBuildStep
+import jetbrains.buildServer.configs.kotlin.buildSteps.exec
 import jetbrains.buildServer.configs.kotlin.buildSteps.script
 import jetbrains.buildServer.configs.kotlin.toId
 
@@ -46,6 +48,7 @@ class IntegrationTests(
             }
 
             script {
+              this.name = "Start test environment"
               scriptContent =
                   """
                 #!/bin/bash -eu
@@ -60,7 +63,9 @@ class IntegrationTests(
               dockerImage = javaVersion.dockerImage
               dockerRunParameters = "--volume /var/run/docker.sock:/var/run/docker.sock"
             }
+
             commonMaven(javaVersion) {
+              this.name = "Run integration tests"
               this.goals = "verify"
               this.runnerArgs =
                   "$MAVEN_DEFAULT_ARGS -Djava.version=${javaVersion.version} -DskipUnitTests"
@@ -68,7 +73,9 @@ class IntegrationTests(
               dockerRunParameters =
                   "--volume /var/run/docker.sock:/var/run/docker.sock --network neo4j-kafka-connector_default"
             }
+
             script {
+              this.name = "Backup diagnostics"
               scriptContent =
                   """
                 #!/bin/bash -eu
@@ -85,16 +92,13 @@ class IntegrationTests(
               dockerImage = javaVersion.dockerImage
               dockerRunParameters = "--volume /var/run/docker.sock:/var/run/docker.sock"
             }
-            script {
-              scriptContent =
-                  """
-                #!/bin/bash -eu
-                dip compose down --rmi local
-            """
-                      .trimIndent()
+
+            exec {
+              this.name = "Tear down test environment"
+              this.path = "scripts/tear-down-test-environment.sh"
               formatStderrAsError = true
               executionMode = BuildStep.ExecutionMode.ALWAYS
-              dockerImagePlatform = ScriptBuildStep.ImagePlatform.Linux
+              dockerImagePlatform = ExecBuildStep.ImagePlatform.Linux
               dockerImage = javaVersion.dockerImage
               dockerRunParameters = "--volume /var/run/docker.sock:/var/run/docker.sock"
             }

--- a/dip.yml
+++ b/dip.yml
@@ -48,5 +48,5 @@ interaction:
 
 provision:
   - dip build-package
-  - dip compose down --rmi local
+  - dip compose down --rmi local --volumes
   - dip compose up -d neo4j zookeeper broker schema-registry control-center

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       NEO4J_ACCEPT_LICENSE_AGREEMENT: "yes"
       NEO4J_server_memory_heap_max__size: "4G"
       NEO4J_server_logs_config: "/tmp/conf/cdc-debug.xml"
+      NEO4J_db_tx__log_preallocate: "false"
+      NEO4J_db_tx__log_rotation_size: "1.00MiB"
     healthcheck:
       test: [ "CMD", "cypher-shell", "-u", "neo4j", "-p", "password", "RETURN 1" ]
       start_period: 2m

--- a/scripts/tear-down-test-environment.sh
+++ b/scripts/tear-down-test-environment.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -eu
 
 # This file exists to prevent issues with creating a script dynamically, which can occur is the build agent is running low on disk.
-dip compose down --rmi local
+dip compose down --rmi local --volumes

--- a/scripts/tear-down-test-environment.sh
+++ b/scripts/tear-down-test-environment.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -eu
+
+# This file exists to prevent issues with creating a script dynamically, which can occur is the build agent is running low on disk.
+dip compose down --rmi local

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/SinkActionStatementGeneratorIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/SinkActionStatementGeneratorIT.kt
@@ -32,8 +32,7 @@ import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.caniuse.Neo4jVersion
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.createDatabase
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.dropDatabase
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -49,13 +48,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 class SinkActionStatementGeneratorIT {
 
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSchemaHandlerApocIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSchemaHandlerApocIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.ApocBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,14 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CdcSchemaHandlerApocIT(eosOffsetLabel: String) :
     CdcSchemaHandlerIT(eosOffsetLabel, ApocBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withPlugins("apoc")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer().withPlugins("apoc")
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSchemaHandlerNativeIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSchemaHandlerNativeIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.NativeBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,13 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CdcSchemaHandlerNativeIT(eosOffsetLabel: String) :
     CdcSchemaHandlerIT(eosOffsetLabel, NativeBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSourceIdHandlerApocIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSourceIdHandlerApocIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.ApocBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,14 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CdcSourceIdHandlerApocIT(eosOffsetLabel: String) :
     CdcSourceIdHandlerIT(eosOffsetLabel, ApocBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withPlugins("apoc")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer().withPlugins("apoc")
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSourceIdHandlerNativeIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcSourceIdHandlerNativeIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.NativeBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,13 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CdcSourceIdHandlerNativeIT(eosOffsetLabel: String) :
     CdcSourceIdHandlerIT(eosOffsetLabel, NativeBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CudHandlerApocIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CudHandlerApocIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.ApocBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,14 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CudHandlerApocIT(eosOffsetLabel: String) :
     CudHandlerIT(eosOffsetLabel, ApocBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withPlugins("apoc")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer().withPlugins("apoc")
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CudHandlerNativeIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CudHandlerNativeIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.NativeBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,13 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CudHandlerNativeIT(eosOffsetLabel: String) :
     CudHandlerIT(eosOffsetLabel, NativeBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cypher/CypherHandlerApocIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cypher/CypherHandlerApocIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.ApocBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,14 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CypherHandlerApocIT(eosOffsetLabel: String) :
     CypherHandlerIT(eosOffsetLabel, ApocBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withPlugins("apoc")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer().withPlugins("apoc")
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cypher/CypherHandlerNativeIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cypher/CypherHandlerNativeIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.NativeBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,13 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class CypherHandlerNativeIT(eosOffsetLabel: String) :
     CypherHandlerIT(eosOffsetLabel, NativeBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternHandlerApocIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternHandlerApocIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.ApocBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,14 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class PatternHandlerApocIT(eosOffsetLabel: String) :
     PatternHandlerIT(eosOffsetLabel, ApocBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withPlugins("apoc")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer().withPlugins("apoc")
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternHandlerNativeIT.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternHandlerNativeIT.kt
@@ -21,8 +21,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.neo4j.caniuse.Neo4j
 import org.neo4j.caniuse.Neo4jDetector
 import org.neo4j.connectors.kafka.sink.strategy.NativeBatchStrategy
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -34,13 +33,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 abstract class PatternHandlerNativeIT(eosOffsetLabel: String) :
     PatternHandlerIT(eosOffsetLabel, NativeBatchStrategy::class) {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jCdcTaskTest.kt
@@ -53,10 +53,9 @@ import org.neo4j.connectors.kafka.configuration.Neo4jConfiguration
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.createDatabase
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.dropDatabase
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.connectors.kafka.testing.createNodeKeyConstraint
 import org.neo4j.connectors.kafka.testing.createRelationshipKeyConstraint
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
 import org.neo4j.driver.GraphDatabase
@@ -69,13 +68,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 @Testcontainers
 class Neo4jCdcTaskTest {
   companion object {
-    @Container
-    val container: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val container: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
     private lateinit var neo4j: Neo4j

--- a/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
+++ b/source/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jQueryTaskTest.kt
@@ -43,8 +43,7 @@ import org.neo4j.connectors.kafka.data.DynamicTypes
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.createDatabase
 import org.neo4j.connectors.kafka.testing.DatabaseSupport.dropDatabase
 import org.neo4j.connectors.kafka.testing.TestSupport.runTest
-import org.neo4j.connectors.kafka.testing.neo4jDatabase
-import org.neo4j.connectors.kafka.testing.neo4jImage
+import org.neo4j.connectors.kafka.testing.createNeo4jContainer
 import org.neo4j.connectors.kafka.utils.JSONUtils
 import org.neo4j.driver.AuthTokens
 import org.neo4j.driver.Driver
@@ -61,13 +60,7 @@ import org.testcontainers.junit.jupiter.Testcontainers
 class Neo4jQueryTaskTest {
 
   companion object {
-    @Container
-    val neo4j: Neo4jContainer<*> =
-        Neo4jContainer(neo4jImage())
-            .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
-            .withExposedPorts(7687)
-            .withoutAuthentication()
-            .waitingFor(neo4jDatabase())
+    @Container val neo4j: Neo4jContainer<*> = createNeo4jContainer()
 
     private lateinit var driver: Driver
 

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DatabaseSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/DatabaseSupport.kt
@@ -101,7 +101,8 @@ object DatabaseSupport {
     if (database == DEFAULT_DATABASE) {
       return this
     }
-    this.run("DROP DATABASE \$db_name WAIT 30 SECONDS", mapOf("db_name" to database)).consume()
+    this.run("DROP DATABASE \$db_name IF EXISTS WAIT 30 SECONDS", mapOf("db_name" to database))
+        .consume()
     return this
   }
 }

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/Neo4jSupport.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/Neo4jSupport.kt
@@ -126,3 +126,14 @@ fun Session.createRelationshipKeyConstraint(
     }
   }
 }
+
+fun createNeo4jContainer(): Neo4jContainer<*> =
+    Neo4jContainer(neo4jImage())
+        .withEnv("NEO4J_ACCEPT_LICENSE_AGREEMENT", "yes")
+        // reduce transaction log disk footprint to account to multiple databases created by test
+        // extensions
+        .withNeo4jConfig("db.tx_log.preallocate", "false")
+        .withNeo4jConfig("db.tx_log.rotation.size", "1.00MiB")
+        .withExposedPorts(7687)
+        .withoutAuthentication()
+        .waitingFor(neo4jDatabase())

--- a/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtension.kt
+++ b/testing/src/main/kotlin/org/neo4j/connectors/kafka/testing/source/Neo4jSourceExtension.kt
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.extension.ExtensionConfigurationException
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
 import org.junit.jupiter.api.extension.ParameterResolver
-import org.junit.jupiter.api.extension.TestExecutionExceptionHandler
 import org.neo4j.caniuse.CanIUse.canIUse
 import org.neo4j.caniuse.Dbms
 import org.neo4j.caniuse.Neo4j
@@ -92,12 +91,7 @@ internal class Neo4jSourceExtension(
         { properties, topic ->
           ConsumerResolver.getSubscribedConsumer(properties, topic)
         },
-) :
-    ExecutionCondition,
-    BeforeEachCallback,
-    AfterEachCallback,
-    ParameterResolver,
-    TestExecutionExceptionHandler {
+) : ExecutionCondition, BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
   companion object {
     private val log: Logger = LoggerFactory.getLogger(Neo4jSourceExtension::class.java)
@@ -122,7 +116,6 @@ internal class Neo4jSourceExtension(
       val resolvers: SourceAnnotationResolvers,
       private var driver: Driver? = null,
       var source: Neo4jSourceRegistration? = null,
-      var testFailed: Boolean = false,
   ) : AutoCloseable {
     @OptIn(ExperimentalAtomicApi::class) val dbCreated = AtomicBoolean(false)
     val topicRegistry = TopicRegistry()
@@ -181,10 +174,8 @@ internal class Neo4jSourceExtension(
     @OptIn(ExperimentalAtomicApi::class)
     override fun close() {
       source?.unregister()
-      if (!testFailed) {
-        if (dbCreated.load()) {
-          driver?.dropDatabase(neo4jDatabase)
-        }
+      if (dbCreated.load()) {
+        driver?.dropDatabase(neo4jDatabase)
       }
       driver?.close()
 
@@ -307,14 +298,6 @@ internal class Neo4jSourceExtension(
     )
     log.info("registered source connector with name {}", state.source!!.name)
     state.topicRegistry.log()
-
-    state.testFailed = false
-  }
-
-  override fun handleTestExecutionException(context: ExtensionContext, throwable: Throwable) {
-    val state = getState(context)
-    state.testFailed = true
-    throw throwable
   }
 
   override fun afterEach(context: ExtensionContext) {


### PR DESCRIPTION
* use exec step to increase chances to tear down test environment
* delete all test databases
* reduce transaction log size and don't preallocate it