### PR TITLE
fix: merge collection of elements having schemas with different key sets

### DIFF
--- a/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
+++ b/common/src/main/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverter.kt
@@ -130,15 +130,33 @@ class CompactValueConverter : ValueConverter {
                   .build()
 
           else -> {
-            // When element schemas differ only because the same key has a null value
-            // in some elements (yielding OPTIONAL_STRING from schema(null)) and a
-            // concrete type in others, merge them into a single STRUCT with all
-            // fields marked optional. This avoids the indexed-struct {e0, e1, ...}
-            // fallback and the DataException raised when value() tries to coerce
-            // the concrete value against the OPTIONAL_STRING schema.
-            val merged = mergeNullableStructSchemas(nonEmptyElementTypes.toSet())
-            if (merged != null) {
-              SchemaBuilder.array(if (optional) makeOptional(merged) else merged)
+            // Elements whose schemas differ merge into a single STRUCT covering the
+            // union of their keys, so the collection stays an array rather than
+            // collapsing into the indexed-struct {e0, e1, ...} form below.
+            //
+            // Only Maps and Nodes/Relationships may merge. nonEmptyElementTypes leaves out
+            // elements that notNullOrEmpty() calls empty,
+            // but value() converts every element. So merging a type that can be left out
+            // would convert it against a schema inferred without it. Nodes and
+            // Relationships are never left out. Maps can be, which is why
+            // mergeMapElementSchemas re-reads them from value.
+            val nonNullElements = value.filterNotNull()
+            val mergedSchema =
+                when {
+                  nonNullElements.all { it is Map<*, *> } ->
+                      mergeMapElementSchemas(
+                          nonNullElements.filterIsInstance<Map<*, *>>(),
+                          forceMapsAsStruct,
+                      )
+
+                  nonNullElements.all { it is Node || it is Relationship } ->
+                      mergeNullableStructSchemas(nonEmptyElementTypes.toSet())
+
+                  else -> null
+                }
+            if (mergedSchema != null) {
+              // An optional element schema keeps null elements valid.
+              SchemaBuilder.array(makeOptional(mergedSchema))
                   .apply { if (optional) optional() }
                   .build()
             } else {
@@ -320,20 +338,14 @@ class CompactValueConverter : ValueConverter {
   }
 
   /**
-   * Attempts to merge multiple STRUCT schemas where the only difference is that some elements have
-   * a null-typed schema (from [schema] called with `null`, which yields [SimpleTypes.NULL]) at a
-   * field where other elements have a concrete type. All schemas must share the identical set of
-   * field names. Returns `null` when schemas have differing field name sets or have conflicting
-   * non-null field types so the caller can fall back to the existing indexed-struct representation.
+   * Merges STRUCT schemas sharing an identical set of field names, resolving fields that are
+   * [SimpleTypes.NULL] in some schemas and concrete in others to the concrete type. Every field is
+   * optional, so later messages may omit any of them. Returns `null` for differing field name sets
+   * or conflicting non-null types, leaving the caller on the indexed-struct fallback.
    *
-   * Every field of the merged schema is marked optional, regardless of whether a null was actually
-   * observed for it, so that subsequent messages missing a value for any of these fields remain
-   * compatible with the merged schema.
-   *
-   * This intentionally does not handle the broader case of differing field name sets across
-   * elements — doing so would require [value] to tolerate keys that are absent from some Map
-   * elements, and merging Map-typed elements with Struct-typed ones would silently drop keys
-   * present only in the Map element.
+   * Reads the element schemas, so it suits [Node] and [Relationship], whose shape they capture in
+   * full. Maps go through [mergeMapElementSchemas], which reads the raw values and can therefore
+   * also merge differing key sets.
    */
   private fun mergeNullableStructSchemas(schemas: Set<Schema>): Schema? {
     if (schemas.any { it.type() != Schema.Type.STRUCT }) return null
@@ -364,20 +376,85 @@ class CompactValueConverter : ValueConverter {
     return builder.build()
   }
 
+  /**
+   * Merges Map elements into a single STRUCT schema covering the union of their keys, recursing
+   * into nested Maps. Every field is optional, so later messages may omit any of them. Returns
+   * `null` when a key holds incompatible non-null types, leaving the caller on the indexed-struct
+   * fallback.
+   *
+   * Keys are sorted, so element order cannot change the resulting [Schema] and spawn redundant
+   * schema versions downstream.
+   *
+   * Field schemas come from the raw values rather than the elements' own schemas, so a key inferred
+   * as MAP in one element (uniformly typed values) and STRUCT in another (mixed) still contributes
+   * every key. A value counts as absent only when `null`: an empty Collection or Map is a real type
+   * at that key, and skipping it would build a schema [value] cannot coerce its element against.
+   */
+  private fun mergeMapElementSchemas(
+      elements: List<Map<*, *>>,
+      forceMapsAsStruct: Boolean,
+  ): Schema? {
+    val allKeys = sortedSetOf<String>()
+    elements.forEach { element ->
+      element.keys.forEach { key ->
+        allKeys.add(
+            key as? String
+                ?: throw IllegalArgumentException(
+                    "unsupported map key type ${key?.javaClass?.name}"
+                )
+        )
+      }
+    }
+
+    val builder = SchemaBuilder.struct()
+    for (key in allKeys) {
+      val fieldValues = elements.mapNotNull { it[key] }
+
+      val fieldSchema =
+          if (fieldValues.isEmpty()) {
+            SimpleTypes.NULL.schema(true)
+          } else {
+            val fieldSchemas = fieldValues.map { schema(it, true, forceMapsAsStruct) }.toSet()
+            when {
+              fieldSchemas.size == 1 -> fieldSchemas.first()
+              fieldValues.all { it is Map<*, *> } ->
+                  mergeMapElementSchemas(
+                      fieldValues.filterIsInstance<Map<*, *>>(),
+                      forceMapsAsStruct,
+                  ) ?: return null
+
+              else -> return null
+            }
+          }
+
+      builder.field(key, makeOptional(fieldSchema))
+    }
+    return builder.build()
+  }
+
   private fun makeOptional(schema: Schema): Schema {
     if (schema.isOptional) return schema
-    return when (schema.type()) {
-      Schema.Type.STRUCT ->
-          SchemaBuilder.struct()
-              .apply {
+    val builder =
+        when (schema.type()) {
+          Schema.Type.STRUCT ->
+              SchemaBuilder.struct().apply {
                 schema.fields().forEach { field(it.name(), it.schema()) }
-                optional()
               }
-              .build()
-      Schema.Type.ARRAY -> SchemaBuilder.array(schema.valueSchema()).optional().build()
-      Schema.Type.MAP ->
-          SchemaBuilder.map(schema.keySchema(), schema.valueSchema()).optional().build()
-      else -> SchemaBuilder.type(schema.type()).optional().build()
-    }
+
+          Schema.Type.ARRAY -> SchemaBuilder.array(schema.valueSchema())
+          Schema.Type.MAP -> SchemaBuilder.map(schema.keySchema(), schema.valueSchema())
+          else -> SchemaBuilder.type(schema.type())
+        }
+    // name() carries the Neo4j logical type marker Schema.matches() keys off, so it and the rest
+    // of the metadata have to survive the rebuild.
+    return builder
+        .name(schema.name())
+        .version(schema.version())
+        .doc(schema.doc())
+        .apply {
+          schema.parameters()?.let { parameters(it) }
+          optional()
+        }
+        .build()
   }
 }

--- a/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverterTest.kt
+++ b/common/src/test/kotlin/org/neo4j/connectors/kafka/data/converter/CompactValueConverterTest.kt
@@ -724,7 +724,8 @@ class DynamicTypesCompactTest {
     schema.valueSchema().type() shouldBe Schema.Type.STRUCT
 
     val elementSchema = schema.valueSchema()
-    elementSchema.fields().map { it.name() } shouldBe listOf("name", "addr", "age")
+    // merged fields are sorted, not in encounter order
+    elementSchema.fields().map { it.name() } shouldBe listOf("addr", "age", "name")
     // every merged field is optional, even those that never held a null value
     elementSchema.field("name").schema() shouldBe Schema.OPTIONAL_STRING_SCHEMA
     elementSchema.field("addr").schema().type() shouldBe Schema.Type.STRUCT
@@ -772,9 +773,7 @@ class DynamicTypesCompactTest {
   }
 
   @Test
-  fun `collections with differing field name sets should fall back to indexed struct schema`() {
-    // Different keys across elements is the "Case 1" scenario which is not addressed here.
-    // The merge must decline so the value() conversion stays consistent with the schema.
+  fun `collections with differing field name sets should merge into array schema`() {
     val coll =
         listOf(
             mapOf("name" to "alice", "addr" to "tokyo", "age" to 30L),
@@ -784,9 +783,20 @@ class DynamicTypesCompactTest {
     val schema = converter.schema(coll, false)
     val actualValue = converter.value(schema, coll)
 
-    schema.type() shouldBe Schema.Type.STRUCT
-    schema.fields().map { it.name() } shouldBe listOf("e0", "e1")
-    actualValue.shouldBeInstanceOf<Struct>()
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("addr", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    actualValue shouldBe
+        listOf(
+            Struct(elementSchema).put("addr", "tokyo").put("age", 30L).put("name", "alice"),
+            Struct(elementSchema).put("addr", null).put("age", 25L).put("name", "bob"),
+        )
   }
 
   @Test
@@ -869,5 +879,397 @@ class DynamicTypesCompactTest {
 
     actualValue.shouldBeInstanceOf<List<*>>()
     actualValue.size shouldBe 2
+  }
+
+  @Test
+  fun `collection of maps where one key set is a superset of the other should merge into array of struct`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "age" to 21),
+            mapOf(
+                "name" to "jane",
+                "age" to 25,
+                "address" to mapOf("city" to "london", "zip" to 10001),
+            ),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val addressSchema =
+        SchemaBuilder.struct()
+            .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("zip", Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build()
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("address", addressSchema)
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema).put("address", null).put("age", 21L).put("name", "john"),
+            Struct(elementSchema)
+                .put("address", Struct(addressSchema).put("city", "london").put("zip", 10001L))
+                .put("age", 25L)
+                .put("name", "jane"),
+        )
+  }
+
+  @Test
+  fun `collection of maps with no common keys should merge into array of struct`() {
+    val coll = listOf(mapOf("name" to "john"), mapOf("age" to 21))
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema).put("age", null).put("name", "john"),
+            Struct(elementSchema).put("age", 21L).put("name", null),
+        )
+  }
+
+  @Test
+  fun `collection of a map inferred as MAP schema and a map inferred as STRUCT schema should keep all keys`() {
+    // the first element infers as MAP<String, String> (uniform value types), the second as a
+    // STRUCT (mixed), so `y` only exists under the MAP-typed one
+    val coll = listOf(mapOf("x" to "s1", "y" to "s2"), mapOf("x" to "s", "z" to 123))
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("x", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("y", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("z", Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema).put("x", "s1").put("y", "s2").put("z", null),
+            Struct(elementSchema).put("x", "s").put("y", null).put("z", 123L),
+        )
+  }
+
+  @Test
+  fun `collection of three maps with varying key sets should merge and round-trip`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "age" to 21),
+            mapOf("name" to "jane", "employed" to true),
+            mapOf("name" to "bob", "age" to 30, "employed" to false),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("employed", Schema.OPTIONAL_BOOLEAN_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema).put("age", 21L).put("employed", null).put("name", "john"),
+            Struct(elementSchema).put("age", null).put("employed", true).put("name", "jane"),
+            Struct(elementSchema).put("age", 30L).put("employed", false).put("name", "bob"),
+        )
+  }
+
+  @Test
+  fun `collection of maps with conflicting non-null types should fall back to indexed struct`() {
+    val coll = listOf(mapOf("name" to "john"), mapOf("name" to 42))
+    val schema = converter.schema(coll, false)
+
+    schema shouldBe
+        SchemaBuilder.struct()
+            .field("e0", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+            .field("e1", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT64_SCHEMA).build())
+            .build()
+  }
+
+  @Test
+  fun `collection mixing maps and non-maps should fall back to indexed struct`() {
+    val coll = listOf(mapOf("name" to "john"), "a string")
+    val schema = converter.schema(coll, false)
+
+    schema shouldBe
+        SchemaBuilder.struct()
+            .field("e0", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.STRING_SCHEMA).build())
+            .field("e1", Schema.STRING_SCHEMA)
+            .build()
+  }
+
+  @Test
+  fun `collection of maps with differing key sets should still enforce string map keys`() {
+    shouldThrow<IllegalArgumentException> {
+      converter.schema(listOf(mapOf("name" to "john"), mapOf(1 to 5, "a" to "b")), false)
+    } shouldHaveMessage ("unsupported map key type java.lang.Integer")
+  }
+
+  @Test
+  fun `nested map field with differing key sets across elements should merge recursively`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "address" to mapOf("city" to "london", "zip" to 10001)),
+            mapOf(
+                "name" to "jane",
+                "address" to mapOf("city" to "paris", "zip" to 75001, "country" to "fr"),
+            ),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val addressSchema =
+        SchemaBuilder.struct()
+            .field("city", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("country", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("zip", Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build()
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("address", addressSchema)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema)
+                .put(
+                    "address",
+                    Struct(addressSchema)
+                        .put("city", "london")
+                        .put("country", null)
+                        .put("zip", 10001L),
+                )
+                .put("name", "john"),
+            Struct(elementSchema)
+                .put(
+                    "address",
+                    Struct(addressSchema)
+                        .put("city", "paris")
+                        .put("country", "fr")
+                        .put("zip", 75001L),
+                )
+                .put("name", "jane"),
+        )
+  }
+
+  @Test
+  fun `nested maps with single typed values should keep their map schema when merging`() {
+    val coll =
+        listOf(
+            mapOf("name" to "john", "tags" to mapOf("a" to "x")),
+            mapOf("name" to "jane", "tags" to mapOf("a" to "y"), "age" to 21),
+        )
+    val schema = converter.schema(coll, false)
+    val converted = converter.value(schema, coll)
+
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("age", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field(
+                "tags",
+                SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.OPTIONAL_STRING_SCHEMA)
+                    .optional()
+                    .build(),
+            )
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).build()
+
+    converted shouldBe
+        listOf(
+            Struct(elementSchema)
+                .put("age", null)
+                .put("name", "john")
+                .put("tags", mapOf("a" to "x")),
+            Struct(elementSchema).put("age", 21L).put("name", "jane").put("tags", mapOf("a" to "y")),
+        )
+  }
+
+  @Test
+  fun `merged collection should be optional only when requested`() {
+    val coll = listOf(mapOf("name" to "john"), mapOf("age" to 21))
+
+    // only the array follows the flag; the element schema is always optional
+    converter.schema(coll, false).isOptional shouldBe false
+    converter.schema(coll, false).valueSchema().isOptional shouldBe true
+    converter.schema(coll, true).isOptional shouldBe true
+    converter.schema(coll, true).valueSchema().isOptional shouldBe true
+  }
+
+  @Test
+  fun `collection containing a non-map element should fall back to indexed struct`() {
+    // the empty list is invisible to notNullOrEmpty(), yet value() still has to convert it
+    val coll =
+        listOf(
+            mapOf("name" to "alice", "age" to 30L, "dob" to "x"),
+            mapOf("name" to "bob", "age" to 25L, "dob" to null),
+            emptyList<Any>(),
+        )
+
+    val schema = converter.schema(coll, true)
+
+    schema.type() shouldBe Schema.Type.STRUCT
+    schema.fields().map { it.name() } shouldBe listOf("e0", "e1", "e2")
+    converter.value(schema, coll).shouldBeInstanceOf<Struct>()
+  }
+
+  @Test
+  fun `collection whose element holds an empty collection at a merged key should fall back`() {
+    // "name" holds an empty list in the last element: a real type at that key, not an absent one
+    val coll =
+        listOf(
+            mapOf("name" to "alice", "age" to 30L, "dob" to "x"),
+            mapOf("name" to "bob", "age" to 25L, "dob" to null),
+            mapOf("name" to emptyList<Any>(), "age" to null, "dob" to null),
+        )
+
+    val schema = converter.schema(coll, true)
+
+    schema.type() shouldBe Schema.Type.STRUCT
+    schema.fields().map { it.name() } shouldBe listOf("e0", "e1", "e2")
+    converter.value(schema, coll).shouldBeInstanceOf<Struct>()
+  }
+
+  @Test
+  fun `collection element whose values are all null should still contribute its keys`() {
+    // {"a": null} is invisible to notNullOrEmpty(), so the key union comes from the raw elements
+    val coll = listOf(mapOf("a" to null), mapOf("b" to 2L), mapOf("c" to 3L))
+
+    val schema = converter.schema(coll, true, forceMapsAsStruct = true)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    schema.valueSchema().fields().map { it.name() } shouldBe listOf("a", "b", "c")
+  }
+
+  @Test
+  fun `collection element whose values are all null should still enforce string map keys`() {
+    shouldThrow<IllegalArgumentException> {
+      converter.schema(
+          listOf(mapOf(1 to null), mapOf("b" to 2L), mapOf("c" to 3L)),
+          true,
+          forceMapsAsStruct = true,
+      )
+    } shouldHaveMessage ("unsupported map key type java.lang.Integer")
+  }
+
+  @Test
+  fun `merged element schema should not depend on the order of the collection elements`() {
+    val ab = listOf(mapOf("a" to 1L, "z" to "s"), mapOf("b" to 2L, "z" to "s"))
+    val ba = listOf(mapOf("b" to 2L, "z" to "s"), mapOf("a" to 1L, "z" to "s"))
+
+    converter.schema(ab, true) shouldBe converter.schema(ba, true)
+  }
+
+  @Test
+  fun `merged collection should tolerate a null element`() {
+    val coll = listOf(null, mapOf("b" to 1L), mapOf("c" to 2L))
+
+    val schema = converter.schema(coll, true, forceMapsAsStruct = true)
+    val elementSchema =
+        SchemaBuilder.struct()
+            .field("b", Schema.OPTIONAL_INT64_SCHEMA)
+            .field("c", Schema.OPTIONAL_INT64_SCHEMA)
+            .optional()
+            .build()
+    schema shouldBe SchemaBuilder.array(elementSchema).optional().build()
+
+    converter.value(schema, coll) shouldBe
+        listOf(
+            null,
+            Struct(elementSchema).put("b", 1L).put("c", null),
+            Struct(elementSchema).put("b", null).put("c", 2L),
+        )
+  }
+
+  @Test
+  fun `merging should preserve neo4j logical type names`() {
+    // merging rebuilds the field schema, which must keep the marker Schema.matches() keys off
+    val coll =
+        listOf(
+            mapOf("name" to "alice", "dob" to LocalDate.of(2020, 1, 1)),
+            mapOf("name" to "bob", "dob" to null),
+        )
+
+    val schema = converter.schema(coll, false)
+
+    schema.valueSchema().field("dob").schema() shouldBe SimpleTypes.LOCALDATE.schema(true)
+  }
+
+  @Test
+  fun `collection of nodes with a null property should merge into array of struct`() {
+    // nodes carry their shape in their schema, so they merge on the schema path, not the Map one
+    val coll =
+        listOf(
+            TestNode(
+                "0",
+                listOf("Person"),
+                mapOf("name" to Values.value("john"), "age" to Values.value(21L)),
+            ),
+            TestNode(
+                "1",
+                listOf("Person"),
+                mapOf("name" to Values.value("jane"), "age" to Values.NULL),
+            ),
+        )
+
+    val schema = converter.schema(coll, false)
+
+    schema.type() shouldBe Schema.Type.ARRAY
+    val elementSchema = schema.valueSchema()
+    elementSchema.isOptional shouldBe true
+    elementSchema.field("name").schema() shouldBe Schema.OPTIONAL_STRING_SCHEMA
+    elementSchema.field("age").schema() shouldBe Schema.OPTIONAL_INT64_SCHEMA
+
+    converter.value(schema, coll) shouldBe
+        listOf(
+            Struct(elementSchema)
+                .put("<elementId>", "0")
+                .put("<labels>", listOf("Person"))
+                .put("name", "john")
+                .put("age", 21L),
+            Struct(elementSchema)
+                .put("<elementId>", "1")
+                .put("<labels>", listOf("Person"))
+                .put("name", "jane")
+                .put("age", null),
+        )
+  }
+
+  @Test
+  fun `collection mixing nodes and maps should fall back to indexed struct`() {
+    val coll =
+        listOf(
+            TestNode("0", listOf("Person"), mapOf("name" to Values.value("john"))),
+            mapOf("name" to "jane", "age" to 21L),
+        )
+
+    val schema = converter.schema(coll, false)
+
+    schema.type() shouldBe Schema.Type.STRUCT
+    schema.fields().map { it.name() } shouldBe listOf("e0", "e1")
   }
 }

