### PR TITLE
fix: only report bad record data to DLQ

### DIFF
--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/utils/CypherRendererTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/utils/CypherRendererTest.kt
@@ -52,9 +52,9 @@ class CypherRendererTest {
 
   object BelowThresholdParams : ArgumentsProvider {
     override fun provideArguments(
-        parameters: ParameterDeclarations?,
-        context: ExtensionContext?,
-    ): Stream<out Arguments?>? {
+        parameters: ParameterDeclarations,
+        context: ExtensionContext,
+    ): Stream<out Arguments> {
       return Stream.of(
           Arguments.of(
               Neo4j(Neo4jVersion(4, 4), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)
@@ -74,9 +74,9 @@ class CypherRendererTest {
 
   object AtOrAboveThresholdParams : ArgumentsProvider {
     override fun provideArguments(
-        parameters: ParameterDeclarations?,
-        context: ExtensionContext?,
-    ): Stream<out Arguments?>? {
+        parameters: ParameterDeclarations,
+        context: ExtensionContext,
+    ): Stream<out Arguments> {
       return Stream.of(
           Arguments.of(
               Neo4j(Neo4jVersion(5, 23), Neo4jEdition.ENTERPRISE, Neo4jDeploymentType.SELF_MANAGED)

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
@@ -112,11 +112,12 @@ abstract class Neo4jSinkErrorIT {
   }
 
   @Neo4jSink(
-      cypher =
+      nodePattern =
           [
-              CypherStrategy(
+              NodePatternStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+                  "(:Person{!id, name, surname})",
+                  mergeNodeProperties = false,
               )
           ],
       errorDlqTopic = DLQ_TOPIC,
@@ -131,15 +132,18 @@ abstract class Neo4jSinkErrorIT {
   ) {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
 
-    val schemaWithMissingSurname =
+    // the record is missing the key the pattern requires. Only a fault in the record's own content
+    // reaches the DLQ, so a Neo4j-side rejection can no longer be used to trigger this.
+    val schemaWithMissingId =
         SchemaBuilder.struct()
-            .field("id", Schema.INT64_SCHEMA)
             .field("name", Schema.STRING_SCHEMA)
+            .field("surname", Schema.STRING_SCHEMA)
             .build()
-    val struct = Struct(schemaWithMissingSurname)
-    struct.put("id", 1L)
+    val struct = Struct(schemaWithMissingId)
     struct.put("name", "John")
-    producer.publish(valueSchema = schemaWithMissingSurname, value = struct)
+    struct.put("surname", "Doe")
+    val messageToFail = KafkaMessage(valueSchema = schemaWithMissingId, value = struct)
+    producer.publish(messageToFail)
 
     TopicVerifier.createForMap(errorConsumer)
         .assertMessage(schemaTopic = producer.topic) {
@@ -154,24 +158,25 @@ abstract class Neo4jSinkErrorIT {
           errorHeaders.getValue(ErrorHeaders.CLASS_NAME) shouldBe
               "org.apache.kafka.connect.sink.SinkTask"
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "org.neo4j.driver.exceptions.ClientException"
+              "org.neo4j.connectors.kafka.exceptions.InvalidDataException"
           errorHeaders
               .getValue(ErrorHeaders.EXCEPTION_MESSAGE)
               .shouldBeInstanceOf<String>() shouldContain
-              """Cannot merge the following node because of null property value for 'surname': (:Person {surname: null})"""
+              "Key 'id' could not be located in the message."
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_STACKTRACE) shouldNotBe null
 
-          it.value shouldBe mapOf("id" to 1L, "name" to "John")
+          it.value shouldBe mapOf("name" to "John", "surname" to "Doe")
         }
         .verifyWithin(Duration.ofSeconds(30))
   }
 
   @Neo4jSink(
-      cypher =
+      nodePattern =
           [
-              CypherStrategy(
+              NodePatternStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+                  "(:Person{!id, name, surname})",
+                  mergeNodeProperties = false,
               )
           ],
       errorDlqTopic = DLQ_TOPIC,
@@ -187,14 +192,17 @@ abstract class Neo4jSinkErrorIT {
       neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
-    val schemaWithMissingSurname =
+    // a record fault, so that it is the error tolerance being tested rather than the
+    // record-versus-infrastructure classification
+    val schemaWithMissingId =
         SchemaBuilder.struct()
-            .field("id", Schema.INT64_SCHEMA)
             .field("name", Schema.STRING_SCHEMA)
+            .field("surname", Schema.STRING_SCHEMA)
             .build()
-    val struct = Struct(schemaWithMissingSurname)
-    struct.put("id", 1L)
+    val struct = Struct(schemaWithMissingId)
     struct.put("name", "John")
+    struct.put("surname", "Doe")
+    val messageToFail = KafkaMessage(valueSchema = schemaWithMissingId, value = struct)
 
     // before the failure
     eventually(30.seconds) {
@@ -203,11 +211,12 @@ abstract class Neo4jSinkErrorIT {
       tasks.get(0).get("state").asText() shouldBe "RUNNING"
     }
 
-    producer.publish(valueSchema = schemaWithMissingSurname, value = struct)
+    producer.publish(messageToFail)
 
+    // the dlq message is deserialised into a map, so it cannot be compared to the struct
     TopicVerifier.createForMap(errorConsumer)
         .assertMessageValue(schemaTopic = producer.topic) {
-          it shouldBe mapOf("id" to 1L, "name" to "John")
+          it shouldBe mapOf("name" to "John", "surname" to "Doe")
         }
         .verifyWithin(Duration.ofSeconds(30))
 
@@ -220,11 +229,12 @@ abstract class Neo4jSinkErrorIT {
   }
 
   @Neo4jSink(
-      cypher =
+      nodePattern =
           [
-              CypherStrategy(
+              NodePatternStrategy(
                   TOPIC,
-                  "MERGE (p:Person {id: event.id, name: event.name, surname: event.surname})",
+                  "(:Person{!id, name, surname})",
+                  mergeNodeProperties = false,
               )
           ],
       errorDlqTopic = DLQ_TOPIC,
@@ -240,14 +250,17 @@ abstract class Neo4jSinkErrorIT {
       neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
-    val schemaWithMissingSurname =
+    // a record fault, so that it is the error tolerance being tested rather than the
+    // record-versus-infrastructure classification
+    val schemaWithMissingId =
         SchemaBuilder.struct()
-            .field("id", Schema.INT64_SCHEMA)
             .field("name", Schema.STRING_SCHEMA)
+            .field("surname", Schema.STRING_SCHEMA)
             .build()
-    val struct = Struct(schemaWithMissingSurname)
-    struct.put("id", 1L)
+    val struct = Struct(schemaWithMissingId)
     struct.put("name", "John")
+    struct.put("surname", "Doe")
+    val messageToFail = KafkaMessage(valueSchema = schemaWithMissingId, value = struct)
 
     // before the failure
     eventually(30.seconds) {
@@ -256,11 +269,11 @@ abstract class Neo4jSinkErrorIT {
       tasks.get(0).get("state").asText() shouldBe "RUNNING"
     }
 
-    producer.publish(valueSchema = schemaWithMissingSurname, value = struct)
+    producer.publish(messageToFail)
 
     TopicVerifier.createForMap(errorConsumer)
         .assertMessageValue(schemaTopic = producer.topic) {
-          it shouldBe mapOf("id" to 1L, "name" to "John")
+          it shouldBe mapOf("name" to "John", "surname" to "Doe")
         }
         .verifyWithin(Duration.ofSeconds(30))
 
@@ -281,14 +294,14 @@ abstract class Neo4jSinkErrorIT {
               )
           ],
       errorDlqTopic = DLQ_TOPIC,
-      errorTolerance = "all",
+      errorTolerance = "none",
       enableErrorHeaders = true,
   )
   @Test
-  fun `should report failed events with cypher strategy`(
+  fun `should fail the task when neo4j rejects a record with the cypher strategy`(
       @TopicProducer(TOPIC) producer: ConvertingKafkaProducer,
-      @TopicConsumer(topic = DLQ_TOPIC, offset = "earliest") errorConsumer: ConvertingKafkaConsumer,
       session: Session,
+      sink: Neo4jSinkRegistration,
       neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
@@ -328,42 +341,10 @@ abstract class Neo4jSinkErrorIT {
     )
 
     eventually(30.seconds) {
-      session.run("MATCH (n) RETURN n", emptyMap()).list().map {
-        it.get("n").asNode().let { n -> (n.labels() to n.asMap()) }
-      } shouldContainExactlyInAnyOrder
-          listOf(
-              (listOf("Person") to mapOf("id" to 1L, "name" to "John", "surname" to "Doe")),
-              (listOf("Person") to mapOf("id" to 3L, "name" to "Mary", "surname" to "Doe")),
-              (listOf("Person") to mapOf("id" to 5L, "name" to "Sue", "surname" to "Doe")),
-          )
+      val tasks = sink.getConnectorTasksForStatusCheck()
+      tasks shouldHaveSize 1
+      tasks.get(0).get("state").asText() shouldBe "FAILED"
     }
-
-    TopicVerifier.createForMap(errorConsumer)
-        .assertMessage(schemaTopic = producer.topic) { msg ->
-          val errorHeaders = ErrorHeaders(msg.raw.headers())
-          errorHeaders.getValue(ErrorHeaders.OFFSET) shouldBe 1
-          errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "org.neo4j.driver.exceptions.ClientException"
-          errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE).shouldBeInstanceOf<String> {
-            it shouldContain
-                "Cannot merge the following node because of null property value for 'name': (:Person {name: null})"
-          }
-
-          msg.value shouldBe mapOf("id" to 2L, "surname" to "Doe")
-        }
-        .assertMessage(schemaTopic = producer.topic) { msg ->
-          val errorHeaders = ErrorHeaders(msg.raw.headers())
-          errorHeaders.getValue(ErrorHeaders.OFFSET) shouldBe 3
-          errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "org.neo4j.driver.exceptions.ClientException"
-          errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE).shouldBeInstanceOf<String> {
-            it shouldContain
-                "Cannot merge the following node because of null property value for 'surname': (:Person {surname: null})"
-          }
-
-          msg.value shouldBe mapOf("id" to 4L, "name" to "Martin")
-        }
-        .verifyWithin(Duration.ofSeconds(30))
   }
 
   @Neo4jSink(
@@ -431,7 +412,7 @@ abstract class Neo4jSinkErrorIT {
           val errorHeaders = ErrorHeaders(it.raw.headers())
           errorHeaders.getValue(ErrorHeaders.OFFSET) shouldBe 1
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "org.apache.kafka.connect.errors.ConnectException"
+              "org.neo4j.connectors.kafka.exceptions.InvalidDataException"
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE) shouldBe
               "Message value must be convertible to a Map."
 
@@ -560,7 +541,7 @@ abstract class Neo4jSinkErrorIT {
           val errorHeaders = ErrorHeaders(it.raw.headers())
           errorHeaders.getValue(ErrorHeaders.OFFSET) shouldBe 2
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "org.apache.kafka.connect.errors.ConnectException"
+              "org.neo4j.connectors.kafka.exceptions.InvalidDataException"
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE) shouldBe
               "Message value must be convertible to a Map."
 
@@ -687,7 +668,7 @@ abstract class Neo4jSinkErrorIT {
           val errorHeaders = ErrorHeaders(it.raw.headers())
           errorHeaders.getValue(ErrorHeaders.OFFSET) shouldBe 0
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "java.lang.IllegalArgumentException"
+              "org.neo4j.connectors.kafka.exceptions.InvalidDataException"
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE) shouldBe
               "Unsupported data type ('null') for CUD file operation"
 
@@ -697,7 +678,7 @@ abstract class Neo4jSinkErrorIT {
           val errorHeaders = ErrorHeaders(it.raw.headers())
           errorHeaders.getValue(ErrorHeaders.OFFSET) shouldBe 2
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "org.apache.kafka.connect.errors.ConnectException"
+              "org.neo4j.connectors.kafka.exceptions.InvalidDataException"
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE) shouldBe
               "Message value must be convertible to a Map."
 
@@ -1089,7 +1070,7 @@ abstract class Neo4jSinkErrorIT {
           val errorHeaders = ErrorHeaders(it.raw.headers())
           errorHeaders.getValue(ErrorHeaders.TOPIC) shouldBe producer1.topic
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_CLASS_NAME) shouldBe
-              "java.lang.IllegalArgumentException"
+              "org.neo4j.connectors.kafka.exceptions.InvalidDataException"
           errorHeaders.getValue(ErrorHeaders.EXCEPTION_MESSAGE) shouldBe
               "Unsupported data type ('null') for CUD file operation"
 

--- a/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
+++ b/sink-connector/src/test/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkErrorIT.kt
@@ -192,8 +192,7 @@ abstract class Neo4jSinkErrorIT {
       neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
-    // a record fault, so that it is the error tolerance being tested rather than the
-    // record-versus-infrastructure classification
+    // a bad record, so this test stays about error tolerance
     val schemaWithMissingId =
         SchemaBuilder.struct()
             .field("name", Schema.STRING_SCHEMA)
@@ -213,7 +212,6 @@ abstract class Neo4jSinkErrorIT {
 
     producer.publish(messageToFail)
 
-    // the dlq message is deserialised into a map, so it cannot be compared to the struct
     TopicVerifier.createForMap(errorConsumer)
         .assertMessageValue(schemaTopic = producer.topic) {
           it shouldBe mapOf("name" to "John", "surname" to "Doe")
@@ -250,8 +248,7 @@ abstract class Neo4jSinkErrorIT {
       neo4j: Neo4j,
   ) = runTest {
     session.createNodeKeyConstraint(neo4j, "person_id", "Person", "id")
-    // a record fault, so that it is the error tolerance being tested rather than the
-    // record-versus-infrastructure classification
+    // a bad record, so this test stays about error tolerance
     val schemaWithMissingId =
         SchemaBuilder.struct()
             .field("name", Schema.STRING_SCHEMA)

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
@@ -18,10 +18,12 @@ package org.neo4j.connectors.kafka.sink
 
 import kotlin.time.measureTime
 import kotlin.time.measureTimedValue
+import org.apache.kafka.connect.errors.DataException
 import org.apache.kafka.connect.sink.SinkRecord
 import org.apache.kafka.connect.sink.SinkTask
 import org.jetbrains.annotations.VisibleForTesting
 import org.neo4j.connectors.kafka.configuration.helpers.VersionUtil
+import org.neo4j.connectors.kafka.exceptions.InvalidDataException
 import org.neo4j.connectors.kafka.metrics.Metrics
 import org.neo4j.connectors.kafka.metrics.MetricsFactory
 import org.slf4j.Logger
@@ -69,6 +71,21 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
     }
     log.info("processed {} records in {} ms", records?.size ?: 0, duration.inWholeMilliseconds)
   }
+
+  /**
+   * Whether the failure is attributable to the record's own content, which is the only reason to
+   * divert a record to the dead letter queue.
+   *
+   * Deliberately narrow: a wrongly-failed task is recoverable, whereas a wrongly-diverted record is
+   * data loss, since its offsets are committed while the task stays healthy. Anything shared by the
+   * whole topic -- an unreachable database, a bad Cypher template, a wrong constraint -- must fail
+   * loudly instead, or the entire topic drains into the DLQ behind a green health check.
+   *
+   * Every type listed here is raised while parsing record content, before any write, so the
+   * batch-level exception is the same one a single record would produce. That is what makes it safe
+   * to classify before narrowing down to the offending record.
+   */
+  private fun isRecordFault(e: Throwable): Boolean = e is InvalidDataException || e is DataException
 
   private fun processMessages(handler: SinkStrategyHandler, messages: List<SinkMessage>) {
     val handled = mutableSetOf<SinkMessage>()
@@ -123,17 +140,20 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
       }
 
       val reporter = context.errantRecordReporter()
-      if (reporter != null) {
-        log.warn("DLQ is enabled, will try to identify offending message", e)
-        val unhandled = messages.minus(handled)
-
-        if (unhandled.size > 1) {
-          unhandled.forEach { m -> processMessages(handler, listOf(m)) }
-        } else {
-          unhandled.forEach { m -> reporter.report(m.record, e).get() }
-        }
-      } else {
+      // Not a record-content failure, so raise it and let Connect retry and alert.
+      // `reporter == null` is the existing "no DLQ configured" path, which fails the task the same
+      // way.
+      if (reporter == null || !isRecordFault(e)) {
         throw e
+      }
+
+      log.warn("DLQ is enabled, will try to identify offending message", e)
+      val unhandled = messages.minus(handled)
+
+      if (unhandled.size > 1) {
+        unhandled.forEach { m -> processMessages(handler, listOf(m)) }
+      } else {
+        unhandled.forEach { m -> reporter.report(m.record, e).get() }
       }
     }
   }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
@@ -75,15 +75,6 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
   /**
    * Whether the failure is attributable to the record's own content, which is the only reason to
    * divert a record to the dead letter queue.
-   *
-   * Deliberately narrow: a wrongly-failed task is recoverable, whereas a wrongly-diverted record is
-   * data loss, since its offsets are committed while the task stays healthy. Anything shared by the
-   * whole topic -- an unreachable database, a bad Cypher template, a wrong constraint -- must fail
-   * loudly instead, or the entire topic drains into the DLQ behind a green health check.
-   *
-   * Every type listed here is raised while parsing record content, before any write, so the
-   * batch-level exception is the same one a single record would produce. That is what makes it safe
-   * to classify before narrowing down to the offending record.
    */
   private fun isRecordFault(e: Throwable): Boolean = e is InvalidDataException || e is DataException
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
@@ -72,11 +72,7 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
     log.info("processed {} records in {} ms", records?.size ?: 0, duration.inWholeMilliseconds)
   }
 
-  /**
-   * Whether the failure is attributable to the record's own content, which is the only reason to
-   * divert a record to the dead letter queue.
-   */
-  private fun isRecordFault(e: Throwable): Boolean = e is InvalidDataException || e is DataException
+  private fun isDataException(e: Throwable): Boolean = e is InvalidDataException || e is DataException
 
   private fun processMessages(handler: SinkStrategyHandler, messages: List<SinkMessage>) {
     val handled = mutableSetOf<SinkMessage>()

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/Neo4jSinkTask.kt
@@ -72,7 +72,8 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
     log.info("processed {} records in {} ms", records?.size ?: 0, duration.inWholeMilliseconds)
   }
 
-  private fun isDataException(e: Throwable): Boolean = e is InvalidDataException || e is DataException
+  private fun isDataException(e: Throwable): Boolean =
+      e is InvalidDataException || e is DataException
 
   private fun processMessages(handler: SinkStrategyHandler, messages: List<SinkMessage>) {
     val handled = mutableSetOf<SinkMessage>()
@@ -130,7 +131,7 @@ class Neo4jSinkTask(private val metricsFactory: MetricsFactory = MetricsFactory(
       // Not a record-content failure, so raise it and let Connect retry and alert.
       // `reporter == null` is the existing "no DLQ configured" path, which fails the task the same
       // way.
-      if (reporter == null || !isRecordFault(e)) {
+      if (reporter == null || !isDataException(e)) {
         throw e
       }
 

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcEventTransformer.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cdc/CdcEventTransformer.kt
@@ -23,6 +23,7 @@ import org.neo4j.cdc.client.model.NodeEvent
 import org.neo4j.cdc.client.model.RelationshipEvent
 import org.neo4j.connectors.kafka.data.StreamsTransactionEventExtensions.toChangeEvent
 import org.neo4j.connectors.kafka.data.toChangeEvent
+import org.neo4j.connectors.kafka.exceptions.InvalidDataException
 import org.neo4j.connectors.kafka.sink.SinkMessage
 import org.neo4j.connectors.kafka.sink.strategy.SinkAction
 import org.neo4j.connectors.kafka.sink.strategy.SinkEventTransformer
@@ -42,16 +43,16 @@ interface CdcEventTransformer : SinkEventTransformer {
             EntityOperation.CREATE -> transformCreate(e)
             EntityOperation.UPDATE -> transformUpdate(e)
             EntityOperation.DELETE -> transformDelete(e)
-            else -> throw IllegalArgumentException("unknown operation ${e.operation}")
+            else -> throw InvalidDataException("unknown operation ${e.operation}")
           }
       is RelationshipEvent ->
           when (e.operation) {
             EntityOperation.CREATE -> transformCreate(e)
             EntityOperation.UPDATE -> transformUpdate(e)
             EntityOperation.DELETE -> transformDelete(e)
-            else -> throw IllegalArgumentException("unknown operation ${e.operation}")
+            else -> throw InvalidDataException("unknown operation ${e.operation}")
           }
-      else -> throw IllegalArgumentException("unsupported event type ${e.eventType}")
+      else -> throw InvalidDataException("unsupported event type ${e.eventType}")
     }
   }
 
@@ -78,7 +79,7 @@ internal fun parseCdcChangeEvent(message: SinkMessage): ChangeEvent =
     when (val value = message.value) {
       is Struct -> value.toChangeEvent()
       else ->
-          throw IllegalArgumentException(
+          throw InvalidDataException(
               "unexpected message value type ${value?.javaClass?.name} in $message"
           )
     }
@@ -86,7 +87,7 @@ internal fun parseCdcChangeEvent(message: SinkMessage): ChangeEvent =
 internal fun parseStreamsChangeEvent(message: SinkMessage): ChangeEvent {
   val event =
       message.record.toStreamsSinkEntity().toStreamsTransactionEvent { _ -> true }
-          ?: throw IllegalArgumentException("unsupported change event message in $message")
+          ?: throw InvalidDataException("unsupported change event message in $message")
 
   return event.toChangeEvent()
 }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CudEventTransformer.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/CudEventTransformer.kt
@@ -16,8 +16,8 @@
  */
 package org.neo4j.connectors.kafka.sink.strategy.cud
 
-import org.apache.kafka.connect.errors.ConnectException
 import org.apache.kafka.connect.errors.DataException
+import org.neo4j.connectors.kafka.exceptions.InvalidDataException
 import org.neo4j.connectors.kafka.sink.SinkMessage
 import org.neo4j.connectors.kafka.sink.strategy.SinkAction
 import org.neo4j.connectors.kafka.sink.strategy.SinkEventTransformer
@@ -28,7 +28,7 @@ class CudEventTransformer : SinkEventTransformer {
     val value =
         when (val value = message.valueFromConnectValue()) {
           is Map<*, *> -> value as Map<String, Any?>
-          else -> throw ConnectException("Message value must be convertible to a Map.")
+          else -> throw InvalidDataException("Message value must be convertible to a Map.")
         }
     val cud = Operation.from(value)
     return try {

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/Operation.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/cud/Operation.kt
@@ -64,21 +64,19 @@ interface Operation {
               when (val type = values[Keys.TYPE]) {
                 is String -> type
                 else ->
-                    throw IllegalArgumentException(
-                        "Unsupported data type ('$type') in CUD file type."
-                    )
+                    throw InvalidDataException("Unsupported data type ('$type') in CUD file type.")
               }
-          ) ?: throw IllegalArgumentException("CUD file type must be specified.")
+          ) ?: throw InvalidDataException("CUD file type must be specified.")
       val operation =
           OperationType.fromString(
               when (val operation = values[Keys.OPERATION]) {
                 is String -> operation
                 else ->
-                    throw IllegalArgumentException(
+                    throw InvalidDataException(
                         "Unsupported data type ('$operation') for CUD file operation"
                     )
               }
-          ) ?: throw IllegalArgumentException("CUD file operation must be specified.")
+          ) ?: throw InvalidDataException("CUD file operation must be specified.")
 
       val mapper = JSONUtils.getObjectMapper()
       val node = mapper.valueToTree<JsonNode>(values)
@@ -99,7 +97,7 @@ interface Operation {
         RELATIONSHIP to MERGE -> MergeRelationship.from(values)
         RELATIONSHIP to DELETE -> DeleteRelationship.from(values)
         else ->
-            throw IllegalArgumentException(
+            throw InvalidDataException(
                 "Unknown type ('$type') and operation ('$operation') for CUD file"
             )
       }

--- a/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternEventTransformer.kt
+++ b/sink/src/main/kotlin/org/neo4j/connectors/kafka/sink/strategy/pattern/PatternEventTransformer.kt
@@ -18,7 +18,6 @@ package org.neo4j.connectors.kafka.sink.strategy.pattern
 
 import java.time.Instant
 import java.time.ZoneOffset
-import org.apache.kafka.connect.errors.ConnectException
 import org.neo4j.connectors.kafka.data.ConstraintData
 import org.neo4j.connectors.kafka.exceptions.InvalidDataException
 import org.neo4j.connectors.kafka.sink.SinkConfiguration
@@ -53,7 +52,7 @@ abstract class PatternEventTransformer<T : Pattern>(
             this[bindValueAs] =
                 when (val value = message.valueFromConnectValue()) {
                   is Map<*, *> -> value as Map<String, Any?>
-                  else -> throw ConnectException("Message value must be convertible to a Map.")
+                  else -> throw InvalidDataException("Message value must be convertible to a Map.")
                 }
           }
         }

--- a/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/NativeBatchStrategyTest.kt
+++ b/sink/src/test/kotlin/org/neo4j/connectors/kafka/sink/strategy/NativeBatchStrategyTest.kt
@@ -240,9 +240,9 @@ class NativeBatchStrategyTest {
         "WITH e.params AS _e MERGE (n:`Person` {id: _e.matchProperties.id}) SET n += _e.mutateProperties"
 
     override fun provideArguments(
-        parameters: ParameterDeclarations?,
-        context: ExtensionContext?,
-    ): Stream<out Arguments?>? {
+        parameters: ParameterDeclarations,
+        context: ExtensionContext,
+    ): Stream<out Arguments> {
       return Stream.of(
           Arguments.of(
               neo4j5_18,


### PR DESCRIPTION
Changes: 
  - Neo4jSinkTask — only bad record content goes to the DLQ now. Everything else (like Neo4j being down) is thrown instead of being quietly filed away.                                                    
  - cud/Operation.kt, cdc/CdcEventTransformer.kt — bad-records throws changed from IllegalArgumentException to InvalidDataException, so the filter can recognise them.           