### PR TITLE
fix: updates do not reject null property values

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/MapUtils.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/utils/MapUtils.kt
@@ -48,7 +48,7 @@ object MapUtils {
                       "Keys of '$key' is not an instance of ${K::class.simpleName}"
                   )
                 }
-                if (!V::class.isInstance(it.value)) {
+                if (it.value != null && !V::class.isInstance(it.value)) {
                   throw InvalidDataException(
                       "Values of '$key' is not an instance of ${V::class.simpleName}"
                   )

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/utils/MapUtilsTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/utils/MapUtilsTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [https://neo4j.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.connectors.kafka.utils
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import org.junit.jupiter.api.Test
+import org.neo4j.connectors.kafka.exceptions.InvalidDataException
+import org.neo4j.connectors.kafka.utils.MapUtils.getMap
+
+class MapUtilsTest {
+
+  @Test
+  fun `should keep null values`() {
+    val message = mapOf("properties" to mapOf("name" to null))
+
+    message.getMap<String, Any?>("properties") shouldBe mapOf("name" to null)
+  }
+
+  @Test
+  fun `should keep a mix of null and non-null values`() {
+    val message = mapOf("properties" to mapOf("name" to null, "age" to 21))
+
+    message.getMap<String, Any?>("properties") shouldBe mapOf("name" to null, "age" to 21)
+  }
+
+  @Test
+  fun `should reject a wrong value type`() {
+    val message = mapOf("properties" to mapOf("name" to 21))
+
+    shouldThrow<InvalidDataException> { message.getMap<String, String>("properties") }
+        .shouldHaveMessage("Values of 'properties' is not an instance of String")
+  }
+
+  @Test
+  fun `should reject a wrong key type`() {
+    val message = mapOf("properties" to mapOf(1 to "name"))
+
+    shouldThrow<InvalidDataException> { message.getMap<String, String>("properties") }
+        .shouldHaveMessage("Keys of 'properties' is not an instance of String")
+  }
+
+  @Test
+  fun `should reject a value that is not a map`() {
+    val message = mapOf("properties" to "not a map")
+
+    shouldThrow<InvalidDataException> { message.getMap<String, Any?>("properties") }
+        .shouldHaveMessage("Map element 'properties' is not an instance of Map")
+  }
+}

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateNodeTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/UpdateNodeTest.kt
@@ -94,4 +94,17 @@ class UpdateNodeTest {
     shouldThrow<InvalidDataException> { operation.toAction() } shouldHaveMessage
         "Node must contain at least one ID property."
   }
+
+  @Test
+  fun `should parse null property value`() {
+    val operation =
+        UpdateNode.from(
+            mapOf(
+                Keys.LABELS to listOf("Person"),
+                Keys.IDS to mapOf("id" to 1),
+                Keys.PROPERTIES to mapOf("name" to null),
+            )
+        )
+    operation shouldBe UpdateNode(setOf("Person"), mapOf("id" to 1), mapOf("name" to null))
+  }
 }


### PR DESCRIPTION
Changes:

-  One more condition check for MapUtils : `it.value != null`
-  MapUtilsTest class added
-  new test added to UpdateNodeTest