--- a/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
+++ b/source-connector/src/test/kotlin/org/neo4j/connectors/kafka/source/Neo4jSourceQueryIT.kt
@@ -317,14 +317,17 @@ class Neo4jSourceJsonRawCompactIT : Neo4jSourceQueryIT() {
           "WITH {id: 'ROOT_ID', list: [{ property1: 'value1' }, { property2: 'value2' }]} AS data RETURN data, data.id AS guid, dateTime().epochMillis AS timestamp",
   )
   @Test
-  fun `serializes list of heterogeneous objects as map by default`(
+  fun `serializes list of heterogeneous objects as merged list by default`(
       @TopicConsumer(topic = TOPIC, offset = "earliest") consumer: ConvertingKafkaConsumer
   ) = runTest {
     TopicVerifier.createForMap(consumer)
         .assertMessageValue { value ->
           val list = (value["data"] as Map<*, *>)["list"]
           list shouldBe
-              mapOf("e0" to mapOf("property1" to "value1"), "e1" to mapOf("property2" to "value2"))
+              listOf(
+                  mapOf("property1" to "value1", "property2" to null),
+                  mapOf("property1" to null, "property2" to "value2"),
+              )
         }
         .verifyWithin(Duration.ofSeconds(30))
   }


### PR DESCRIPTION
Based on [this PR](https://github.com/neo4j/neo4j-kafka-connector/pull/573). 

Additionally, handled few edge cases such as:
* merge collection of structs, when one element is empty. Could lead to a crash. 
* key union is taken from all non-null maps
* added explicit exception, when map keys are not string
* element schema made always optional
* `makeOptional` now preserves `name`, `doc`, `version`, `parameters`
* keys are sorted to avoid schema changes on equivalent schemas